### PR TITLE
rename AI_CONTROLLER macros

### DIFF
--- a/macros/ai/ai_controller.cfg
+++ b/macros/ai/ai_controller.cfg
@@ -1,6 +1,6 @@
 #textdomain wesnoth
 
-#define AI_CONTROLLER_ALLOW_UNIT_CONTROL CONTROLLER_SIDE UNIT_ID
+#define ANO_AI_CONTROLLER_ALLOW_UNIT_CONTROL CONTROLLER_SIDE UNIT_ID
     # Right-click content menu item for issuing instructions to an allied AI unit
     [store_unit]
         [filter]
@@ -52,7 +52,7 @@
     {CLEAR_VARIABLE ai_controller_unit}
 #enddef
 
-#define AI_CONTROLLER_ALLOW_LEADER_CONTROL CONTROLLER_SIDE CONTROLLED_SIDE
+#define ANO_AI_CONTROLLER_ALLOW_LEADER_CONTROL CONTROLLER_SIDE CONTROLLED_SIDE
     # Right-click content menu item for issuing instructions to an allied AI side's leader
     [store_unit]
         [filter]
@@ -102,14 +102,14 @@
     {CLEAR_VARIABLE ally_leader}
 #enddef
 
-#define AI_CONTROLLER_NOTE
+#define ANO_AI_CONTROLLER_NOTE
     # Note for the objectives that instructions can be issued to an allied AI side
     [note]
         description= _ "In this scenario, you may issue instructions to an allied side by right-clicking on a unit that belongs to it."
     [/note]
 #enddef
 
-#define AI_CONTROLLER AFFIX PLAYER_SIDES ALLY_SIDES VARIABLES_WML
+#define ANO_AI_CONTROLLER AFFIX PLAYER_SIDES ALLY_SIDES VARIABLES_WML
     # Right-click content menu item for issuing instructions to an allied AI side
     [event]
         name=prestart
@@ -1006,11 +1006,11 @@ Behavior: $ai_controller.side_$ally_side|_current_settings.currently_doing_behav
     [/event]
 #enddef
 
-#define DISABLE_AI_CONTROLLER AFFIX
+#define ANO_DISABLE_AI_CONTROLLER AFFIX
     {VARIABLE ai_controller_{AFFIX}.enabled no}
 #enddef
 
-#define DISABLE_AI_CONTROLLER_FOR_SIDE AFFIX SIDE
+#define ANO_DISABLE_AI_CONTROLLER_FOR_SIDE AFFIX SIDE
     [if]
         [variable]
             name=ai_controller_{AFFIX}.disabled_for_sides
@@ -1043,7 +1043,7 @@ Behavior: $ai_controller.side_$ally_side|_current_settings.currently_doing_behav
     [/if]
 #enddef
 
-#define ENABLE_AI_CONTROLLER_FOR_SIDE AFFIX SIDE
+#define ANO_ENABLE_AI_CONTROLLER_FOR_SIDE AFFIX SIDE
     [if]
         [variable]
             name=ai_controller_{AFFIX}.disabled_for_sides
@@ -1098,11 +1098,11 @@ Behavior: $ai_controller.side_$ally_side|_current_settings.currently_doing_behav
 #enddef
 
 # A stub for scenario 7 of LoW
-#define AI_LOCATION AFFIX STRING RADIUS X Y
+#define ANO_AI_LOCATION AFFIX STRING RADIUS X Y
     {SET_LABEL {X} {Y} ({STRING})}
 #enddef
 
-#define AI_CONTROLLER_FUTURE_STRINGS
+#define ANO_AI_CONTROLLER_FUTURE_STRINGS
     # These will be used for the special orders menu and the order for telling
     # the ally leader to move someplace
     future_string_1= _ "Set special orders..."  #wmllint: ignore

--- a/macros/ano_macros.cfg
+++ b/macros/ano_macros.cfg
@@ -1037,3 +1037,6 @@
     note="*"+_"Scenario notes:"+"
 "+{_NOTES_TEXT}
 #enddef
