### PR TITLE
Remove loyal overlay on Lady Lorin

### DIFF
--- a/scenarios/01_Breaking_the_Circle.cfg
+++ b/scenarios/01_Breaking_the_Circle.cfg
@@ -141,7 +141,7 @@
             canrecruit=yes
             unrenamable=yes
             [modifications]
-                {TRAIT_LOYAL}
+                {TRAIT_LOYAL OVERLAY=""}
 #ifdef EASY
                 {TRAIT_STRONG}
 #endif


### PR DESCRIPTION
The loyal icon above the crown is weird, I have seen this omission on other campaigns and there is a simple solution. If it's intentional, ignore this PR