### PR TITLE
copy over some changes from my other repo

### DIFF
--- a/macros/ano-01_06macros.cfg
+++ b/macros/ano-01_06macros.cfg
@@ -120,12 +120,26 @@
     [if]
         {CONDITION ano_fpassrebel equals no}
         [then]
-            # TODO: fill in 3rd parameter; {WHO} can be either "unit" or "second_unit" so I dunno how to handle both:
-            {MESSAGE ({WHO}) () () _"Traitors! How can you be so dishonorable as to fight against your own rightful king!"}
+            [scroll_to_unit]
+                id=${WHO}.id
+                highlight=yes
+            [/scroll_to_unit]
+            [lock_view][/lock_view]
+            [redraw][/redraw]
+            # OK so yeah it looks like ${WHO}.name works here:
+            {MESSAGE ({WHO}) () (${WHO}.name) _"Traitors! How can you be so dishonorable as to fight against your own rightful king!"}
+            [unlock_view][/unlock_view]
+            [scroll_to_unit]
+                id=Oeame
+                highlight=yes
+            [/scroll_to_unit]
+            [lock_view][/lock_view]
+            [redraw][/redraw]
             {MESSAGE Oeame () (Oeame) _"Our king is dead! We are not traitors!"}
+            [unlock_view][/unlock_view]
             {MSG_Reme _"But here is king's son, his rightful heir. Are you going to fight him?"}
             {MESSAGE Oeame () (Oeame) _"The king's son is dead! We heard about it!"}
-            {MSG_Gawen  _"Do I look dead to you?"}
+            {MSG_Gawen _"Do I look dead to you?"}
             {MESSAGE Oeame () (Oeame) _"We were deceived! My king, please forgive me!"}
             {MESSAGE Roule () (Roule) _"You fool! He is mixling, he can't be our king!"}
             {CHANGE_SIDE Oeame 3}
@@ -220,7 +234,8 @@
     [/delay]
     [unlock_view][/unlock_view]
     {MSG_Gawen _"Which one is better?"}
-    {MSG_Reme _"There is no difference, really. We can use either to reach Vattin. The eastern one leads amidst swamps and forests, while the western one leads through the hills and grasslands. God, I swear to sacrifice a horse if you will help us survive this. A whole, beautiful horse. And I will add a golden saddle!"}
+    #po: the "silver saddle" here was golden previously, but I didn't want players getting confused with gold as in the currency, and plus "silver" gets us an alliteration:
+    {MSG_Reme _"There is no difference, really. We can use either to reach Vattin. The eastern one leads amidst swamps and forests, while the western one leads through the hills and grasslands. God, I swear to sacrifice a horse if you will help us survive this. A whole, beautiful horse. And I will add a silver saddle!"}
     {MSG_Gawen _"Reme, take my step-mother and protect her. I will stay here to guard your rear during withdrawal."}
     {MSG_Lorin _"No! That's suicide! I won't let you!"}
     {MSG_Gawen _"Reme, take her and go. That is an order. And this is not suicide; I will follow you as soon as possible."}
@@ -231,7 +246,7 @@
     [/modify_turns]
     [objectives]
         side=1
-        {OBJECTIVE_NOTES _"Any unit which reaches either signpost will be evacuated and join Lorin and Reme's party. Gawen will be refunded the cost of evacuated loyal units. Units not recalled will be lost. Units that do not escape will also be lost. Gawen must not escape, or he would be considered an unworthy coward by his soldiers. Lorin will get a bonus for each turn Gawen resists beyond the required limit."}
+        {OBJECTIVE_NOTES _"Any unit which reaches either signpost will be evacuated and join Lorin and Reme's party. Gawen will be refunded the cost of evacuated loyal units. Units not recalled will be lost. Units that do not escape will also be lost. Gawen must not escape, or he would be considered an unworthy coward by his soldiers. Lorin will get a bonus applied to her own pool of gold for each turn Gawen resists beyond the required limit. Note that Lorin's gold is separate from Gawen's, so she will not be able to access any gold that he has left over after this scenario. Thus, it is better if Gawen spends all gold available to him now."}
         [objective]
             description={OBJECTIVE}
             condition=win
