### PR TITLE
Removed all redundant {IS_LOYAL}

### DIFF
--- a/macros/ano-20macros.cfg
+++ b/macros/ano-20macros.cfg
@@ -113,7 +113,6 @@
         [modifications]
             {TRAIT_LOYAL}
         [/modifications]
-        {IS_LOYAL}
     [/unit]
 #enddef
 

--- a/scenarios/01_Breaking_the_Circle.cfg
+++ b/scenarios/01_Breaking_the_Circle.cfg
@@ -184,7 +184,6 @@
                 {TRAIT_RESILIENT}
 #endif
             [/modifications]
-            {IS_LOYAL}
         [/unit]
         [unit]
             id=Iree Rothe
@@ -200,7 +199,6 @@
                 {TRAIT_RESILIENT}
 #endif
             [/modifications]
-            {IS_LOYAL}
         [/unit]
         [unit]
             id=Reuke Rothe
@@ -220,7 +218,6 @@
                 {TRAIT_RESILIENT}
 #endif
             [/modifications]
-            {IS_LOYAL}
         [/unit]
         [unit]
             id=Strome Ohavenort
@@ -236,7 +233,6 @@
                 {TRAIT_RESILIENT}
 #endif
             [/modifications]
-            {IS_LOYAL}
         [/unit]
         [unit]
             id=Reonee
@@ -256,7 +252,6 @@
                 {TRAIT_RESILIENT}
 #endif
             [/modifications]
-            {IS_LOYAL}
         [/unit]
         [unit]
             id=Raoke
@@ -276,7 +271,6 @@
                 {TRAIT_STRONG}
 #endif
             [/modifications]
-            {IS_LOYAL}
         [/unit]
 #ifdef NIGHTMARE
         # We are still in a side declaration here and I don't like leaving empty branches in my ifdefs:
@@ -299,7 +293,6 @@
                 {TRAIT_STRONG}
 #endif
             [/modifications]
-            {IS_LOYAL}
         [/unit]
 #endif
 #endif # NIGHTMARE
@@ -316,7 +309,6 @@
             [modifications]
                 {TRAIT_LOYAL}
             [/modifications]
-            {IS_LOYAL}
         [/unit]
 #endif
     [/side]

--- a/scenarios/07_Ally_From_the_Past.cfg
+++ b/scenarios/07_Ally_From_the_Past.cfg
@@ -331,7 +331,6 @@
             [modifications]
                 {TRAIT_LOYAL}
             [/modifications]
-            {IS_LOYAL}
         [/unit]
         {MESSAGE (Karl Regven) (portraits/regven.png) (Karl Regven) _"My lord, I was not able to stop her."}
         {MSG_Karen _"Don't be too hard on him, father. He really tried. So, this is little Haldric whom you told us about? He looks quite normal, not Akladian at all."}

--- a/scenarios/08_Outlaw_Base.cfg
+++ b/scenarios/08_Outlaw_Base.cfg
@@ -465,7 +465,6 @@
                         {TRAIT_LOYAL}
                         # (maybe give him an additional trait on EASY?)
                     [/modifications]
-                    {IS_LOYAL}
                 [/unit]
                 {CLEAR_VARIABLE ano_robroe_unit}
                 # (new recruits are dealt with later)

--- a/scenarios/13_Scouting.cfg
+++ b/scenarios/13_Scouting.cfg
@@ -183,7 +183,6 @@
             {TRAIT_LOYAL}
             {TRAIT_DEXTROUS}
         [/modifications]
-        {IS_LOYAL}
     [/unit]
     {ELSE}
     {MESSAGE (narrator) ({IMG}) () _"Ha, ha, and I thought you were serious."}
@@ -251,7 +250,6 @@
             {TRAIT_STRONG}
             {TRAIT_RESILIENT}
         [/modifications]
-        {IS_LOYAL}
     [/unit]
     {END_IF}
     #IMPOSSIBLE
@@ -900,7 +898,6 @@
                 {TRAIT_DEXTROUS}
                 {TRAIT_INTELLIGENT}
             [/modifications]
