### PR TITLE
Fix Reumario loyal and simplified code

### DIFF
--- a/macros/ano_macros.cfg
+++ b/macros/ano_macros.cfg
@@ -1008,28 +1008,14 @@
 #enddef
 
 #define MAKE_LOYAL OP WHAT
-    {CLEAR_VARIABLE ano_loyal}
-    [store_unit]
-        variable=ano_loyal
+    [modify_unit]
         [filter]
             {OP}={WHAT}
             side=1
         [/filter]
-    [/store_unit]
+		{TRAIT_LOYAL}
+    [/modify_unit]
     {MSG_narrator _"The unit $ano_loyal[0].name became LOYAL."}
-    {VARIABLE (ano_loyal[0].traits_description) ("$ano_loyal[0].traits_description" + _"loyal")}
-    {VARIABLE (ano_loyal[0].upkeep) ("loyal")}
-    {VARIABLE (ano_loyal[0].modifications.trait[2].id) ("loyal")}
-    {VARIABLE (ano_loyal[0].modifications.trait[2].name) (_"loyal")}
-    {VARIABLE (ano_loyal[0].modifications.trait[2].effect.apply_to) ("loyal")}
-    # wmllint: validate-off
-    {VARIABLE (ano_loyal[0].modifications.trait[2].description) (_"Zero upkeep")} # wmllint: ignore
-    # wmllint: validate-on
-    {VARIABLE (ano_loyal[0].overlays) ("misc/loyal-icon.png")}
-    [unstore_unit]
-        variable=ano_loyal[0]
-    [/unstore_unit]
-    {CLEAR_VARIABLE ano_loyal}
 #enddef
 
 # FIXME: how about refactoring this just to use the normal "notes" tag?
@@ -1037,6 +1023,3 @@
     note="*"+_"Scenario notes:"+"
 "+{_NOTES_TEXT}
 #enddef
-
-# For the AI controller:
-{./ai}

--- a/macros/ano_macros.cfg
+++ b/macros/ano_macros.cfg
@@ -1023,3 +1023,6 @@
     note="*"+_"Scenario notes:"+"
 "+{_NOTES_TEXT}
 #enddef
+
+# For the AI controller:
+{./ai}

--- a/scenarios/09_Hired_Swords.cfg
+++ b/scenarios/09_Hired_Swords.cfg
@@ -523,13 +523,18 @@
                                         {MSG_Lorin  _"So, we won."}
                                         {MSG_Yahyazad _"You sound disappointed... were you relishing the thought of more action?"}
                                         {MSG_Lorin _"I'm sure there will be plenty of action when the orcs arrive."}
-                                        [store_unit]
-                                            [filter]
-                                                id=Reumario
-                                            [/filter]
-                                            variable=ano_reumario_unit
-                                            kill=yes
-                                        [/store_unit]
+										[modify_unit]
+                                                [filter]
+                                                    id=Reumario
+                                                [/filter]
+												{TRAIT_LOYAL}
+												canrecruit=no
+												side=1
+										[/modify_unit]
+										[transform_unit]
+										    id=Reumario
+										    transform_to=Akladian Chieftain
+										[/transform_unit]
                                         [endlevel]
                                             result=victory
                                             bonus=yes
@@ -597,42 +602,9 @@
                 equals=join
             [/variable]
             [then]
-                [set_variable]
-                    name=ano_reumario_unit.side
-                    value=1
-                [/set_variable]
-                [set_variable]
-                    name=ano_reumario_unit.type
-                    value=Akladian Chieftain
-                [/set_variable]
-                {VARIABLE (ano_reumario_unit.traits_description) ("$ano_loyal[0].traits_description" + _"loyal")}
-                {VARIABLE (ano_reumario_unit.upkeep) ("free")}
-                {VARIABLE (ano_reumario_unit.canrecruit) ("0")}
-                {VARIABLE (ano_reumario_unit.modifications.trait[2].id) ("loyal")}
-                {VARIABLE (ano_reumario_unit.modifications.trait[2].name) ("loyal")}
-                {VARIABLE (ano_reumario_unit.modifications.trait[2].male_name) ("loyal")} # is it necessary?
-                {VARIABLE (ano_reumario_unit.modifications.trait[2].effect.apply_to) ("loyal")}
-                # wmllint: validate-off
-                {VARIABLE (ano_reumario_unit.modifications.trait[2].description) ("Zero upkeep")} # wmllint: ignore
-                # wmllint: validate-on
-                # WIP: borrowing this from the code to make other units loyal:
-                {VARIABLE (ano_reumario_unit.overlays) ("misc/loyal-icon.png")}
-                [unstore_unit]
-                    variable=ano_reumario_unit
-                    find_vacant=yes
-                [/unstore_unit]
-                {CLEAR_VARIABLE ano_reumario_unit}
                 [allow_recruit]
                     side=1