+
+# For the AI controller:
+{./ai}

--- a/scenarios/02_Fighting_for_Passage.cfg
+++ b/scenarios/02_Fighting_for_Passage.cfg
@@ -211,8 +211,8 @@
         [/ai]
     [/side]
 
-    # Yes, I know the AI_CONTROLLER macro is going to be deprecated, but until I figure out how to write a custom AI, I can't think of any other option to use here:
-    {AI_CONTROLLER () 1 3 ()}
+    # Since the AI_CONTROLLER macro is being deprecated in mainline, I've renamed the macro with the "ANO_" prefix for this campaign:
+    {ANO_AI_CONTROLLER () 1 3 ()}
     # (Note: giving side 3 a leader is necessary for this to work; please leave that change I made to ANO_FPASS_REBEL in macros/ano01_06macros.cfg intact)
 
     [event]
@@ -353,7 +353,7 @@
             #po: NORMAL, HARD, or NIGHTMARE difficulty, so instead of being a hint, this should just be a pure description of mechanics:
             {OBJECTIVE_NOTES _"Gawen's income depends on whether he is standing on his keep or not in this scenario."}
 #endif
-            {AI_CONTROLLER_NOTE}
+            {ANO_AI_CONTROLLER_NOTE}
         [/objectives]
     [/event]
 
@@ -463,8 +463,22 @@
         [filter_second]
             side=2
         [/filter_second]
+        [scroll_to_unit]
+            id=$unit.id
+            highlight=yes
+        [/scroll_to_unit]
+        [lock_view][/lock_view]
+        [redraw][/redraw]
         {MSG_unit _"Death to the traitors!"}
+        [unlock_view][/unlock_view]
+        [scroll_to_unit]
+            id=$second_unit.id
+            highlight=yes
+        [/scroll_to_unit]
+        [lock_view][/lock_view]
+        [redraw][/redraw]
         {MESSAGE second_unit () ($second_unit.name) _"Yes, death to you!"}
+        [unlock_view][/unlock_view]
     [/event]
 
     [event]
@@ -548,6 +562,16 @@
             side=1
         [/filter_second]
 
+        [scroll_to_unit]
+            id=Oeame
+            highlight=yes
+        [/scroll_to_unit]
+        [lock_view][/lock_view]
+        [redraw][/redraw]
+        [delay]
+            time=123
+        [/delay]
+        [unlock_view][/unlock_view]
         {ANO_FPASS_REBEL second_unit} # defined in macros/ano-01_06macros.cfg
         [hide_unit]
             x=$x1

--- a/scenarios/25_The_Awakening.cfg
+++ b/scenarios/25_The_Awakening.cfg
@@ -341,8 +341,9 @@
         [/ai]
     [/side]
 
-    # Yes, I know the AI_CONTROLLER macro is going to be deprecated, but sometimes Huon needs help:
-    {AI_CONTROLLER () 1 2 ()}
+    # The AI_CONTROLLER macro may be getting deprecated in mainline, but I personally still like it,
+    # and sometimes Huon needs help, so we have a local copy prefixed with "ANO_" for this campaign:
+    {ANO_AI_CONTROLLER () 1 2 ()}
 
     [side]
         controller=ai
@@ -680,7 +681,7 @@
                 condition=lose
             [/objective]
             {TURNS_RUN_OUT}
-            {AI_CONTROLLER_NOTE}
+            {ANO_AI_CONTROLLER_NOTE}
         [/objectives]
     [/event]
 


### PR DESCRIPTION
This was originally suggested by @Toranks.
It ought to be equivalent to cooljeanius/A_New_Order@801ad19, although it looks like another unrelated change that I'd forgotten about from previously from cooljeanius/A_New_Order@70537a0 has slipped in as well...
I think that this ought to be enough for issue #45, but I'll leave that up to @nemaara to decide.
