### PR TITLE
Redo advancement path of Akladian Clansman/Warrior/Leader/Chieftain

### DIFF
--- a/units/akladians/Akladian_Clansman.cfg
+++ b/units/akladians/Akladian_Clansman.cfg
@@ -12,7 +12,7 @@
     experience=19
     level=0
     alignment=neutral
-    advances_to=Akladian Warrior,Akladian Homeguard,Akladian Raider
+    advances_to=Akladian Warrior,Akladian Homeguard,Akladian Raider,Akladian Leader
     cost=10
     usage=fighter
     description= _ "Akladian Clansmen are the core of the Akladian tribes. They are raised in a culture promoting violence and hearing from childhood that their destination is to rule over the world. While very lightly armoured and badly armed they still can be dangerous, especially when used in larger groups. They are recruited only for the defense of their kingdoms."

--- a/units/akladians/Akladian_Leader.cfg
+++ b/units/akladians/Akladian_Leader.cfg
@@ -13,7 +13,7 @@
         [/frame]
     [/defend]
     profile="portraits/akladian_lord.png"
-    hitpoints=30
+    hitpoints=32 # (1 less than the Homeguard, which should have the highest HP of things a Clansman can advance to)
     movement_type=akladianfoot
     movement=5
     experience=40

--- a/units/akladians/Akladian_Warrior.cfg
+++ b/units/akladians/Akladian_Warrior.cfg
@@ -12,7 +12,7 @@
     experience=48
     level=1
     alignment=neutral
-    advances_to=Akladian Light Infantry,Akladian Leader
+    advances_to=Akladian Light Infantry,Akladian Chieftain
     cost=17
     usage=fighter
     description= _ "Spending their times in constant fights and raids, many Akladian clansmen become warriors, joining armies not only in defense, but also in raids against neighbouring lands."


### PR DESCRIPTION
This fixes issue #9 by choosing the option to have the Leader advance from the Clansman, and the Warrior advance into the Chieftain instead. It also buffs the Leader a bit (just +2HP) to compensate for the possibility that he might not get used as much anymore. 