-            {IS_LOYAL}
         [/unit]
         {MSGW_Ruvio _"Someone is hiding here!"}
         {IF ano_lorin_joined equals yes}

--- a/scenarios/14d_Avenging_Ruen.cfg
+++ b/scenarios/14d_Avenging_Ruen.cfg
@@ -326,7 +326,6 @@
                 {TRAIT_STRONG}
                 {TRAIT_RESILIENT}
             [/modifications]
-            {IS_LOYAL}
         [/unit]
         [unit]
             type=Peasant
@@ -341,7 +340,6 @@
                 {TRAIT_RESILIENT}
                 # maybe add an image mod to make his portrait and/or sprite smaller?
             [/modifications]
-            {IS_LOYAL}
         [/unit]
         [unit]
             type=Peasant
@@ -355,7 +353,6 @@
                 {TRAIT_QUICK}
                 {TRAIT_INTELLIGENT}
             [/modifications]
-            {IS_LOYAL}
         [/unit]
         {MESSAGE (Quick Herman) () (Quick Herman) _"Hurray! We are free! Now, death to the orcs!"}
     [/event]
@@ -380,7 +377,6 @@
                 {TRAIT_STRONG}
                 {TRAIT_RESILIENT}
             [/modifications]
-            {IS_LOYAL}
         [/unit]
         [unit]
             type=Peasant
@@ -394,7 +390,6 @@
                 {TRAIT_DEXTROUS}
                 {TRAIT_RESILIENT}
             [/modifications]
-            {IS_LOYAL}
         [/unit]
         [unit]
             type=Peasant
@@ -408,7 +403,6 @@
                 {TRAIT_QUICK}
                 {TRAIT_INTELLIGENT}
             [/modifications]
-            {IS_LOYAL}
         [/unit]
         {MESSAGE (Fast Robin) () (Fast Robin) _"Hurray! We are free! Now, death to the orcs!"}
     [/event]

--- a/scenarios/18_Start_of_the_Quest.cfg
+++ b/scenarios/18_Start_of_the_Quest.cfg
@@ -330,7 +330,6 @@
                 {TRAIT_LOYAL}
                 {TRAIT_RESILIENT}
             [/modifications]
-            {IS_LOYAL}
         [/unit]
         {ELSE}
         {MESSAGE (narrator) (portraits/akladian_peasant.png) (_"Village leader") _"Fight for you? Against my own kin? No thanks."}
@@ -404,7 +403,6 @@
                 {TRAIT_STRONG}
                 {TRAIT_RESILIENT}
             [/modifications]
-            {IS_LOYAL}
         [/unit]
         {ELSE}
         # (no)
@@ -429,7 +427,6 @@
                 {TRAIT_STRONG}
                 {TRAIT_RESILIENT}
             [/modifications]
-            {IS_LOYAL}
         [/unit]
         {ELSE}
         # (no)
@@ -515,7 +512,6 @@
                 {TRAIT_LOYAL}
                 {TRAIT_RESILIENT}
             [/modifications]
-            {IS_LOYAL}
         [/unit]
         {ELSE}
         # (no)

--- a/scenarios/19c_The_Oracle.cfg
+++ b/scenarios/19c_The_Oracle.cfg
@@ -1831,7 +1831,6 @@
                 {TRAIT_STRONG}
 #endif
             [/modifications]
-            {IS_LOYAL}
         [/unit]
         [delay]
             time=100

--- a/scenarios/20_Okladia.cfg
+++ b/scenarios/20_Okladia.cfg
@@ -107,7 +107,6 @@
                 {TRAIT_INTELLIGENT}
 #endif
             [/modifications]
-            {IS_LOYAL}
         [/unit]
         {MAKE_HERO Deorien}
         {END_IF}
@@ -378,7 +377,6 @@
                 {TRAIT_STRONG}
                 {TRAIT_LOYAL}
             [/modifications]
-            {IS_LOYAL}
         [/unit]
         {END_IF}
         {ELSE_IF ano_opt equals deorien}

--- a/scenarios/23_Trapped.cfg
+++ b/scenarios/23_Trapped.cfg
@@ -668,7 +668,6 @@
                 {TRAIT_STRONG}
                 {TRAIT_RESILIENT}
             [/modifications]