-                    type=Akladian Clansman
-                [/allow_recruit]
-                [allow_recruit]
-                    side=1
-                    type=Akladian Warrior
-                [/allow_recruit]
-                [allow_recruit]
-                    side=1
-                    type=Akladian Wiseman
+                    type=Akladian Clansman,Akladian Warrior,Akladian Wiseman
                 [/allow_recruit]
                 {BUFF_AKLADIAN_HEALERS}
             [/then]

--- a/scenarios/09_Hired_Swords.cfg
+++ b/scenarios/09_Hired_Swords.cfg
@@ -523,18 +523,18 @@
                                         {MSG_Lorin  _"So, we won."}
                                         {MSG_Yahyazad _"You sound disappointed... were you relishing the thought of more action?"}
                                         {MSG_Lorin _"I'm sure there will be plenty of action when the orcs arrive."}
-										[modify_unit]
-                                                [filter]
-                                                    id=Reumario
-                                                [/filter]
-												{TRAIT_LOYAL}
-												canrecruit=no
-												side=1
-										[/modify_unit]
-										[transform_unit]
-										    id=Reumario
-										    transform_to=Akladian Chieftain
-										[/transform_unit]
+                                        [modify_unit]
+                                            [filter]
+                                                id=Reumario
+                                            [/filter]
+                                            {TRAIT_LOYAL}
+                                            canrecruit=no
+                                            side=1
+                                        [/modify_unit]
+                                        [transform_unit]
+                                            id=Reumario
+                                            transform_to=Akladian Chieftain
+                                        [/transform_unit]
                                         [endlevel]
                                             result=victory
                                             bonus=yes

--- a/scenarios/10_Siege_of_Haeltin.cfg
+++ b/scenarios/10_Siege_of_Haeltin.cfg
@@ -21,30 +21,14 @@
     {STARTING_VILLAGES 3 5}
     {STARTING_VILLAGES 4 5}
 #define MAKELOYAL TYPE
-    {CLEAR_VARIABLE ano_loyal}
-    [store_unit]
-        variable=ano_loyal
+    [modify_unit]
         [filter]
             type={TYPE}
             side=1
         [/filter]
-    [/store_unit]
+		{TRAIT_LOYAL}
+    [/modify_unit]
     {MSG_narrator _"It seems that $ano_loyal[0].type $ano_loyal[0].name was so impressed by Lorin's performance in this siege, that he will now fight for her without the need to pay him. He became LOYAL."}
-    {VARIABLE (ano_loyal[0].traits_description) ("$ano_loyal[0].traits_description" + _"loyal")}
-    {VARIABLE (ano_loyal[0].upkeep) ("loyal")}
-    {VARIABLE (ano_loyal[0].modifications.trait[2].id) ("loyal")}
-    {VARIABLE (ano_loyal[0].modifications.trait[2].name) (_"loyal")}
-    {VARIABLE (ano_loyal[0].modifications.trait[2].male_name) (_"loyal")} # is it necessary?
-    {VARIABLE (ano_loyal[0].modifications.trait[2].effect.apply_to) ("loyal")}
-    # wmllint: validate-off
-    {VARIABLE (ano_loyal[0].modifications.trait[2].description) (_"Zero upkeep")} # wmllint: ignore
-    # wmllint: validate-on
-    {VARIABLE (ano_loyal[0].overlays) ("misc/loyal-icon.png")}
-
-    [unstore_unit]
-        variable=ano_loyal[0]
-    [/unstore_unit]
-    {CLEAR_VARIABLE ano_loyal}
 #enddef
     [story]
         [part]


### PR DESCRIPTION
This is one of the weirdest unit modifications I've ever seen xD
Storing unit, directly modifying variables, and unstoring unit? All of this completely unnecessary and makes the trait "loyal" non translatable.
I've done all the changes with [modify_unit] and [transform_unit] without storing anything, much cleaner. I've simplified other parts of the code too, as the [allow_recruit] using comma list instead of repeat every time.