### PR TITLE
Recall can't be undo on this scenario, deleted messages

### DIFF
--- a/KNOWN_BUGS.txt
+++ b/KNOWN_BUGS.txt
@@ -1,12 +1,13 @@
-Note: this file is outdated; see the bugtracker on GitHub instead 
+Note: this file is outdated; see the bugtracker on GitHub instead:
+https://github.com/nemaara/A_New_Order/issues
+
+Old Known Bugs:
 
 in scenario 4 Battle_of_Barnon, you can send Lorin and Reme west, and all the rest
 to the east, but still they are happily reunited in the next scenario.
 (at least there's code preventing Reme and Lorin from being separated like that)
 
-
-* In scenarios when you recall units to choose the best ones, if you withdraw your choice, it is still counted.
-* In "Orannon", the game did not end when I got Lady Lorin killed (this was after she had to return to the keep within 6 turns).
+* In "Orannon", the game did not end once when I (szopen) got Lady Lorin killed (this was after she had to return to the keep within 6 turns).
 
 wesnoth messages: 
 20120124 22:06:01 error ai/goal: bad value of protect_goal

--- a/scenarios/16_Choosing_the_Best.cfg
+++ b/scenarios/16_Choosing_the_Best.cfg
@@ -240,15 +240,15 @@
             side=1
 #ifdef EASY
             #po: EASY difficulty:
-            {OBJECTIVE_NOTES (_"There is too little space to recall all 18 units at once. Move the units out of the castle to make room for others. The units will be able to move (in this scenario only!!) immediately after recalling, so do not push end turn button."+_" Important Note: do not UNDO the recall, units recalled are always counted even if you have undone the recall.")}
+            {OBJECTIVE_NOTES (_"There is too little space to recall all 18 units at once. Move the units out of the castle to make room for others. The units will be able to move (in this scenario only!!) immediately after recalling, so do not push end turn button.")}
 #endif
 #ifdef NORMAL
             #po: NORMAL difficulty; "this time" is supposed to be slightly more vague than "(in this scenario only!!)":
-            {OBJECTIVE_NOTES (_"There is too little space to recall all 15 units at once. Move the units out of the castle to make room for others. The units will be able to move this time immediately after recalling, so do not push end turn button."+_" Important Note: do not UNDO the recall, units recalled are always counted even if you have undone the recall.")}
+            {OBJECTIVE_NOTES (_"There is too little space to recall all 15 units at once. Move the units out of the castle to make room for others. The units will be able to move this time immediately after recalling, so do not push end turn button.")}
 #endif
 #ifdef HARD
             #po: HARD difficulty; supposed to be shorter and vaguer than on the two easier difficulties:
-            {OBJECTIVE_NOTES (_"There is too little space to recall all 12 units at once. Move the units away to make room. The units will have “haste” (to borrow a term from a famous trading card game), so avoid ending your turn prematurely."+_" Important Note: do not UNDO the recall, units recalled are always counted even if you have undone the recall.")}
+            {OBJECTIVE_NOTES (_"There is too little space to recall all 12 units at once. Move the units away to make room. The units will have “haste” (to borrow a term from a famous trading card game), so avoid ending your turn prematurely.")}
 #endif
             # (no note about recalling mechanics here on NIGHTMARE)
             [note]


### PR DESCRIPTION
It doesn't really matter, but you can't undo recall in this scenario because you have a recall event without [allow_undo], so it's redundant.