### PR TITLE
Fixed die event for heroes doesn't trigger on S27

### DIFF
--- a/macros/ano-20macros.cfg
+++ b/macros/ano-20macros.cfg
@@ -113,7 +113,6 @@
         [modifications]
             {TRAIT_LOYAL}
         [/modifications]
-        {IS_LOYAL}
     [/unit]
 #enddef
 

--- a/macros/ano-20macros.cfg
+++ b/macros/ano-20macros.cfg
@@ -113,6 +113,7 @@
         [modifications]
             {TRAIT_LOYAL}
         [/modifications]
+        {IS_LOYAL}
     [/unit]
 #enddef
 

--- a/macros/deaths.cfg
+++ b/macros/deaths.cfg
@@ -93,7 +93,7 @@
 
 #define REME_DEATH
     [event]
-        name=die
+        name=last breath
         [filter]
             id=Reme Carrenemoe
         [/filter]
@@ -107,7 +107,7 @@
 
 #define KAREN_DEATH
     [event]
-        name=die
+        name=last breath
         [filter]
             id=Karen
         [/filter]
@@ -122,7 +122,7 @@
 
 #define RUVIO_DEATH
     [event]
-        name=die
+        name=last breath
         [filter]
             id=Ruvio
         [/filter]

--- a/scenarios/27_Orannon.cfg
+++ b/scenarios/27_Orannon.cfg
@@ -1642,9 +1642,9 @@ Forces of Darkness will consume your mind."}
 
     # A good portion of this scenario's code is actually in this FINAL_INTERROGATIONS macro;
     # it is located in macros/ano-20macros.cfg:
-    {FINAL_INTERROGATIONS}
     {ALL_ANO_DEATHS}
     {ELVISH_DEATHS}
     {MAGE_DEATHS}
     {ELVISH_KILLING}
+    {FINAL_INTERROGATIONS}
 [/scenario]


### PR DESCRIPTION
The solution was even simpler than what I told you on discord. Put the death events BEFORE the interrogation events, where the undead transformation event is included.
Also, moved die events to last breath on some character that must say a sentence when die, same as other characters. I think it was an omission or an oversight, but in cases like this, the died unit says his final sentence while being invisible.

Notes:
- Draft because need testing. Debug mode has a secret trigger to make Grekulak come on any turn, must be useful.
~~- {IS_LOYAL} is redundant, deleted just to reduce code~~