@@ -445,6 +460,11 @@
         x,y=19,5
     [/scroll_to]
     [lock_view][/lock_view]
+#ifdef DEBUG_MODE
+    {IF_DEBUG_MODE_IS_ACTUALLY_ON}
+    {DEBUGMSG1 "Scattering Hoyre's reinforcements..."}
+    {END_IF_WITHOUT_ELSE}
+#endif
     {SCATTER_UNITS {ON_DIFFICULTY4 20 30 40 50} "Akladian Protector,Akladian Darknite,Akladian Fastfoot,Akladian Pikeneer" 2 (
         x=10-29
         y=1-12
@@ -468,7 +488,7 @@
         side=2 # Hoyre
         generate_name=yes
         random_traits=yes
-        # (until Akladians have more directional sprite variations, don't put a `facing=` key here yet, so that Hoyre's units face random directions)
+        # until Akladians have more directional sprite variations, omit the `facing=` key, so these ones face random directions
     )}
     [redraw][/redraw]
     [delay]
@@ -479,6 +499,11 @@
         x,y=1,4
     [/scroll_to]
     [lock_view][/lock_view]
+#ifdef DEBUG_MODE
+    {IF_DEBUG_MODE_IS_ACTUALLY_ON}
+    {DEBUGMSG1 "Scattering Bor Cryne's reinforcements..."}
+    {END_IF_WITHOUT_ELSE}
+#endif
     {SCATTER_UNITS {ON_DIFFICULTY4 10 15 20 25} "Akladian Protector,Akladian Darknite,Akladian Fastfoot,Akladian Pikeneer" 2 (
         x=1-9
         y=1-12
@@ -513,6 +538,11 @@
         x,y=3,33
     [/scroll_to]
     [lock_view][/lock_view]
+#ifdef DEBUG_MODE
+    {IF_DEBUG_MODE_IS_ACTUALLY_ON}
+    {DEBUGMSG1 "Scattering more of Bor Cryne's reinforcements..."}
+    {END_IF_WITHOUT_ELSE}
+#endif
     {SCATTER_UNITS {ON_DIFFICULTY4 20 30 40 50} "Akladian Protector,Akladian Darknite,Akladian Fastfoot,Akladian Pikeneer" 2 (
         x=1-15
         y=27-40
@@ -547,6 +577,11 @@
         x,y=40,21
     [/scroll_to]
     [lock_view][/lock_view]
+#ifdef DEBUG_MODE
+    {IF_DEBUG_MODE_IS_ACTUALLY_ON}
+    {DEBUGMSG1 "Scattering Uri's reinforcements..."}
+    {END_IF_WITHOUT_ELSE}
+#endif
     {SCATTER_UNITS {ON_DIFFICULTY4 20 30 40 50} "Akladian Protector,Akladian Darknite,Akladian Fastfoot,Akladian Pikeneer" 2 (
         x=27-40
         y=20-40
@@ -581,6 +616,11 @@
         x,y=39,37
     [/scroll_to]
     [lock_view][/lock_view]
+#ifdef DEBUG_MODE
+    {IF_DEBUG_MODE_IS_ACTUALLY_ON}
+    {DEBUGMSG1 "Scattering more of Uri's reinforcements..."}
+    {END_IF_WITHOUT_ELSE}
+#endif
     {SCATTER_UNITS {ON_DIFFICULTY4 10 15 20 25} "Akladian Protector,Akladian Darknite,Akladian Fastfoot,Akladian Pikeneer" 2 (
         x=22-27
         y=26-40

--- a/scenarios/01_Breaking_the_Circle.cfg
+++ b/scenarios/01_Breaking_the_Circle.cfg
@@ -629,6 +629,14 @@
                         {MSG_Lorin _"My son! Please, don't give up!"}
                     [/then]
                 [/if]
+                [modify_unit]
+                    [filter]
+                        id=Gawen Hagarthen
+                    [/filter]
+                    [status]
+                        poisoned=yes
+                    [/status]
+                [/modify_unit]
                 # FIXME: this fires on the very first turn, which means that setting his health earlier is pointless:
                 {SETVAL ("Gawen Hagarthen") (hitpoints) 1}
             [/then]
@@ -714,6 +722,7 @@
         [filter]
             side=1
         [/filter]
+        # TODO: some variation depending on if it's Gawen?
         {MSG_unit _"Truly a shame we have no time to loot it or tax the inhabitants..."}
     [/event]
 

--- a/scenarios/02_Fighting_for_Passage.cfg
+++ b/scenarios/02_Fighting_for_Passage.cfg
@@ -95,6 +95,7 @@
         [ai]
             aggression={ON_DIFFICULTY4 0.0 0.25 0.5 0.75}
             caution={ON_DIFFICULTY4 0.5 0.15 -0.2 -0.55}
+            recruitment_more={ON_DIFFICULTY4 "1,1" "1" "2" "2,2"}
         [/ai]
 
         [unit]
@@ -1012,5 +1013,25 @@
         # (15 6 already handled above)
         {IF_NOT_HAVE_CREATE_LOYAL 2 (Akladian Clansman) 15 7}
         {IF_NOT_HAVE_CREATE_LOYAL 2 (Akladian Clansman) 16 5}
+    [/event]
+
+    [event]
+        name=attack
+        [filter]
+            id="Raul O Gaeltin"
+        [/filter]
+        [filter_second]
+            side=1
+        [/filter_second]
+        {MESSAGE (Raul O Gaeltin) () (Raul O Gaeltin) _"See how a true Akladian Lord fights!"}
+        [gold]
+            side=2
+            amount={ON_DIFFICULTY4 10 20 30 40}
+        [/gold]
+        [scroll_to_unit]
+            id="Raul O Gaeltin"
+            highlight=yes
+        [/scroll_to_unit]
+        # TODO: Show how a true Akladian Lord fights
     [/event]
 [/scenario]

--- a/scenarios/03_Coronation.cfg
+++ b/scenarios/03_Coronation.cfg
@@ -243,7 +243,7 @@
         [hide_unit]
             x,y=5,2
         [/hide_unit]
-        {PLACE_IMAGE (units/akl-chieftain-kn.png) 5 2}
+        {PLACE_IMAGE ("units/akl-chieftain-kn.png~TC(1, magenta)") 5 2}
         [redraw]
         [/redraw]
         {MSG_Lorin _"And you, noble Graeme?"}
@@ -252,14 +252,14 @@
             x=3
             y=5
         [/kill]
-        {PLACE_IMAGE (units/akl-lord-kn.png) 3 5}
+        {PLACE_IMAGE ("units/akl-lord-kn.png~TC(2, magenta)") 3 5}
         {MSG_Lorin _"Uri van Roe?"}
         #po: Uri van Roe isn't exactly referring to Gawen as "the true king" here; he believes there is a different true king:
         {MSG_Uri _"Hail the true king of Vakladia."}
         [kill]
             x,y=5,5
         [/kill]
-        {PLACE_IMAGE (units/akl-lord-kn.png) 5 5}
+        {PLACE_IMAGE ("units/akl-lord-kn.png~TC(4, magenta)") 5 5}
         [redraw]
         [/redraw]
         {MSG_Lorin  _"Bor Cryne?"}
@@ -268,7 +268,7 @@
         [kill]
             x,y=7,5
         [/kill]
-        {PLACE_IMAGE (units/akl-lord-kn.png) 7 5}
+        {PLACE_IMAGE ("units/akl-lord-kn.png~TC(3, magenta)") 7 5}
         {MSG_Lorin _"To guarantee your fealty, I insist that each of you send your first-born son to the court of Vattin, where he shall learn how to best serve the crown."}
         [kill]
             id=Royal guard

--- a/scenarios/04_Battle_of_Barnon.cfg
+++ b/scenarios/04_Battle_of_Barnon.cfg
@@ -407,6 +407,17 @@
             terrain=Ke
         [/terrain]
 #endif
+#ifdef NORMAL
+        # ...and also on NORMAL, but not as much:
+        [terrain]
+            x,y=19,23
+            terrain=Ke
+        [/terrain]
+        [terrain]
+            x,y=2,22
+            terrain=Khr
+        [/terrain]
+#endif # NORMAL
         [recall]
             id=Lady Lorin
         [/recall]
@@ -699,7 +710,7 @@
                             [/then]
                             [else]
                                 [print]
-                                    #po: FIXME: plurals:
+                                    #po: FIXME: plurals; see: https://github.com/wesnoth/wesnoth/issues/1135
                                     text=_"Bonus for resisting $ano_tmp| turns above requirement"
                                     size=18
                                     red,green,blue=255,255,255
@@ -786,7 +797,8 @@
                 {IF ano_barnon_turns equals 0}
                 # Lorin and Reme haven't escaped yet
                 {IF ano_tr greater_than_equal_to 7}
-                #FIXME: this only ever seems to give Clansmen to Uri; the IF_EVEN/IF_ODD macros must be broken:
+                #FIXME: this only ever seems to give Clansmen to Uri; the IF_EVEN/IF_ODD macros must be broken...
+                # see: https://github.com/nemaara/A_New_Order/issues/70
                 {IF_EVEN $turn_number|}
                 {IF_NOT_HAVE_CREATE_LOYAL 3 (Akladian Clansman) 2 40}
                 {END_IF_WITHOUT_ELSE}
@@ -1194,6 +1206,10 @@
                         [/ai]
                     [/modify_side]
                 [/then]
+                [else]
+                    [redraw][/redraw]
+                    # TODO (...slow?)
+                [/else]
             [/if]
         [/event]
     [/event]
@@ -1707,7 +1723,7 @@
         # FIXME: what if Uri has moved out of this zone in his attack on Barnon?
         # If the player is trying to capture villages he left behind after his attack,
         # that's not exactly "coming for me" (from his perspective), it's more like
-        # running away from him... may need to adjust filter or something.
+        # running away from him... may need to adjust filter, or the dialogue, or something.
         [filter]
             side=1
             x=24-40
@@ -2154,7 +2170,8 @@
         # (ok after testing, yup, it does indeed help)
 #ifdef NIGHTMARE
         [event]
-            # FIXME: doesn't seem to work?
+            # delayed_variable_substitution=no gets the event to fire, but it also means that other dollar-sign usages might not work:
+            delayed_variable_substitution=no
             name="turn $($turn_number + 6)"
             id=Hoyre_returns
             [scroll_to]
@@ -2177,12 +2194,23 @@
                     invulnerable=yes
                 [/status]
             [/modify_unit]
+            [redraw][/redraw]
             {MESSAGE (Hoyre O Barnone) (portraits/hoyre.png) (Hoyre O Barnone) _"I'm back with the reinforcements, just as promised!"}
-            # Tee hee hee I'm evil:
-            {ANO4_TIMEOVER_REINFORCEMENTS} # defined in ano-01_06macros.cfg
+            # Fire this as a separate event due to this one using delayed_variable_substitution=no above:
+            [fire_event]
+                # Tee hee hee I'm evil:
+                name=timeover_reinforcements
+            [/fire_event]
             {CLEAR_VARIABLE ano_barnon_Hoyre_tmp}
         [/event]
 #endif
+    [/event]
+
+    # Put out here so it can be called from elsewhere:
+    [event]
+        name=timeover_reinforcements
+        id=timeover_reinforcements
+        {ANO4_TIMEOVER_REINFORCEMENTS} # defined in ano-01_06macros.cfg
     [/event]
 
     # Easter egg:


### PR DESCRIPTION
This addresses some feedback from @Toranks
Changes include:
- addresses the question about macro usage with message captions in issue #7
- clarify Barnon's gold mechanic a bit further
- extra debug messages for reinforcement scattering in S04
- ensure Gawen is *really* always poisoned in the first scenario
- some additional tuning of the second scenario
- fix team coloring of kneeling Akladian lords in the coronation cutscene (S03)
- additional recruiting space in Barnon on NORMAL, too
- fix Hoyre returning on NIGHTMARE; closes issue #78
