### PR TITLE
Fix a bug that prevents an event at the recruitment of Kyobaine.

### DIFF
--- a/macros/elvish_macros.cfg
+++ b/macros/elvish_macros.cfg
@@ -106,9 +106,9 @@
             id=Kyobaine
         [/filter]
         {VARIABLE_OP ano_kyobaine_recalled add 1}
-        {IF ano_loyal_elves equals true}
+        {IF ano_loyal_elves boolean_equals true}
         {IF ano_kyobaine_recalled greater_than 4}
-        {IF ano_loyal_kyobaine equals false}
+        {IF ano_loyal_kyobaine boolean_equals false}
         {VARIABLE ano_loyal_kyobaine true}
         # TODO: test this further:
         [if]


### PR DESCRIPTION
Strangely enough, WML seems to decide true is not equal to a variable set to true.