-            {IS_LOYAL}
 #endif
         [/unit]
         [gold]
@@ -692,7 +691,6 @@
                 {TRAIT_LOYAL}
                 {TRAIT_RESILIENT}
             [/modifications]
-            {IS_LOYAL}
         [/unit]
         [unit]
             side=3
@@ -703,7 +701,6 @@
                 {TRAIT_LOYAL}
                 {TRAIT_RESILIENT}
             [/modifications]
-            {IS_LOYAL}
         [/unit]
 #endif
     [/event]
@@ -723,7 +720,6 @@
                 {TRAIT_LOYAL}
                 {TRAIT_RESILIENT}
             [/modifications]
-            {IS_LOYAL}
         [/unit]
         [unit]
             side=3
@@ -734,7 +730,6 @@
                 {TRAIT_LOYAL}
                 {TRAIT_RESILIENT}
             [/modifications]
-            {IS_LOYAL}
         [/unit]
 #endif
     [/event]

--- a/scenarios/25_The_Awakening.cfg
+++ b/scenarios/25_The_Awakening.cfg
@@ -67,7 +67,6 @@
             {TRAIT_STRONG}
             {TRAIT_RESILIENT}
         [/modifications]
-        {IS_LOYAL}
     [/unit]
 #ifdef EASY
     [gold]
@@ -88,7 +87,6 @@
             {TRAIT_QUICK}
             {TRAIT_INTELLIGENT}
         [/modifications]
-        {IS_LOYAL}
     [/unit]
 #ifdef EASY
     [gold]
@@ -109,7 +107,6 @@
             {TRAIT_QUICK}
             {TRAIT_RESILIENT}
         [/modifications]
-        {IS_LOYAL}
     [/unit]
 #ifdef EASY
     [gold]
@@ -130,7 +127,6 @@
             {TRAIT_QUICK}
             {TRAIT_STRONG}
         [/modifications]
-        {IS_LOYAL}
     [/unit]
 #ifdef EASY
     [gold]
@@ -151,7 +147,6 @@
             {TRAIT_INTELLIGENT}
             {TRAIT_STRONG}
         [/modifications]
-        {IS_LOYAL}
     [/unit]
 #ifdef EASY
     [gold]
@@ -172,7 +167,6 @@
             {TRAIT_INTELLIGENT}
             {TRAIT_RESILIENT}
         [/modifications]
-        {IS_LOYAL}
     [/unit]
 #ifdef EASY
     [gold]
@@ -217,7 +211,6 @@
             {TRAIT_STRONG}
             {TRAIT_RESILIENT}
         [/modifications]
-        {IS_LOYAL}
     [/unit]
     {MESSAGE ({CLANSMAN_ID}) () ({CLANSMAN_ID}) _"Long live our king Gawen Haldric! It will be honour to fight for you, my king!"}
 #enddef

--- a/scenarios/27_Orannon.cfg
+++ b/scenarios/27_Orannon.cfg
@@ -321,7 +321,6 @@
         {INCOME4 6 8 10 12}
         [modifications]
             {TRAIT_WEAK}
-            {TRAIT_LOYAL}
             {TRAIT_INTELLIGENT}
         [/modifications]
         [ai]

--- a/scenarios/27_Orannon.cfg
+++ b/scenarios/27_Orannon.cfg
@@ -321,6 +321,7 @@
         {INCOME4 6 8 10 12}
         [modifications]
             {TRAIT_WEAK}
+            {TRAIT_LOYAL OVERLAY=""}
             {TRAIT_INTELLIGENT}
         [/modifications]
         [ai]


### PR DESCRIPTION
{IS_LOYAL} is used to set the icon and nothing else. Since TRAIT_LOYAL already includes it, it is redundant. This doesn't solve anything, it just simplifies the code. I saw this while fixing the other loyal.

I also include a redundant loyal trait on Mal-Raylal, that is a faction leader. Leaders are always loyal, and the superimposed icon is solved too. I'm adding it here because I realized after the PR that fixes all icons.