### PR TITLE
Castle blink fix on S13

### DIFF
--- a/scenarios/13_Scouting.cfg
+++ b/scenarios/13_Scouting.cfg
@@ -419,6 +419,11 @@
         {END_IF_WITHOUT_ELSE}
         {END_IF_WITHOUT_ELSE}
         #end of finding frozen orc
+        [terrain]
+            x=10
+            y=7
+            terrain=Aa
+        [/terrain]
     [/event]
 
     [event]
@@ -434,11 +439,7 @@
         {MSGW_Karen _"No, no, no. He HAS to have a beard. All of our great Wesnothian kings had beards!"}
         {END_IF_WITHOUT_ELSE}
         {END_IF}
-        [terrain]
-            x=10
-            y=7
-            terrain=Aa
-        [/terrain]
+
 
         [objectives]
             side=1


### PR DESCRIPTION
Moving the terrain change from start to prestart prevents that flicker where you see a castle in the tent for a second