### PR TITLE
Fix loyalty check in S02 for issue #23

### DIFF
--- a/scenarios/02_Fighting_for_Passage.cfg
+++ b/scenarios/02_Fighting_for_Passage.cfg
@@ -917,6 +917,12 @@
             side=1
         [/filter]
         {MSG_Gawen _"Poor fellow!"}
+        [heal_unit]
+            [filter]
+                id=$unit.id
+            [/filter]
+            amount=1
+        [/heal_unit]
 #ifdef NIGHTMARE
         #po: be terser for NIGHTMARE difficulty:
         {MSG_Reme _"He dies an honorable death. You will have to get used to losing units."}
@@ -924,26 +930,21 @@
         #po: all other difficulties; have this be more advice-like:
         {MSG_Reme _"He dies an honorable death. You cannot let the fear of losing units paralyse you; there are many more clansmen ready to fight for you."}
 #endif
-        # FIXME: This loyalty check doesn't seem to work, even after changing it from a "die" event to a "last breath" event, so I don't know what's wrong:
+        # Getting this loyalty check to work was a pain; see issue 23: https://github.com/nemaara/A_New_Order/issues/23
         [if]
             [have_unit]
                 id=$unit.id
-                [filter_wml]
-                    upkeep="loyal"
-                    [or]
-                        [modifications]
-                            [trait]
-                                id=loyal
-                            [/trait]
-                        [/modifications]
-                    [/or]
-                [/filter_wml]
+                upkeep="loyal"
             [/have_unit]
             [then]
                 {MSG_Gawen _"But he was loyal to our cause though!"}
                 {MSG_Reme _"Well, I suppose you do have a point there. Feel free to be more careful with our most loyal supporters."}
             [/then]
         [/if]
+        [kill]
+            id=$unit.id
+            animate=yes
+        [/kill]
     [/event]
 
     [event]


### PR DESCRIPTION
I wrote the existing loyalty check for BfW 1.14. Conversation with @CelticMinstrel (and checking the wiki) reminded me that `upkeep="loyal"` can go directly into a SUF now, as of BfW 1.15.3, so we can just use that.
Closes issue #23.
