### PR TITLE
Update code for odd/even turn number check.

### DIFF
--- a/macros/programming-macros.cfg
+++ b/macros/programming-macros.cfg
@@ -45,8 +45,10 @@
 #    {MULTIPLY <numeric-variable> <numeric-value>}
 #    {INCREMENT <numeric-variable>}
 #    {DECREMENT <numeric-variable>}
-#    {IF_EVEN <numeric-variable>}
-#    {IF_ODD <numeric-variable>}
+#-------------------------------------------------------------------------------
+# Turn numbers:
+#    {IF_TURN_EVEN}
+#    {IF_TURN_ODD}
 #===============================================================================
 #-------------------------------------------------------------------------------
 # Definitions:
@@ -274,32 +276,30 @@
 #define DECREMENT N
     {ADD {N} -1}
 #enddef
+#===============================================================================
+# Turn numbers:
 #-------------------------------------------------------------------------------
-# {IF_EVEN <numeric-variable>}
-# {IF_ODD <numeric-variable>}
-#define CHECK_EVEN N
-    # FIXME: This has got to be the hackiest way possible to do this; can't we just use a modulo instead?
-    # see: https://github.com/nemaara/A_New_Order/issues/70
-    {SET temp_a {N}}
-    {SET temp_b {N}}
-    {INCREMENT temp_a}
-    {MULTIPLY temp_a .5}
-    {MULTIPLY temp_b .5}
-    {IF temp_a equals $temp_b}
-    {SET_TRUE global_var__is_even}
-    {ELSE}
-    {SET_FALSE global_var__is_even}
-    {END_IF}
-    {RELEASE temp_a}
-    {RELEASE temp_b}
+# {IF_TURN_EVEN}
+# {IF_TURN_ODD}
+
+#define IF_TURN_EVEN
+    [if]
+        [variable]
+            name=turn_number
+            formula="$turn_number % 2 = 0"
+        [/variable]
+        [then]
+        # wmlxgettext: [/then]
+    # wmlxgettext: [/if]
 #enddef
-#define IF_EVEN N
-    {CHECK_EVEN {N}}
-    {IF_TRUE global_var__is_even}
-    # no good place to deallocate 'global_var__is_even'.
-#enddef
-#define IF_ODD N
-    {CHECK_EVEN {N}}
-    {IF_FALSE global_var__is_even}
-    # no good place to deallocate 'global_var__is_even'.
+
+#define IF_TURN_ODD
+    [if]
+        [variable]
+            name=turn_number
+            formula="$turn_number % 2 = 1"
+        [/variable]
+        [then]
+        # wmlxgettext: [/then]
+    # wmlxgettext: [/if]
 #enddef

--- a/macros/programming-macros.cfg
+++ b/macros/programming-macros.cfg
@@ -281,7 +281,8 @@
 #-------------------------------------------------------------------------------
 # {IF_TURN_EVEN}
 # {IF_TURN_ODD}
-
+#wmlindent: start ignoring
+#wmllint: unbalanced-on
 #define IF_TURN_EVEN
     [if]
         [variable]
@@ -289,8 +290,8 @@
             formula="$turn_number % 2 = 0"
         [/variable]
         [then]
-        # wmlxgettext: [/then]
-    # wmlxgettext: [/if]
+            # wmlxgettext: [/then]
+            # wmlxgettext: [/if]
 #enddef
 
 #define IF_TURN_ODD
@@ -300,6 +301,8 @@
             formula="$turn_number % 2 = 1"
         [/variable]
         [then]
-        # wmlxgettext: [/then]
-    # wmlxgettext: [/if]
+            # wmlxgettext: [/then]
+            # wmlxgettext: [/if]
 #enddef
+#wmllint: unbalanced-off
+#wmlindent: stop ignoring

--- a/scenarios/04_Battle_of_Barnon.cfg
+++ b/scenarios/04_Battle_of_Barnon.cfg
@@ -802,8 +802,6 @@
                 {IF ano_barnon_turns equals 0}
                 # Lorin and Reme haven't escaped yet
                 {IF ano_tr greater_than_equal_to 7}
