### PR TITLE
Fix a bug where Gawen's death doesn't cause a defeat.

### DIFF
--- a/scenarios/17_Sneaking_out_of_Raedwood.cfg
+++ b/scenarios/17_Sneaking_out_of_Raedwood.cfg
@@ -649,9 +649,7 @@
     #		{END_IF}
     #	[/event]
 
-    {RUVIO_DEATH}
-    {LORIN_DEATH}
-    {REME_DEATH_N}
+    {ALL_ANO_DEATHS}
     {ELVISH_DEATHS}
 
     {ELVISH_KILLING}


### PR DESCRIPTION
Fix a bug where Gawen's death doesn't cause a defeat.

I replaced {*_DEATH} with {ALL_ANO_DEATHS}  because {ALL_ANO_DEATHS} was used in scenarios since scenario#14.