-                #FIXME: this only ever seems to give Clansmen to Uri; the IF_EVEN/IF_ODD macros must be broken...
-                # see: https://github.com/nemaara/A_New_Order/issues/70
                 {IF_TURN_EVEN}
                 {IF_NOT_HAVE_CREATE_LOYAL 3 (Akladian Clansman) 2 40}
                 {END_IF_WITHOUT_ELSE}

--- a/scenarios/04_Battle_of_Barnon.cfg
+++ b/scenarios/04_Battle_of_Barnon.cfg
@@ -804,38 +804,38 @@
                 {IF ano_tr greater_than_equal_to 7}
                 #FIXME: this only ever seems to give Clansmen to Uri; the IF_EVEN/IF_ODD macros must be broken...
                 # see: https://github.com/nemaara/A_New_Order/issues/70
-                {IF_EVEN $turn_number|}
+                {IF_TURN_EVEN}
                 {IF_NOT_HAVE_CREATE_LOYAL 3 (Akladian Clansman) 2 40}
                 {END_IF_WITHOUT_ELSE}
-                {IF_ODD $turn_number|}
+                {IF_TURN_ODD}
                 {IF_NOT_HAVE_CREATE_LOYAL 4 (Akladian Clansman) 38 40}
                 {END_IF_WITHOUT_ELSE}
                 {END_IF_WITHOUT_ELSE} # ano_tr
                 {ELSE}
                 {IF ano_barnon_turns less_than $ano_howmanyturns|}
                 # Lorin and Reme have escaped, but Gawen still needs to resist
-                {IF_EVEN $turn_number|}
+                {IF_TURN_EVEN}
                 {IF_NOT_HAVE_CREATE_LOYAL 3 (Akladian Warrior) 2 40}
                 {END_IF_WITHOUT_ELSE}
-                {IF_ODD $turn_number|}
+                {IF_TURN_ODD}
                 {IF_NOT_HAVE_CREATE_LOYAL 4 (Akladian Warrior) 38 40}
                 {END_IF_WITHOUT_ELSE}
                 {ELSE}
                 {IF ano_tmp greater_than_equal_to 1}
                 # Gawen is above the requirement and into bonus turns
-                {IF_EVEN $turn_number|}
+                {IF_TURN_EVEN}
                 {IF_NOT_HAVE_CREATE_LOYAL 3 (Akladian Light Infantry) 2 40}
                 {END_IF_WITHOUT_ELSE}
-                {IF_ODD $turn_number|}
+                {IF_TURN_ODD}
                 {IF_NOT_HAVE_CREATE_LOYAL 4 (Akladian Light Infantry) 38 40}
                 {END_IF_WITHOUT_ELSE}
                 {ELSE}
                 {IF ano_uri_warned greater_than_equal_to 3}
                 # probably not reached
-                {IF_EVEN $turn_number|}
+                {IF_TURN_EVEN}
                 {IF_NOT_HAVE_CREATE_LOYAL 3 (Akladian Pikeneer) 2 40}
                 {END_IF_WITHOUT_ELSE}
-                {IF_ODD $turn_number|}
+                {IF_TURN_ODD}
                 {IF_NOT_HAVE_CREATE_LOYAL 4 (Akladian Pikeneer) 38 40}
                 {END_IF_WITHOUT_ELSE}
                 {ELSE}


### PR DESCRIPTION
As mentioned in issue #70, the code for the `{CHECK_EVEN}`, `{IF_EVEN}` and `{IF_ODD}` macros is ancient.
There are several ways to update it, by using WML variables, Lua or Formula syntax; I went for the last option, but this can of course be changed if something else is preferred.
The code which uses these checks is used only on the `NIGHTMARE` difficulty level, so at the moment I can't test it (but I tested my code in a test scenario and it seems to work). It's also worth noting that this isn't an ideal fix: the same block of code uses a lot of `{IF...` and `{END_IF...` macros, which were made when the `[elseif]` tag didn't exist, so a better solution would require rewriting that whole block in a more modern (and more readable) style.
I also decided to make the macros specialized to check the turn number because they weren't used for any other purpose.