### PR TITLE
Fixes for issues targeted for Milestone 1.7.0

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,5 +1,5 @@
+---
 # These are supported funding model platforms
-
 github: cooljeanius
 patreon: EricGallager
 ko_fi: maraanelang

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,4 @@
+---
 # To get started with Dependabot version updates, you'll need to specify which
 # package ecosystems to update and where the package manifests are located.
 # Please see the documentation for all configuration options:
@@ -5,8 +6,8 @@
 
 version: 2
 updates:
-  - package-ecosystem: "gitsubmodule" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "gitsubmodule"  # See documentation for possible values
+    directory: "/"  # Location of package manifests
     schedule:
       interval: "weekly"
       day: "tuesday"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,3 +1,4 @@
+---
 name: lint
 
 on: [push, pull_request]
@@ -10,11 +11,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
-    - name: Verify images
-      uses: czyzby/wesnoth-png-optimizer@v1
-      if: always()
-      with:
-        wesnoth-version: ${{ env.WESNOTH_VERSION }}
-        threshold: 50
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Verify images
+        uses: czyzby/wesnoth-png-optimizer@v1
+        if: always()
+        with:
+          wesnoth-version: ${{ env.WESNOTH_VERSION }}
+          threshold: 50

--- a/.github/workflows/luacheck.yml
+++ b/.github/workflows/luacheck.yml
@@ -1,3 +1,4 @@
+---
 name: Luacheck
 on: [push, pull_request]
 jobs:

--- a/.github/workflows/luacheck.yml
+++ b/.github/workflows/luacheck.yml
@@ -1,0 +1,10 @@
+name: Luacheck
+on: [push, pull_request]
+jobs:
+  sile:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Luacheck linter
+        uses: nebularg/actions-luacheck@v1

--- a/CHANGELOG.cfg
+++ b/CHANGELOG.cfg
@@ -6,6 +6,9 @@ Changelog for 1.7.0 (WIP):
 * Validator fixes
 * Additional disclaimer about mature content added
 * New macros for wrapping dialogue messages
+* Gawen's allies remember that they're not supposed to call him "Gawen" more often
+* Raedwood East is now enabled for regular gameplay
+* Objectives should now do a better job of specifying carryover
 
 Changelog for 1.6.0:
 * New portraits, including new winter clothes for Kyobaine

--- a/_main.cfg
+++ b/_main.cfg
@@ -109,7 +109,9 @@ Version "+{~{LDR_PATH}/dist/VERSION}
 {./_editor.cfg}
 
 # wmllint: general spellings Wesnoth Wesnothian Wesnothians Elensefar lich Gweddry Mal-Ravanal Dacyn Weldyn orcish dwarvish exp
+# wmllint: general spellings unburied undead liches dwarves saurians Milord AMLA
 # wmllint: directory spellings Gawen Ruvio Vattin Yahyazad Akladian Akladians Darknite Darknites Grekulak Huon Ryedric Deorien Gallorae Hoyre
 # wmllint: directory spellings Raedwood Caerwyn Orannon Guilcorta Okladia Okladian Carrenemoe Carrenemoes Cryne Buffin mixling Gaeltin Hyer
 # wmllint: directory spellings Saoren Graeme Borraine Gwidle Easkladia Mithrandil Saorduc Oyre Mathauri Bontom Skagrrak Gauri Mavourneen
-# wmllint: directory spellings Lorin Vakladia
+# wmllint: directory spellings Lorin Vakladia readme.txt Reme Karen Majid Bor Freetown Barnon Raul Uri Ruen Turlin Luc Ostans
+# wmllint: directory spellings Holymen Wisemen Wondermen backroads

--- a/_main.cfg
+++ b/_main.cfg
@@ -20,6 +20,9 @@
 #
 # look also for LICENSE.important.txt for license details discussion
 #
+
+# wmlscope: export=no
+
 ### define the campaign itself
 # wmlindent: start ignoring
 #define LDR_PATH

--- a/_main.cfg
+++ b/_main.cfg
@@ -37,6 +37,9 @@ add-ons/A_New_Order#enddef
     id=A_New_Order
     name=_ "A New Order"
     abbrev=_ "ANO"
+#ifdef DEBUG_MODE
+    rank=0
+#endif
 #ifdef OLD_STYLE_VERSIONING
     version={~{LDR_PATH}/dist/VERSION}
 #else

--- a/lua/ano_wml_tags.lua
+++ b/lua/ano_wml_tags.lua
@@ -10,7 +10,8 @@ function wml_actions.get_support_between(cfg)
 end
 
 function check_srankability(cfg)
-	-- check for existing sranks
-	-- chech for compatibility
+	-- TODO:
+	-- - check for existing sranks
+	-- - check for compatibility
 end
 

--- a/macros/ano-01_06macros.cfg
+++ b/macros/ano-01_06macros.cfg
@@ -274,6 +274,7 @@
             description=_"Cowardly escape of Gawen Hagarthen"
             condition=lose
         [/objective]
+        {HAS_NO_TURN_LIMIT}
     [/objectives]
     {VARIABLE ano_barnon_tr yes}
 #enddef

--- a/macros/ano-01_06macros.cfg
+++ b/macros/ano-01_06macros.cfg
@@ -206,6 +206,19 @@
                 [/ai]
             [/modify_side]
             {VARIABLE ano_fpassrebel yes}
+            [event]
+                name=capture
+                [filter]
+                    id=Oeame
+                [/filter]
+                [filter_condition]
+                    [variable]
+                        name=ano_fpassrebel
+                        equals=yes
+                    [/variable]
+                [/filter_condition]
+                {MSG_Oeame _"Please, feel free to use any villages I capture, my king! I have no plans for them myself!"}
+            [/event]
         [/then]
     [/if]
 #enddef
@@ -336,6 +349,7 @@
                                 time=1
                             [/delay]
 #endif
+                            [redraw][/redraw]
                         [/then]
                     [/elseif]
                     [else]
@@ -348,6 +362,7 @@
                             time=1
                         [/delay]
 #endif
+                        [redraw][/redraw]
                     [/else]
                 [/if]
                 [store_unit]
@@ -365,12 +380,22 @@
 #ifdef DEBUG_MODE
                 {IF_DEBUG_MODE_IS_ACTUALLY_ON}
                 {DEBUGMSG1 "It's not time to evacuate yet!"}
-                {END_IF_WITHOUT_ELSE}
+                {ELSE}
+                [move_unit]
+                    x,y={X},{Y}
+#ifdef EASY
+                    dir=n # towards Hoyre
+#else
+                    dir=s # towards Uri and Bor
+#endif
+                [/move_unit]
+                {END_IF}
 #else
                 [delay]
                     time=1
                 [/delay]
 #endif
+                [redraw][/redraw]
             [/else]
         [/if]
     [/event]

--- a/macros/ano_macros.cfg
+++ b/macros/ano_macros.cfg
@@ -955,6 +955,8 @@
     _"This is a debug message. If you see it, then it means I forgot to delete it from the release scenario. "+"'{TEXT}'"}
 #enddef
 
+    # Use the {OBJECTIVES_GOLD_CARRYOVER_STANDARD} and {EARLY_FINISH_BONUS_FOOTNOTE} macros
+    # in the objectives when using this macro to end a scenario:
 #define NEXT_SCENARIO_VICTORY SCENARIO
     [endlevel]
         next_scenario={SCENARIO}
@@ -963,6 +965,8 @@
     [/endlevel]
 #enddef
 
+    # Use the {OBJECTIVES_GOLD_CARRYOVER_FULL} macro in the objectives
+    # when using this macro to end a scenario:
 #define NEXT_SCENARIO_CONTINUE SCENARIO
     [endlevel]
         next_scenario={SCENARIO}
@@ -1119,6 +1123,18 @@
 #define OBJECTIVE_NOTES _NOTES_TEXT
     note="*"+_"Scenario notes:"+"
 "+{_NOTES_TEXT}
+#enddef
+
+#define OBJECTIVES_GOLD_CARRYOVER_STANDARD
+    [gold_carryover]
+        carryover_percentage=80
+    [/gold_carryover]
+#enddef
+
+#define OBJECTIVES_GOLD_CARRYOVER_FULL
+    [gold_carryover]
+        carryover_percentage=100
+    [/gold_carryover]
 #enddef
 
 # wmlindent: start ignoring

--- a/macros/conversations.cfg
+++ b/macros/conversations.cfg
@@ -52,7 +52,6 @@
         variable=ano_lorin_stored
         kill=yes
     [/store_unit]
-    # TODO: maybe provide some other free recall to make up for Lorin being unavailable on this mission? Possibly Karl Regven?
     {MSG_Ruvio _"Gawen, I've never seen your step-mother like this before. I think she is sick. Very sick. I saw her vomiting yesterday."}
     #po: Gawen is reacting to Ruvio informing him that he saw Lorin vomiting yesterday; the way he intended
     #po: to complete the "Is she..." sentence at the end is left intentionally ambiguous so that Ruvio can complete
@@ -67,6 +66,14 @@
     {MSG_Ruvio _"My lord, our scouts also told us that we are being followed by a very large army of Akladians. Someone has noticed us. Maybe our successes have been too much. We have to win quickly, or we will be crushed by another foe."}
     {END_IF}
     {MSGm_Gawen _"It will be have to be a quick and decisive victory, then."}
+#ifdef EASY
+    {IF_HAVE_UNIT_ANY (Karl Regven)}
+    {RECALL (Karl Regven)}
+    {MSG_Regven _"I am ready to take Lorin's place in your battle formation, my lord."}
+    {ELSE}
+    {MSGm_Gawen _"If only we had someone to take Lorin's place..."}
+    {END_IF}
+#endif
 #enddef
 
 #define RUVIOORACLE

--- a/macros/deaths.cfg
+++ b/macros/deaths.cfg
@@ -6,6 +6,7 @@
 #define REME_DEATH_N
     [event]
         name=last breath
+        id=reme_last_breath_n
         [filter]
             id=Reme Carrenemoe
         [/filter]
@@ -16,6 +17,7 @@
 #define REUMARIO_DEATH
     [event]
         name=last breath
+        id=reumario_last_breath
         [filter]
             id=Reumario
         [/filter]
@@ -27,6 +29,7 @@
 #define REGVEN_DEATH
     [event]
         name=last breath
+        id=regven_last_breath
         [filter]
             id=Karl Regven
         [/filter]
@@ -38,6 +41,7 @@
 #define YAHYAZAD_DEATH
     [event]
         name=last breath
+        id=yahyazad_last_breath
         [filter]
             id=Majid Yahyazad
         [/filter]
@@ -47,6 +51,7 @@
     [/event]
     [event]
         name=die
+        id=yahyazad_death
         [filter]
             id=Majid Yahyazad
         [/filter]
@@ -59,6 +64,7 @@
 #define GAWEN_DEATH
     [event]
         name=last breath
+        id=gawen_last_breath
         [filter]
             id=Gawen Hagarthen
         [/filter]
@@ -67,6 +73,7 @@
     [/event]
     [event]
         name=die
+        id=gawen_death
         [filter]
             id=Gawen Hagarthen
         [/filter]
@@ -79,6 +86,7 @@
 #define LORIN_DEATH
     [event]
         name=last breath
+        id=lorin_last_breath
         [filter]
             id=Lady Lorin
         [/filter]
@@ -87,6 +95,7 @@
     [/event]
     [event]
         name=die
+        id=lorin_death
         [filter]
             id=Lady Lorin
         [/filter]
@@ -99,6 +108,7 @@
 #define REME_DEATH
     [event]
         name=last breath
+        id=reme_last_breath
         [filter]
             id=Reme Carrenemoe
         [/filter]
@@ -107,6 +117,7 @@
     [/event]
     [event]
         name=die
+        id=reme_death
         [filter]
             id=Reme Carrenemoe
         [/filter]
@@ -119,6 +130,7 @@
 #define KAREN_DEATH
     [event]
         name=last breath
+        id=karen_last_breath
         [filter]
             id=Karen
         [/filter]
@@ -128,6 +140,7 @@
     [/event]
     [event]
         name=die
+        id=karen_death
         [filter]
             id=Karen
         [/filter]
@@ -140,6 +153,7 @@
 #define RUVIO_DEATH
     [event]
         name=last breath
+        id=ruvio_last_breath
         [filter]
             id=Ruvio
         [/filter]
@@ -148,12 +162,26 @@
     [/event]
     [event]
         name=die
+        id=ruvio_death
         [filter]
             id=Ruvio
         [/filter]
         [endlevel]
             result=defeat
         [/endlevel]
+    [/event]
+#enddef
+
+#define ROB_ROE_DEATH
+    [event]
+        name=last breath
+        id=rob_roe_last_breath
+        [filter]
+            id=Rob Roe
+        [/filter]
+        {MESSAGE (Rob Roe) (portraits/humans/thug.png) (_"Rob Roe")
+        #po: Rob Roe's "last breath" message:
+        _"You'd think I'd have learned not to underestimate my enemies by now, but... argh..."}
     [/event]
 #enddef
 
@@ -165,8 +193,10 @@
     {KAREN_DEATH}
     {RUVIO_DEATH}
     {REGVEN_DEATH}
+    {ROB_ROE_DEATH}
     [event]
         name=die
+        id=all_ano_deaths_gawen_death
         [filter]
             id=Gawen Hagarthen
         [/filter]

--- a/macros/elvish_macros.cfg
+++ b/macros/elvish_macros.cfg
@@ -5,12 +5,33 @@
         [filter]
             id=Kyobaine
         [/filter]
-        [message]
-            speaker=unit
-            #po: Kyobaine, female Elf
-            message=_"I will never again see our beautiful forests..."
-            image=portraits/kyobaine.png
-        [/message]
+        [if]
+            [found_item]
+                id=Kyobaine_winter_cloak
+            [/found_item]
+            [or]
+                [variable]
+                    name=ano_kyobaine_has_cloak
+                    equals=yes
+                [/variable]
+            [/or]
+            [then]
+                [message]
+                    speaker=unit
+                    #po: Kyobaine, female Elf
+                    message=_"I will never again see our beautiful forests..."
+                    image=portraits/kyobaine_winter.png
+                [/message]
+            [/then]
+            [else]
+                [message]
+                    speaker=unit
+                    # (same as before)
+                    message=_"I will never again see our beautiful forests..."
+                    image=portraits/kyobaine.png
+                [/message]
+            [/else]
+        [/if]
     [/event]
     [event]
         name=last breath

--- a/macros/elvish_macros.cfg
+++ b/macros/elvish_macros.cfg
@@ -154,6 +154,7 @@
 #define KYOBAINE_DRUID
     [event]
         name="post advance"
+        id=Kyobaine_post_advance_clothing_banter
         [filter]
             id=Kyobaine
             type="Elvish Druid"
@@ -182,6 +183,7 @@
 
     [event]
         name=recall
+        id=Kyobaine_recall_clothing_banter
         [filter]
             id=Kyobaine
             type="Elvish Druid"
@@ -242,10 +244,17 @@
         {MSG_Kyobaine _"How horrible! You really must try hugging a tree some day, for your own well-being. But, to return to the previous topic, the way we ensure our clothes fit is to wander the woods hugging trees until one lets the vines growing around it return our embrace in a way that feels just right, and then the vines will form new clothes for us based on this experience."}
         {MSGW_Gawen _"OK, well, it's winter, so I don't think any of the trees around here have vines that would really feel up to that... Could you please try the human measurement system instead just this one time?"}
         {MSG_Kyobaine _"All right, what measurements do you require? The length of my ears?"}
+        # Karen is always present in the scenarios where this conversation can take place, as she always gets auto-recalled,
+        # and her death will cause defeat. Lorin, on the other hand, might not have been found yet, so check for her existence first:
+        {IF_HAVE_UNIT (Lady Lorin)}
         {MSGW_Gawen _"No, it's, ah, er... (*<i>blushes</i>*) ...you know what, maybe it would be better to have one of your fellow females explain this to you... look, there are Lorin and Karen over there; let's go ask one of them."}
         {MSGOPTI2 (Gawen Hagarthen) (portraits/gawen_winter.png) (_"Let's ask...")
         (_"person_to_ask^Lorin.") (lorin)
         (_"person_to_ask^Karen.") (karen)}
+        {ELSE}
+        {MSGW_Gawen _"No, it's, ah, er... (*<i>blushes</i>*) ...you know what, maybe it would be better to have someone female explain this to you... look, there's Karen over there; let's go ask her."}
+        {VARIABLE ano_opt karen}
+        {END_IF}
         {IF ano_opt equals lorin}
         {MSGW_Gawen _"Hi, mother, I was just wondering if you could help explain human measurements to Kyobaine here?"}
         {MSGW_Lorin _"Measurements? You mean like how far I can drive my knife into someone's back?"}

--- a/scenarios/01_Breaking_the_Circle.cfg
+++ b/scenarios/01_Breaking_the_Circle.cfg
@@ -545,6 +545,7 @@
                 condition=lose
             [/objective]
             {TURNS_RUN_OUT}
+            {OBJECTIVES_GOLD_CARRYOVER_FULL}
 #ifndef NIGHTMARE
             #po: this description of mechanics is only present on EASY, NORMAL, and HARD, but not NIGHTMARE, though:
             {OBJECTIVE_NOTES _"You cannot recruit new units in this scenario."}

--- a/scenarios/01_Breaking_the_Circle.cfg
+++ b/scenarios/01_Breaking_the_Circle.cfg
@@ -30,6 +30,7 @@
             story = _ "Content Note: This campaign contains mature themes, some of which may be unsuitable for children. Player discretion advised."
         [/part]
         [part]
+            #po: Now into the actual story part, starting with Lorin speaking to Gawen:
             story = _ "Moments slowly lengthen into hours. Hope is slipping through my fingers..."
             show_title=yes
             # The story image that was being tested here, 'story_images/freetown.png', does not exist, so I have removed it.
@@ -852,6 +853,7 @@
 
     [event]
         name=attack
+        # TODO: vary this event depending on whether second_unit is Gawen or not?
         [filter]
             side=2
         [/filter]

--- a/scenarios/02_Fighting_for_Passage.cfg
+++ b/scenarios/02_Fighting_for_Passage.cfg
@@ -689,7 +689,9 @@
                 [inspect][/inspect]
                 {ELSE}
 #ifdef DEBUGMSG1
+#ifdef __DEBUG__
                 {DEBUGMSG1 "ano_assa_killed value: $ano_assa_killed|."}
+#endif
 #endif
                 {END_IF}
             [/else]

--- a/scenarios/02_Fighting_for_Passage.cfg
+++ b/scenarios/02_Fighting_for_Passage.cfg
@@ -1118,6 +1118,7 @@
             id="Raul O Gaeltin"
             highlight=yes
         [/scroll_to_unit]
+        [redraw][/redraw]
         [delay]
             time=123
         [/delay]
@@ -1133,6 +1134,11 @@
                 factor=0.5
                 relative=yes
             [/zoom]
+            # Just in case the de-zoom decentered him:
+            [scroll_to_unit]
+                id="Raul O Gaeltin"
+            [/scroll_to_unit]
+            [redraw][/redraw]
         [/event]
     [/event]
 [/scenario]

--- a/scenarios/02_Fighting_for_Passage.cfg
+++ b/scenarios/02_Fighting_for_Passage.cfg
@@ -681,6 +681,17 @@
                 [/micro_ai]
                 {MSG_Assassin _"Where is he? He is starting to get on my nerves..."}
             [/then]
+#ifdef DEBUG_MODE
+            [else]
+                {IF_DEBUG_MODE_IS_ACTUALLY_ON}
+                [inspect][/inspect]
+                {ELSE}
+#ifdef DEBUGMSG1
+                {DEBUGMSG1 "ano_assa_killed value: $ano_assa_killed|."}
+#endif
+                {END_IF}
+            [/else]
+#endif
         [/if]
     [/event]
     {ANO_ASSASSIN} # defined in macros/ano-01_06macros.cfg
@@ -858,6 +869,7 @@
         [scroll_to_unit]
             id=Lady Lorin
         [/scroll_to_unit]
+        #po: the "traitors" to which she refers are Akladian Warriors on side 2:
         {MSG_Lorin _"No! More traitors are coming from every side! We cannot hope to deal with all them!"}
         # "From every side":
         [for]
@@ -973,11 +985,28 @@
 #endif
         # Getting this loyalty check to work was a pain; see issue 23: https://github.com/nemaara/A_New_Order/issues/23
         [if]
-            # FIXME: this condition might still be wrong; I had it fire for me with a non-loyal Clansman...
+            # FIXME: this condition might still be wrong; some of the stuff that Toranks and Knyghtmare suggested
+            # from the UnitMarker addon might not be applicable here:
             [have_unit]
                 id=$unit.id
-                # FIXME: validator complaint: "error validation: Invalid key 'upkeep=' in tag [have_unit]":
-                upkeep="loyal"
+                x,y=$x1,$y1
+                side=1
+                [filter_wml]
+                    upkeep="loyal"
+                    [or]
+                        [modifications]
+                            [trait]
+                                id=loyal
+                                [or]
+                                    [effect]
+                                        apply_to=overlay
+                                        add="misc/loyal-icon.png"
+                                    [/effect]
+                                [/or]
+                            [/trait]
+                        [/modifications]
+                    [/or]
+                [/filter_wml]
             [/have_unit]
             [then]
                 {MSG_Gawen _"But he was loyal to our cause though!"}

--- a/scenarios/02_Fighting_for_Passage.cfg
+++ b/scenarios/02_Fighting_for_Passage.cfg
@@ -336,7 +336,8 @@
         [objectives]
             side=1
             [objective]
-                description=_"Reach the northern signpost with Gawen Hagarthen OR"
+                #po: trailing space is intentional, to pad the footnote a bit:
+                description=_"Reach the northern signpost with Gawen Hagarthen " + {EARLY_FINISH_BONUS_FOOTNOTE} + _" OR"
                 condition=win
             [/objective]
             [objective]
@@ -356,6 +357,7 @@
                 condition=lose
             [/objective]
             {TURNS_RUN_OUT}
+            {OBJECTIVES_GOLD_CARRYOVER_STANDARD}
 #ifdef EASY
             #po: EASY difficulty, so this is more of a hint:
             {OBJECTIVE_NOTES _"This scenario is designed for grinding gold and EXP. Your income will increase if you use Gawen for fighting instead of recruiting, so be sure to move him off your keep and into the action!"}

--- a/scenarios/04_Battle_of_Barnon.cfg
+++ b/scenarios/04_Battle_of_Barnon.cfg
@@ -531,6 +531,12 @@
                 # po: this should only show in debug mode, so we can break the fourth wall there:
                 {ANO4_TRAITORS _"Blah blah blah; if you are seeing this, you should already know what the deal is."}
             [/command]
+            [show_if]
+                [variable]
+                    name=ano_barnon_tr
+                    equals=no
+                [/variable]
+            [/show_if]
         [/option]
         [option]
             # po: debug option; completes sentence starting with "Set scenario status to...":
@@ -541,6 +547,12 @@
                     id=Uri_gets_impatient
                 [/fire_event]
             [/command]
+            [show_if]
+                [variable]
+                    name=ano_barnon_tr
+                    equals=yes
+                [/variable]
+            [/show_if]
         [/option]
         [option]
             # po: debug option; completes sentence starting with "Set scenario status to...":
@@ -551,6 +563,7 @@
                     to_x,to_y=1,4
                     fire_event=yes
                 [/move_unit]
+                [redraw][/redraw]
                 [move_unit]
                     id=Reme Carrenemoe
                     to_x,to_y=1,4
@@ -565,6 +578,12 @@
                     linger_mode=no
                 [/endlevel]
             [/command]
+            [show_if]
+                [variable]
+                    name=ano_barnon_tr
+                    equals=yes
+                [/variable]
+            [/show_if]
         [/option]
         [option]
             # po: debug option; completes sentence starting with "Set scenario status to...":
@@ -575,6 +594,7 @@
                     to_x,to_y=40,21
                     fire_event=yes
                 [/move_unit]
+                [redraw][/redraw]
                 [move_unit]
                     id=Reme Carrenemoe
                     to_x,to_y=40,21
@@ -589,6 +609,12 @@
                     linger_mode=no
                 [/endlevel]
             [/command]
+            [show_if]
+                [variable]
+                    name=ano_barnon_tr
+                    equals=yes
+                [/variable]
+            [/show_if]
         [/option]
     )}
 

--- a/scenarios/05_The_Swamp_Things.cfg
+++ b/scenarios/05_The_Swamp_Things.cfg
@@ -14,6 +14,7 @@
     [story]
         {AFTERBARNONSTORY} # from macros/conversations.cfg
         [part]
+            #wmllint: local spelling Duc
             story=_"The party entered the swamps and woods of Saoren Duc with heavy hearts."
             background=story_images/swamp_scena.png
         [/part]

--- a/scenarios/05_The_Swamp_Things.cfg
+++ b/scenarios/05_The_Swamp_Things.cfg
@@ -104,7 +104,6 @@
     {LIMIT_CONTEMPORANEOUS_RECRUITS 3 "Saurian Soothsayer" {ON_DIFFICULTY4 1 2 3 4}}
     [event]
         name=prestart
-        # no need to RECALL Reme Carrenemoe here because we use unstore_unit to get him later
         [set_variable]
             name="ano_reme_stored.x"
             value="22"
@@ -125,11 +124,48 @@
             name="ano_reme_stored.moves"
             value=$ano_reme_stored.max_moves
         [/set_variable]
+        {IF ano_reme_stored.length less_than 1}
+        [if]
+            [have_unit]
+                # wmllint: recognize Reme Carrenemoe
+                id=Reme Carrenemoe
+                x,y=recall,recall
+                search_recall_list=yes
+            [/have_unit]
+            [then]
+                {RECALL ("Reme Carrenemoe")}
+            [/then]
+            [else]
+                # Re-create from scratch:
+                [unit]
+                    id=Reme Carrenemoe
+                    name=_"Reme Carrenemoe"
+                    type=Akladian Chieftain
+                    side=$ano_reme_stored.side
+                    profile=portraits/reme.png
+                    alignment=lawful
+                    x,y=3,9
+                    unrenamable=yes
+                    [modifications]
+                        {TRAIT_LOYAL}
+#ifdef EASY
+                        {TRAIT_STRONG}
+#endif
+                    [/modifications]
+                    {IS_HERO}
+                [/unit]
+            [/else]
+        [/if]
+        {ELSE}
+        # FIXME: even with the new conditional, ano_reme_stored STILL might not have unit data in it
+        # if we are using the :cl debug command to change levels; see:
+        # https://github.com/nemaara/A_New_Order/issues/165
         [unstore_unit]
             variable=ano_reme_stored
             find_vacant=yes
             x,y=3,9
         [/unstore_unit]
+        {END_IF}
         {VARIABLE ano_orcs no}
         [set_variable]
             name=ano_arl_interrogated
@@ -266,6 +302,7 @@
                 description=_"Death of Reme Carrenemoe"
                 condition=lose
             [/objective]
+            {OBJECTIVES_GOLD_CARRYOVER_STANDARD} # ...I guess?
         [/objectives]
     [/event]
     [event]

--- a/scenarios/05_Unexpected_Guests.cfg
+++ b/scenarios/05_Unexpected_Guests.cfg
@@ -12,7 +12,7 @@
     # Once he had to kill orc on the very last turn.
     {INTRO_AND_SCENARIO_MUSIC suspense.ogg into_the_shadows.ogg}
     {EXTRA_SCENARIO_MUSIC wanderer.ogg}
-    {EXTRA_SCENARIO_MUSIC dark_passage.ogg}
+    {EXTRA_SCENARIO_MUSIC suspense/dark_passage.ogg}
     # Battle music now plays after the player has discovered the orcs.
 
     {PLACE_IMAGE (terrain/ruiny.png) 13 13}
@@ -21,7 +21,6 @@
     {PLACE_IMAGE (terrain/akl-ruin.png) 14 15}
     [event]
         name=prestart
-        # no need to RECALL Reme Carrenemoe here because we use unstore_unit to get him later
         {VARIABLE ano_orcs yes}
         [set_variable]
             name=ano_arl_interrogated
@@ -84,10 +83,48 @@
             name="ano_reme_stored.moves"
             value=$ano_reme_stored.max_moves
         [/set_variable]
+        {IF ano_reme_stored.length less_than 1}
+        [if]
+            [have_unit]
+                # wmllint: recognize Reme Carrenemoe
+                id=Reme Carrenemoe
+                x,y=recall,recall
+                search_recall_list=yes
+            [/have_unit]
+            [then]
+                {RECALL ("Reme Carrenemoe")}
+            [/then]
+            [else]
+                # Re-create from scratch:
+                [unit]
+                    id=Reme Carrenemoe
+                    name=_"Reme Carrenemoe"
+                    type=Akladian Chieftain
+                    side=$ano_reme_stored.side
+                    profile=portraits/reme.png
+                    alignment=lawful
+                    placement=leader
+                    passable=yes
+                    unrenamable=yes
+                    [modifications]
+                        {TRAIT_LOYAL}
+#ifdef EASY
+                        {TRAIT_STRONG}
+#endif
+                    [/modifications]
+                    {IS_HERO}
+                [/unit]
+            [/else]
+        [/if]
+        {ELSE}
+        # FIXME: even with the new conditional, ano_reme_stored STILL might not have unit data in it
+        # if we are using the :cl debug command to change levels; see:
+        # https://github.com/nemaara/A_New_Order/issues/165
         [unstore_unit]
             variable=ano_reme_stored
             find_vacant=yes
         [/unstore_unit]
+        {END_IF}
 
         # ensuring player has at least minimal amount of gold
         [store_gold]
@@ -250,6 +287,7 @@
                 description=_"Death of Reme Carrenemoe"
                 condition=lose
             [/objective]
+            {OBJECTIVES_GOLD_CARRYOVER_STANDARD} # ...I guess?
         [/objectives]
     [/event]
 
@@ -353,6 +391,7 @@
                 description=_"Death of Reme Carrenemoe"
                 condition=lose
             [/objective]
+            {OBJECTIVES_GOLD_CARRYOVER_STANDARD} # ...I guess?
         [/objectives]
     [/event]
     [event]

--- a/scenarios/06_Separation.cfg
+++ b/scenarios/06_Separation.cfg
@@ -150,6 +150,7 @@
                 condition=win
             [/objective]
             # (no need for TURNS_RUN_OUT here, because you still win in that case)
+            {OBJECTIVES_GOLD_CARRYOVER_FULL}
         [/objectives]
         [if]
             {CONDITION ano_lorin_gold less_than 200}

--- a/scenarios/07_Ally_From_the_Past.cfg
+++ b/scenarios/07_Ally_From_the_Past.cfg
@@ -349,7 +349,8 @@
         [objectives]
             side=1
             [objective]
-                description=_"Kill the enemy leader and all enemy units. Don't allow any enemy unit to reach the north-western signpost, or the village nearby."
+                #po: trailing space is due to the appended footnote:
+                description=_"Kill the enemy leader and all enemy units. Don't allow any enemy unit to reach the north-western signpost, or the village nearby. " + {EARLY_FINISH_BONUS_FOOTNOTE}
                 condition=win
             [/objective]
             [objective]
@@ -369,6 +370,7 @@
                 condition=lose
             [/objective]
             {TURNS_RUN_OUT}
+            {OBJECTIVES_GOLD_CARRYOVER_STANDARD}
         [/objectives]
     [/event]
     [event]

--- a/scenarios/08_Outlaw_Base.cfg
+++ b/scenarios/08_Outlaw_Base.cfg
@@ -224,6 +224,7 @@
                 condition=lose
             [/objective]
             {TURNS_RUN_OUT}
+            {OBJECTIVES_GOLD_CARRYOVER_STANDARD} # ...I guess?
         [/objectives]
     [/event]
 

--- a/scenarios/08_Outlaw_Base.cfg
+++ b/scenarios/08_Outlaw_Base.cfg
@@ -12,7 +12,7 @@
     {EXTRA_SCENARIO_MUSIC breaking_the_chains.ogg}
     [story]
         [part]
-            story=_"Gawen, Ruvio and Karen didn't celebrate their victory. The bodies of the last Akladians were still warm as they hurried from the battlefield. They entered the forest of Raedwood, hoping that no one would follow them."
+            story=_"Gawen, Ruvio, and Karen didn't celebrate their victory. The bodies of the last Akladians were still warm as they hurried from the battlefield. They entered the forest of Raedwood, hoping that no one would follow them."
         [/part]
     [/story]
     {DAWN}
@@ -181,7 +181,9 @@
         [/modify_unit]
         {MSG_Gawen _"What kind of place is this?"}
         {MSG_Karen _"It's a bad place. Not the worst place imaginable, but it's still bad enough."}
-        {MSG_Ruvio _"You see, Gawen, when the royal family of Wesnoth started a war over succession, a golden era for bandits and thieves began. The succession wars were devastating and divided Wesnoth into many small kingdoms."}
+        {MSG_Ruvio _"You see, Haldric... uh, Haldric? HALDRIC!"}
+        {MSG_Gawen _"...oh right, you mean me. Sorry, I just haven't gotten used to that name yet..."}
+        {MSG_Ruvio _"Right, well, as I was saying, about this place, when the royal family of Wesnoth started a war over succession, a golden era for bandits and thieves began. The succession wars were devastating and divided Wesnoth into many small kingdoms."}
         {MSG_Ruvio _"During the wars, kings became weaker and lost much of their power, so when peace came they no longer had the forces needed to drive bandits out of their hideouts. The bandits continued to flourish even in periods of peace. When the Akladians came, they didn't care about rooting the bandits out either."}
         {MSG_Ruvio _"Fortunately, the place seems to be abandoned now."}
         [modify_unit]

--- a/scenarios/08_Outlaw_Base.cfg
+++ b/scenarios/08_Outlaw_Base.cfg
@@ -465,7 +465,7 @@
                     unrenamable=yes
                     # Man, Rob Roe *sucks* ;-) - Malin
                     random_traits=no
-                    # I'm in doubt here:
+                    # I am in doubt here:
                     # is Rob Roe ever supposed
                     # to be a loyal unit??? - Malin
                     # good question. - A.D.D.

--- a/scenarios/09_Hired_Swords.cfg
+++ b/scenarios/09_Hired_Swords.cfg
@@ -243,9 +243,11 @@
         [objectives]
             side=1
             [objective]
-                description=_"Kill all enemy leaders."
+                description=_"Kill all enemy leaders..."
                 condition=win
             [/objective]
+            #po: continues sentence started by previous objective:
+            {ALTERNATIVE_OBJECTIVE_BONUS _"...except for maybe Reumario?"}
             [objective]
                 description=_"Death of Majid Yahyazad"
                 condition=lose
@@ -254,6 +256,7 @@
                 description=_"Death of Lady Lorin"
                 condition=lose
             [/objective]
+            {OBJECTIVES_GOLD_CARRYOVER_STANDARD}
         [/objectives]
     [/event]
     [event]

--- a/scenarios/10_Siege_of_Haeltin.cfg
+++ b/scenarios/10_Siege_of_Haeltin.cfg
@@ -727,13 +727,77 @@
         # so that it's not firing on the exact same thing:
         name={ON_DIFFICULTY4 (side 1 turn 14) (side 1 turn 15) (side 1 turn 16) (side 1 turn 17)}
         # old relationship: (turn_limit - 1); new relationship: same
+        id=penultimate_turn
+        [role]
+            role=scaredycat
+            side=1 # only your own Akladians should speak
+            type=Akladian Clansman,Akladian Wiseman,Akladian Holyman,Akladian Warrior,Akladian Raider,Akladian Leader,Akladian Homeguard,Akladian Light Infantry,Akladian Fastfoot,Akladian Pikeneer,Akladian Shieldguard,Akladian Protector,Akladian Sturmknight,Akladian Darknite
+            [autorecall][/autorecall]
+            [else]
+                [unit]
+                    side=1
+                    type=Akladian Clansman
+                    id=scaredycat
+                    role=scaredycat
+                    placement=leader
+                [/unit]
+            [/else]
+        [/role]
+        # Just in case the "else" or the "autorecall" failed:
+        [if]
+            [not]
+                [have_unit]
+                    role=scaredycat
+                [/have_unit]
+            [/not]
+            [then]
+                [unit]
+                    side=1
+                    type=Akladian Clansman
+                    id=scaredycat
+                    role=scaredycat
+                    placement=leader
+                [/unit]
+            [/then]
+            [elseif]
+                [have_unit]
+                    role=scaredycat
+                    x,y=recall,recall
+                    search_recall_list=yes
+                [/have_unit]
+                [then]
+                    [recall]
+                        role=scaredycat
+                    [/recall]
+                [/then]
+            [/elseif]
+        [/if]
+        [store_unit]
+            [filter]
+                side=1
+            [/filter]
+            variable=soh_s1units
+        [/store_unit]
+        [store_unit]
+            [filter]
+                side=2,3,4,5
+            [/filter]
+            variable=soh_enemyunits
+        [/store_unit]
+        {IF soh_enemyunits.length greater_than soh_s1units.length}
         [message]
-            side=1
-            type=Akladian Clansman,Akladian Wiseman,Akladian Holyman,Akladian Warrior,Akladian Raider,Akladian Homeguard,Akladian Light Infantry,Akladian Fastfoot,Akladian Pikeneer,Akladian Shieldguard,Akladian Protector,Akladian Sturmknight,Akladian Darknite
-            # TODO: maybe only display this if the enemies actually outnumber you, otherwise display a different message:
-            message=_"Run for your life! They are too many of them!!"
+            role=scaredycat
+            message=_"Run for your life! There are too many of them!!"
         [/message]
+        {ELSE}
+        [message]
+            role=scaredycat
+            message=_"Sheesh, no matter how many of them we kill, they just keep coming!"
+        [/message] #
+        {END_IF}
         {MSGW_Lorin _"Keep fighting! Don't give up! At least kill as many of them as you can! They will surely have to withdraw soon!"}
+        {CLEAR_VARIABLE soh_s1units}
+        {CLEAR_VARIABLE soh_enemyunits}
     [/event]
     [event]
         name=time over

--- a/scenarios/12_Leaving_Raedwood.cfg
+++ b/scenarios/12_Leaving_Raedwood.cfg
@@ -367,6 +367,7 @@ Move Ruvio to signpost to ask him for advice."}
     {RUVIO_DEATH}
     {GAWEN_DEATH}
     {REGVEN_DEATH}
+    {ROB_ROE_DEATH}
     {ELVISH_DEATHS}
     {ELVISH_KILLING}
     {KYOBAINE_DRUID}

--- a/scenarios/12_Leaving_Raedwood.cfg
+++ b/scenarios/12_Leaving_Raedwood.cfg
@@ -205,7 +205,8 @@
 
 Move Ruvio to signpost to ask him for advice."}
             [objective]
-                description=_"Move Gawen to southern edge of the map OR"
+                #po: trailing space is intentional, to pad the footnote a bit:
+                description=_"Move Gawen to southern edge of the map " + {EARLY_FINISH_BONUS_FOOTNOTE} + _" OR"
                 condition=win
             [/objective]
             [objective]
@@ -224,6 +225,7 @@ Move Ruvio to signpost to ask him for advice."}
                 description=_"Death of Ruvio"
                 condition=lose
             [/objective]
+            {OBJECTIVES_GOLD_CARRYOVER_STANDARD}
         [/objectives]
     [/event]
 

--- a/scenarios/13_Scouting.cfg
+++ b/scenarios/13_Scouting.cfg
@@ -473,6 +473,7 @@
             side=1
             # Warning: if these notes get much longer, they start to get cut off:
             {OBJECTIVE_NOTES _"This is a large-scale map, where you may choose a way to go. Move Gawen to a signpost or any other location to move to a new scenario. Move Gawen to the tent to talk with his friends."}
+            {HAS_NO_TURN_LIMIT}
         [/objectives]
     [/event]
 

--- a/scenarios/13_Scouting.cfg
+++ b/scenarios/13_Scouting.cfg
@@ -15,6 +15,21 @@
 
     victory_when_enemies_defeated=no
 
+    [event]
+        name=preload
+        id=scouting_reme_check
+        first_time_only=no
+        {IF ano_bontom_location equals yes}
+        {IF_HAVE_UNIT_ANY (Reme Carrenemoe)}
+        {IF ano_strateg_pos greater_than_equal_to 3}
+        {IF ano_reme_saved equals no}
+        {VARIABLE ano_reme_saved yes}
+        {END_IF_WITHOUT_ELSE}
+        {END_IF_WITHOUT_ELSE}
+        {END_IF_WITHOUT_ELSE}
+        {END_IF_WITHOUT_ELSE}
+    [/event]
+
     [story]
         {IF ano_strateg_pos equals 1}
         [part]

--- a/scenarios/14a_Scouting_Near_Barnon.cfg
+++ b/scenarios/14a_Scouting_Near_Barnon.cfg
@@ -3,7 +3,8 @@
 [scenario]
 #define WINCONDITION
     [objective]
-        description=_"HEROIC: Kill all enemy leaders OR"
+        #po: trailing space is intentional, to pad the footnote a bit:
+        description=_"HEROIC: Kill all enemy leaders " + {EARLY_FINISH_BONUS_FOOTNOTE} + _" OR"
         condition=win
     [/objective]
     [objective]

--- a/scenarios/14b_Bontom.cfg
+++ b/scenarios/14b_Bontom.cfg
@@ -475,8 +475,8 @@
         {MSGW_Gawen _"I'm sorry Reme, but we simply couldn't succeed."}
         {MSGW_Lorin _"Good. Reme left me, we left him, so balance in the universe is preserved."}
         {VARIABLE ano_reme_saved no}
-        # FIXME: this macro still fires the victory event, causing Reme to be freed anyways:
-        {NEXT_SCENARIO_CONTINUE 13_Scouting} # see: https://github.com/nemaara/A_New_Order/issues/79
+        # Danger: this macro still fires the victory event, which can cause Reme to be freed anyways:
+        {NEXT_SCENARIO_CONTINUE 13_Scouting} # see: https://github.com/nemaara/A_New_Order/issues/79 (which is closed now, but... is it really *solved*, though?)
         {ELSE}
         [allow_undo][/allow_undo]
         {END_IF}

--- a/scenarios/14b_Bontom.cfg
+++ b/scenarios/14b_Bontom.cfg
@@ -673,7 +673,7 @@
     [event]
         {KILLEDBY (Uruk Lug) (Lady Lorin)}
 
-        #po: this is a well-known quote from a well-known book -- translators, please find how this quote was translated into your language before trying translating it by yourself.
+        #po: this is the "Litany Against Fear" from the "Dune" franchise -- translators, please find how this quote was translated into your language before trying translating it by yourself.
         {MSG_Uruk_Lug _"I must not fear. Fear is the mind-killer. Fear is the little-death that brings total obliteration. I will face my fear. I will permit it to pass over me and through me. And when it has gone past I will turn the inner eye to see its path. Where the fear has gone there will be nothing. Only I will remain."}
         #po: this is a play on what the orc just said; try to use similar wording when translating:
         {MSGW_Lorin _"Oh that was cute. Now, if you are quite finished, I have here this little knife-thing. This knife is what brings total obliteration, not to mention suffering."}

--- a/scenarios/14b_Bontom.cfg
+++ b/scenarios/14b_Bontom.cfg
@@ -395,14 +395,15 @@
         [objectives]
             side=1
             [objective]
-                description=_"HEROIC: Kill all enemy leaders OR"
+                # (this string already gets a translation note from a previous scenario)
+                description=_"HEROIC: Kill all enemy leaders " + {EARLY_FINISH_BONUS_FOOTNOTE} + _" OR"
                 condition=win
             [/objective]
             [objective]
                 description=_"NORMAL: Rescue Reme Carrenemoe and move him to the north-eastern signpost"
                 condition=win
             [/objective]
-            {OBJECTIVE_NOTES _"You may interrogate the Orcish leader with either Gawen, Ruvio, or Lorin. Other leaders may be interrogated by Gawen only."}
+            {OBJECTIVE_NOTES _"You may interrogate the Orcish leader with either Gawen, Ruvio, or Lorin. Other leaders may be interrogated by Gawen only. The Outlaw leader interrogations are largely identical."}
             {OBJECTIVES14}
             {LORINOBJECTIVES}
             {TURNS_RUN_OUT}
@@ -411,7 +412,7 @@
         [objectives]
             side=1
             [objective]
-                description=_"HEROIC: Kill all enemy leaders OR"
+                description=_"HEROIC: Kill all enemy leaders " + {EARLY_FINISH_BONUS_FOOTNOTE} + _" OR"
                 condition=win
             [/objective]
             [objective]
@@ -419,7 +420,7 @@
                 condition=win
             [/objective]
             # No Lorin in this branch of the conditional, so leave her out of this:
-            {OBJECTIVE_NOTES _"You may interrogate the Orcish leader with either Gawen or Ruvio. Other leaders may be interrogated by Gawen only."}
+            {OBJECTIVE_NOTES _"You may interrogate the Orcish leader with either Gawen or Ruvio. Other leaders may be interrogated by Gawen only. The Outlaw leader interrogations are largely identical."}
             {OBJECTIVES14}
             {TURNS_RUN_OUT}
         [/objectives]
@@ -543,8 +544,8 @@
     #LEIF THRALL BY GAWEN
     [event]
         {KILLEDBY (Leif Thrall) (Gawen Hagarthen)}
-        {MSG_Leif_Thrall _"Such a young man... And yet, one darn good fighter.."}
-        {MSGW_Gawen _"You were worthy opponent too."}
+        {MSG_Leif_Thrall _"Such a young man... And yet, one darn good fighter..."}
+        {MSGW_Gawen _"You were a worthy opponent, too."}
         {MSG_Leif_Thrall _"Yes... it was a good fight, wasn't it?"}
         {MSGW_Gawen _"Yes... Before you pass on, please answer me few questions."}
         {VARIABLE ano_continue yes}
@@ -577,11 +578,13 @@
         {MSGW_Gawen _"Why are you allied with Akladians?"}
         {MSG_Leif_Thrall _"Allied? We are allied with none. They have simply paid for our services. That's all."}
         {ELSE_IF ano_opt equals mother}
+        #po: "whence" is a contraction for "from where"; it has nothing to do with the word "when":
         {MSGW_Gawen _"You are from the Outlaw Base, right? The place whence assassins come... maybe you know who poisoned the mother of Gawen Hagarthen?"}
         {MSG_Leif_Thrall _"I don't know that."}
         {ELSE_IF ano_opt equals assa}
         {MSGW_Gawen _"Someone hired an assassin to kill Gawen Hagarthen, immediately after his father's death. I know he came from the Outlaw Base. Who hired him?"}
-        {MSG_Leif_Thrall _"I think it was one of Akladian lords... yes... his name was Cryne, Bor Cryne..."}
+        #po: lowercase "l" in "lords" because we're talking about the rank generically, not the name of the unit type:
+        {MSG_Leif_Thrall _"I think it was one of the Akladian lords... yes... his name was Cryne, Bor Cryne..."}
         {VARIABLE ano_assa_cryne yes}
         {ELSE}
         {MSG_Leif_Thrall
@@ -593,8 +596,8 @@
     [/event]
     [event]
         {KILLEDBY (Hans the Ripper) (Gawen Hagarthen)}
-        {MESSAGE (Hans the Ripper) () (_"Hans the Ripper") _"Such a young man... And yet, one darn good fighter.."}
-        {MSGW_Gawen _"You were worthy opponent too."}
+        {MESSAGE (Hans the Ripper) () (_"Hans the Ripper") _"Such a young man... And yet, one darn good fighter..."}
+        {MSGW_Gawen _"You were a worthy opponent, too."}
         {MESSAGE (Hans the Ripper)  () (_"Hans the Ripper") _"Yes... it was a good fight, wasn't it?"}
         {MSGW_Gawen _"Yes... Before you pass on, please answer me few questions."}
         {VARIABLE ano_continue yes}
@@ -631,7 +634,7 @@
         {MESSAGE (Hans the Ripper) () (_"Hans the Ripper") _"I don't know that. A lot of Akladians buy poison from us."}
         {ELSE_IF ano_opt equals assa}
         {MSGW_Gawen _"Someone hired an assassin to kill Gawen Hagarthen, immediately after his father's death. I know he came from the Outlaw Base. Who hired him?"}
-        {MESSAGE (Hans the Ripper) () (_"Hans the Ripper") _"I think it was one of Akladian lords... yes... his name was Cryne, Bor Cryne..."}
+        {MESSAGE (Hans the Ripper) () (_"Hans the Ripper") _"I think it was one of the Akladian lords... yes... his name was Cryne, Bor Cryne..."}
         {VARIABLE ano_assa_cryne yes}
         {ELSE}
         {MESSAGE (Hans the Ripper) () (_"Hans the Ripper")
@@ -906,11 +909,40 @@
     [/event]
 
     [event]
+        name=enemies defeated
+        [filter]
+            side=1
+        [/filter]
+        [if]
+            [have_unit]
+                id=Reme Carrenemoe
+                side=1
+                [not]
+                    x,y=1,1
+                [/not]
+                [not]
+                    x,y=recall,recall
+                [/not]
+            [/have_unit]
+            [then]
+                {MSG_Reme _"I am saved!"}
+                {VARIABLE ano_reme_saved yes}
+            [/then]
+            [else]
+                {MSGW_Gawen _"It's a hollow victory, defeating Reme's captors without him among our ranks..."}
+            [/else]
+        [/if]
+    [/event]
+    [event]
         name=victory
         [filter_condition]
             {VARIABLE_CONDITIONAL ano_reme_saved equals yes}
         [/filter_condition]
+        {IF_HAVE_UNIT (Reme Carrenemoe)}
         {MSG_Reme _"The outlaws are defeated!"}
+        {ELSE}
+        {MSGW_Gawen _"We saved Reme, but do not have him here with us for our victory? What happened?"}
+        {END_IF}
     [/event]
     {ELVISH_DEATHS}
     {ALL_ANO_DEATHS}

--- a/scenarios/14e_Saorduc_Swamps.cfg
+++ b/scenarios/14e_Saorduc_Swamps.cfg
@@ -240,7 +240,8 @@
         [objectives]
             side=1
             [objective]
-                description=_"Kill all enemy leaders"
+                #po: trailing space is intentional, to pad the footnote a bit:
+                description=_"Kill all enemy leaders. " + {EARLY_FINISH_BONUS_FOOTNOTE}
                 condition=win
             [/objective]
             {OBJECTIVE_NOTES _"You may withdraw by moving Gawen to signpost."}
@@ -252,7 +253,7 @@
         [objectives]
             side=1
             [objective]
-                description=_"Kill all enemy leaders"
+                description=_"Kill all enemy leaders. " + {EARLY_FINISH_BONUS_FOOTNOTE}
                 condition=win
             [/objective]
             {OBJECTIVE_NOTES _"You may withdraw by moving Gawen to signpost."}

--- a/scenarios/15_Back_in_Freetown.cfg
+++ b/scenarios/15_Back_in_Freetown.cfg
@@ -16,6 +16,7 @@
             story=_"The winter was just ending when we returned to Freetown. Soldiers were singing mirthful songs, waiting impatiently for the chance to see the faces of their wives and children again. "
         [/part]
         [part]
+            #po: This is all just Gawen being clueless here; he's missing that they're actually still passive-aggressively exchanging stealth insults:
             story=_"Even Lorin and Karen seemed to finally be getting along. I thought they might have started to like each other. Karen had even promised to show Lorin a few easy exercises to help her to regain the slenderness of her youth."
             # TODO: come up with a better version of this to use as a background: https://github.com/cooljeanius/ANO_art/blob/main/stare/story_images/story/story_lorin_karen.png
         [/part]

--- a/scenarios/15a_The_Preparations.cfg
+++ b/scenarios/15a_The_Preparations.cfg
@@ -260,16 +260,28 @@
         {END_IF_WITHOUT_ELSE}
         {END_WHILE}
 
-        # TODO: give option to go to Raedwood East:
-        {MSGOPTI2 (Ruvio) (portraits/ruvio.png)
-        (_"My lord, we know an orcish group attacked a few villages north of here. Huon Ryedric was going to go there to defend the villages, but I thought you might want to use the occasion, you know, to check out our troops before you make any final decisions on which soldiers to choose for our quest.")
-        (_"Yes, definitely.") (yes)
-        (_"Well, maybe not.") (no)
+        {MSG_Ruvio _"My lord, we know an orcish group attacked a few villages north of here. Huon Ryedric was going to go there to defend the villages, but I thought you might want to use the occasion, you know, to check out our troops before you make any final decisions on which soldiers to choose for our quest."}
+        {MSG_Mithrandil _"Alternatively, we also know of an Elvish settlement to the east of here that has sent us a distress signal. It said something about the nearby forest being in danger of burning down. I don't know quite what the story is there, but it should also provide for an opportunity to get in some training as well."}
+        #po: a bit of dramatic irony here, for those who know what's to come:
+        {MSG_Ruvio _"Don't worry too much about which one you choose, as I'm sure we'll be able to get someone else to handle these minor problems, if you can't do so yourself. The forces of Freetown are highly independent, and plenty capable of handling any situations in your absence."}
+        {MSGm_Gawen _"Got it."}
+        {MSGOPTI3 (Ruvio) (portraits/ruvio.png)
+        (_"So, which way should we go?")
+        (_"Let's go north, to fight the orcs.") (north)
+        (_"Let's go east, to help the elves.") (east)
+        (_"Let's just stay here and pick our troops.") (stay)
         }
         {CLEAR_VARIABLE ano_lorin_stored}
         {CLEAR_VARIABLE ano_yahyazad_stored}
 
-        {IF ano_opt equals yes}
+        {IF ano_opt not_equals stay}
+        {IF ano_opt equals north}
+        {MSG_Ruvio _"So, north to fight the orcs, then?"}
+        {ELSE_IF ano_opt equals east}
+        {MSG_Ruvio _"So, east to help the elves, then?"}
+        {ELSE}
+        {DEBUGMSG1 "Unhandled option: $ano_opt|."}
+        {TWO_END_IFs}
         {MSGm_Gawen _"Yes, I think that's a great idea."}
         {MSGW_Lorin _"I have to stay here."}
         {MSGm_Gawen _"Why?"}
@@ -291,10 +303,14 @@
         [/store_unit]
         {MSG_Ruvio _"Karen, you will stay here, with your mother and sisters. It's too dangerous for you."}
         {MSG_Karen _"Of courrrrrse."}
+        {IF ano_opt equals north}
         {NEXT_SCENARIO_CONTINUE (15b_Repelling_the_Orcs)}
-        {ELSE_IF ano_opt equals do_secret_scenario}
+        {ELSE_IF ano_opt equals east}
         {NEXT_SCENARIO_CONTINUE (15c_Raedwood_East)}
-        {ELSE}
+        {ELSE} # ???:
+        {DEBUGMSG1 "Unhandled option: $ano_opt|."}
+        {TWO_END_IFs}
+        {ELSE} # stay:
         {CLEAR_VARIABLE ano_reme_prisoned}
         {CLEAR_VARIABLE ano_lorin_joined}
 #ifdef EASY
@@ -328,7 +344,7 @@
             variable=ano_yahyazad_stored
         [/store_unit]
         {NEXT_SCENARIO_CONTINUE (16_Choosing_the_Best)}
-        {TWO_END_IFs}
+        {END_IF}
 
         #should NEVER happen
         [endlevel]

--- a/scenarios/15c_Raedwood_East.cfg
+++ b/scenarios/15c_Raedwood_East.cfg
@@ -18,7 +18,7 @@
 #endif
     [story]
         [part]
-            # TODO: rewrite (will need to form a smooth transition from whatever I decide to do for a menu option in S15a):
+            #po: TODO: rewrite (will need to form a smooth transition from the updated dialogue I added in S15a):
             story=_"And so Gawen and his party went to the eastern part of Raedwood."
         [/part]
     [/story]
@@ -242,7 +242,11 @@
                 condition=lose
             [/objective]
             {OBJECTIVE_NOTES _"Woses standing on campfires will take damage every turn."}
+#ifdef DEBUG_MODE
+            {HAS_NO_TURN_LIMIT}
+#else
             {TURNS_RUN_OUT}
+#endif
         [/objectives]
         {VARIABLE ano_wose_burn_counter 0}
     [/event]

--- a/scenarios/16_Choosing_the_Best.cfg
+++ b/scenarios/16_Choosing_the_Best.cfg
@@ -198,6 +198,7 @@
         {MSGm_Lorin _"You know, I was starting to take a fancy to him. But after last night, he finally... no, don't ask me. I won't answer."}
         {MSGm_Gawen _"I thought he, I mean he and you..."}
         {MSGm_Lorin _"My son, because you lost your memory, you probably forgot about some of our customs. In our tradition, a widow cannot ever have another man again, under penalty of very severe punishment."}
+        #po: it's okay for Ruvio to use Gawen's real name here, since they are solely among allies here, with no need to worry about enemies overhearing them:
         {MSG_Ruvio _"Wait a minute. Your father, Gawen, married Lorin after the death of your mother, didn't he?"}
         {MSGm_Lorin _"Who allowed you to listen, underling? This discussion is between two worthy people. Go and bother someone else."}
         {MSG_Ruvio _"Your step-mother is really starting to get on my nerves."}

--- a/scenarios/17_Sneaking_out_of_Raedwood.cfg
+++ b/scenarios/17_Sneaking_out_of_Raedwood.cfg
@@ -17,6 +17,7 @@
     {IF ano_opt equals gawen}
     {VARIABLE ano_harnen_heard gawen}
     {MSG_Raban _"MY KING! Forgive me, no... kill me now, how could I fight against you? I know now that I am a worthless traitor."}
+    #po: It's okay for Ruvio to use Gawen's real name here, since he just went and revealed it anyways:
     {MSG_Ruvio _"Gawen, I thought I told you to keep your identity a secret."}
     {MSGm_Gawen _"It is for advisors to advise, and the leader to choose whether to follow that advice. Raban, there can be no treachery in ignorance. If you didn't know it was me, you are no traitor."}
     {ELSE}
@@ -49,7 +50,7 @@
     {CLEAR_VARIABLE ano_continue}
     {VARIABLE ano_continue yes}
     {WHILE ano_continue equals yes}
-    {MSGOPTI5  ({WHO}) ({PORTRAIT}) (_"Now, tell me...")
+    {MSGOPTI5 ({WHO}) ({PORTRAIT}) (_"Now, tell me...")
     (_"Why is Bor Cryne allied with orcs?") (orcs)
     (_"What can you tell me about Grekulak?") (grekulak)
     (_"Do you know where the great mage Deorien is?") (deorien)
@@ -415,7 +416,8 @@
         {IF_HAVE_UNIT_ANY (Reumario)}
         {MSG_Reumario _"Well, Gawen, which path will you take? The stealthy route proposed by the underling, or the violent route proposed by the 'She-Wolf of Haeltin'?"}
         {ELSE}
-        {MSG_Ruvio _"Well, Gawen, which path will you take? The stealthy route I proposed, or the violent route proposed by your stepmother?"}
+        #po: Ruvio switches back to Gawen's codename here to emphasize that they're around enemies again, and need to be careful now:
+        {MSG_Ruvio _"Well, Haldric, which path will you take? The stealthy route I proposed, or the violent route proposed by your stepmother?"}
         {TWO_END_IFs}
         {MSGOPTI3 (Gawen Hagarthen) (portraits/gawen_was.png) (_"Well...")
         (_"I think I'll take the stealthy strategy") (stealth)
@@ -577,7 +579,8 @@
             side=1
             {OBJECTIVE_NOTES _"You can interrogate enemy leaders in this scenario with Gawen, Ruvio, Reme, or Lorin, but the effects may - or may not - be different, depending on the enemy leader and interrogating hero."}
             [objective]
-                description=_"Move Gawen to south-eastern signpost OR"
+                #po: trailing space is intentional, to pad the footnote a bit:
+                description=_"Move Gawen to south-eastern signpost " + {EARLY_FINISH_BONUS_FOOTNOTE} + _" OR"
                 condition=win
             [/objective]
             [objective]
@@ -597,6 +600,7 @@
                 condition=lose
             [/objective]
             {TURNS_RUN_OUT}
+            {OBJECTIVES_GOLD_CARRYOVER_STANDARD} # ...I think?
         [/objectives]
     [/event]
 

--- a/scenarios/18_Start_of_the_Quest.cfg
+++ b/scenarios/18_Start_of_the_Quest.cfg
@@ -12,7 +12,7 @@
     {EXTRA_SCENARIO_MUSIC journeys_end.ogg}
     map_data="{~add-ons/A_New_Order/maps/Strategical2.map}"
 
-    turns=-1
+    turns=-1 # i.e. unlimited
 
     victory_when_enemies_defeated=no
     [story]
@@ -138,6 +138,7 @@
         [objectives]
             side=1
             {OBJECTIVE_NOTES _"This is a large-scale map, where you will choose a way to go. You should move Gawen to any of the signpost or any other location to trigger moving to next scenario. Move Gawen to tent to talk with his friends."}
+            {HAS_NO_TURN_LIMIT}
         [/objectives]
     [/event]
 

--- a/scenarios/19a_The_Woods_of_Okladia.cfg
+++ b/scenarios/19a_The_Woods_of_Okladia.cfg
@@ -209,7 +209,7 @@
     # (except on EASY where I'm doing turn limit minus 6 due to triskaidekaphobia):
     [event]
         name={ON_DIFFICULTY4 (turn 12) (turn 11) (turn 9) (turn 7)}
-        {MSG_Ruvio _"We'd better get hurrying, Gawen! If we don't make it to the signpost in time, reinforcements could arrive and trap us!"}
+        {MSG_Ruvio _"We'd better get hurrying! If we don't make it to the signpost in time, reinforcements could arrive and trap us!"}
     [/event]
     [event]
         name=time over

--- a/scenarios/19b_Entering_Okladia.cfg
+++ b/scenarios/19b_Entering_Okladia.cfg
@@ -199,7 +199,7 @@
     # turn limit minus 6 (i.e. the number of turns it'd take Gawen to get from his starting keep to the signpost):
     [event]
         name={ON_DIFFICULTY4 (turn 12) (turn 10) (turn 8) (turn 6)}
-        {MSG_Ruvio _"We'd better get hurrying, Gawen! If we don't make it to the signpost in time, reinforcements could arrive and trap us!"}
+        {MSG_Ruvio _"We'd better get hurrying! If we don't make it to the signpost in time, reinforcements could arrive and trap us!"}
     [/event]
     [event]
         name=time over

--- a/scenarios/19c_The_Oracle.cfg
+++ b/scenarios/19c_The_Oracle.cfg
@@ -108,7 +108,7 @@
         [/modifications]
         [ai]
             {NO_SCOUTS}
-            passive_leader=yes
+            passive_leader=yes # FIXME: the game has ignored this on me at least once; attempting some solutions in the prestart event...
 #ifdef EASY
             recruitment_pattern=fighter,archer,fighter,mixed fighter,fighter,healer,fighter,2
             recruitment_more="2"
@@ -1492,13 +1492,26 @@
         {IF_HAVE_UNIT_ANY (Reumario)}
         {RECALL (Reumario)}
         {END_IF_WITHOUT_ELSE}
+        [modify_unit]
+            [filter]
+                side=2
+                id=Matthias Ramon
+                canrecruit=yes
+            [/filter]
+            goto_x,goto_y=19,23
+        [/modify_unit]
         [micro_ai]
             side=2
             ai_type=zone_guardian
             action=add
 
             [filter]
-                # FIXME: re-check the MAI documentation about how the filter here is supposed to work
+                [not]
+                    id=Matthias Ramon
+                [/not]
+                [not]
+                    canrecruit=yes
+                [/not]
             [/filter]
             ca_score=26000 # (low)
             [filter_location]
@@ -1521,6 +1534,23 @@
                 [/or]
             [/filter_location_enemy]
             station_x,station_y=19,23
+        [/micro_ai]
+        # TODO: maybe also try modifying side 2's movement costs to better suit the play style I've been trying to give them via AI so far...
+        [micro_ai]
+            side=2
+            ai_type=goto
+            action=add
+
+            [filter]
+                id=Matthias Ramon
+                canrecruit=yes
+            [/filter]
+            [filter_location]
+                x,y=19,23
+            [/filter_location]
+            [avoid]
+                terrain=W*,Gll
+            [/avoid]
         [/micro_ai]
         # Replacement for attack_depth being removed:
         [micro_ai]
@@ -1636,6 +1666,9 @@
             to_y=23
         [/move_unit]
     [/event]
+
+    # TODO: add some dialogue for when your own units move next to Matthias Ramon
+    # Have him explain that you can't see the Oracle until the attackers are defeated
 
     [event]
         name=last breath
@@ -1846,7 +1879,7 @@
         [delay]
             time=100
         [/delay]
-        # carets blank EVERYTHING before them, rather than just the preceding word, so that is why I replaced "plural^you" with "all of you" here:
+        #po: carets blank EVERYTHING before them, rather than just the preceding word, so that is why I replaced "plural^you" with "all of you" here:
         {MSG_Oracle _"Here I am. My voice speaks to those willing to listen. I know why you are here. I know who all of you are. Ask your questions and receive the answers, for I can see everything which may be."}
         {MSGm_Lorin _"Everything, huh? Then how come you were besieged and almost captured? Why didn't you escape or call on someone to help you?"}
         {MSG_Oracle _"The answer to this question is the answer to your doubts. Why haven't I escaped? Why didn't I call someone for help?"}
@@ -1865,7 +1898,7 @@
 
         {MSGm_Lorin _"No! No!  There has to be a better answer!"}
         {MSG_Oracle _"As the Oracle, I have nothing more to say to thee... As a woman, I can advise this: There is only one man in the world who may change your future. I think you know his name. Go and find him. Beg him for forgiveness if you have to. Stay with him as long as you can."}
-        #po: FIXME: this wording could be improved:
+        #po: FIXME: this wording could be improved... basically Lorin is saying she accepts the answers the Oracle gave with her Oracle hat on, but not the advice she gave on a woman-to-woman basis:
         {MSGm_Lorin _"Is that all you wanted to tell me? Then know that I've heard, that the She-wolf of Haeltin has heard counsel of the Oracle, voice of God on Earth. She will not hear the counsel woman whom is merely God's tool."}
         {MSGm_Lorin _"Let's go, Gawen. We're finished here."}
         {MSGm_Gawen _"I didn't catch the meaning of the discussion between you, and I know it was important. But why?"}

--- a/scenarios/20_Okladia.cfg
+++ b/scenarios/20_Okladia.cfg
@@ -12,7 +12,7 @@
     {EXTRA_SCENARIO_MUSIC journeys_end.ogg}
     map_data="{~add-ons/A_New_Order/maps/StrategicalOkladia.map}"
 
-    turns=-1
+    turns=-1 # i.e. unlimited
 
     victory_when_enemies_defeated=no
     [story]
@@ -151,6 +151,7 @@
         [objectives]
             side=1
             {OBJECTIVE_NOTES _"This is a large-scale map, where you will choose a way to go. You should move Gawen to any of the signpost or any other location to trigger moving to next scenario. Move Gawen to tent to talk with his friends."}
+            {HAS_NO_TURN_LIMIT}
         [/objectives]
     [/event]
 

--- a/scenarios/21a_Abducted_Bride.cfg
+++ b/scenarios/21a_Abducted_Bride.cfg
@@ -384,7 +384,8 @@
                 condition=win
             [/objective]
             [objective]
-                description=_"Release the peasant girl being kept in a cage and move her to the northern edge of the map."
+                #po: trailing space is intentional, to pad the footnote a bit:
+                description=_"Release the peasant girl being kept in a cage and move her to the northern edge of the map. " + {EARLY_FINISH_BONUS_FOOTNOTE}
                 condition=win
             [/objective]
             [objective]
@@ -413,7 +414,8 @@
                 condition=win
             [/objective]
             [objective]
-                description=_"Release the peasant girl being kept in a cage and move her to the northern edge of the map."
+                # (same note as previously; no need to duplicate it)
+                description=_"Release the peasant girl being kept in a cage and move her to the northern edge of the map. " + {EARLY_FINISH_BONUS_FOOTNOTE}
                 condition=win
             [/objective]
             [objective]

--- a/scenarios/21c_Ruins_of_the_Past.cfg
+++ b/scenarios/21c_Ruins_of_the_Past.cfg
@@ -24,7 +24,7 @@
             # It might be tempting to spoil Grekulak's appearance here by displaying his portrait, but let's not do that yet.
         [/part]
         [part]
-            story=_"After Mal-Ravanal's defeat, Grekulak was trapped in the swamps, spending his days roving in the morass and quagmire. Finally he came up with an idea. The undead had been storming the world of Wesnoth for millenia. They never succeeded, and often a very small group of brave living creatures - be they elves, humans or dwarves - were able to defeat large hordes of undead. "
+            story=_"After Mal-Ravanal's defeat, Grekulak was trapped in the swamps, spending his days roving in the morass and quagmire. Finally he came up with an idea. The undead had been storming the world of Wesnoth for millennia. They never succeeded, and often a very small group of brave living creatures - be they elves, humans or dwarves - were able to defeat large hordes of undead. "
             background=story/swamp-01.jpg
             # ART_TODO.txt entry: "An image illustrating how Grekulak escaped through the swamps (a dark silhouette on dark background)"
         [/part]

--- a/scenarios/21d_Ruins_of_Weldyn.cfg
+++ b/scenarios/21d_Ruins_of_Weldyn.cfg
@@ -6,7 +6,7 @@
     {INTRO_AND_SCENARIO_MUSIC suspense/flanger.ogg suspense/dark_passage.ogg}
     {EXTRA_SCENARIO_MUSIC into_the_shadows.ogg}
     map_data="{~add-ons/A_New_Order/maps/RuinsOfWeldyn.map}"
-    turns=-1
+    turns=-1 # i.e. unlimited
     victory_when_enemies_defeated=no
     [story]
         [part]
@@ -110,6 +110,7 @@
                 description=_"Explore"
                 condition=win
             [/objective]
+            {HAS_NO_TURN_LIMIT}
         [/objectives]
     [/event]
     [event]

--- a/scenarios/22_Leaving_Okladia.cfg
+++ b/scenarios/22_Leaving_Okladia.cfg
@@ -465,7 +465,8 @@
                 condition=win
             [/objective]
             [objective]
-                description=_"Reach the northern edge of the map with Gawen."
+                #po: trailing space is intentional, to pad the footnote a bit:
+                description=_"Reach the northern edge of the map with Gawen. " + {EARLY_FINISH_BONUS_FOOTNOTE}
                 condition=win
             [/objective]
             [objective]

--- a/scenarios/25_The_Awakening.cfg
+++ b/scenarios/25_The_Awakening.cfg
@@ -140,7 +140,7 @@
     [floating_text]
         x,y=$x1,$y1
         #wmllint: markcheck off
-        text="<span color='#BCB088'>+{ON_DIFFICULTY4 3 2 1 0}g</span>"
+        text="<span color='#BCB088'>+{ON_DIFFICULTY4 3 2 1 0}g</span>" #wmllint: no spellcheck
         #wmllint: markcheck on
     [/floating_text]
 #endif
@@ -166,7 +166,7 @@
     [floating_text]
         x,y=$x1,$y1
         #wmllint: markcheck off
-        text="<span color='#BCB088'>+{ON_DIFFICULTY4 4 3 2 1}g</span>"
+        text="<span color='#BCB088'>+{ON_DIFFICULTY4 4 3 2 1}g</span>" #wmllint: no spellcheck
         #wmllint: markcheck on
     [/floating_text]
     {ELSE_IF random equals 5}
@@ -191,7 +191,7 @@
     [floating_text]
         x,y=$x1,$y1
         #wmllint: markcheck off
-        text="<span color='#BCB088'>+{ON_DIFFICULTY4 5 4 3 2}g</span>"
+        text="<span color='#BCB088'>+{ON_DIFFICULTY4 5 4 3 2}g</span>" #wmllint: no spellcheck
         #wmllint: markcheck on
     [/floating_text]
     {ELSE}
@@ -216,7 +216,7 @@
     [floating_text]
         x,y=$x1,$y1
         #wmllint: markcheck off
-        text="<span color='#BCB088'>+{ON_DIFFICULTY4 6 5 4 3}g</span>"
+        text="<span color='#BCB088'>+{ON_DIFFICULTY4 6 5 4 3}g</span>" #wmllint: no spellcheck
         #wmllint: markcheck on
     [/floating_text]
     {FOUR_END_IFs}

--- a/scenarios/27_Orannon.cfg
+++ b/scenarios/27_Orannon.cfg
@@ -1429,7 +1429,7 @@ Forces of Darkness will consume your mind."}
         {IF ano_bridge_questions equals yes}
         [if]
             [variable]
-                name=$unit.id
+                name=unit.id
                 equals=Lady Lorin
             [/variable]
             [then]

--- a/scenarios/27_Orannon.cfg
+++ b/scenarios/27_Orannon.cfg
@@ -759,6 +759,7 @@
                 condition=lose
             [/objective]
             {IS_LAST_SCENARIO}
+            {HAS_NO_TURN_LIMIT}
         [/objectives]
     [/event]
 
@@ -1426,18 +1427,30 @@ Forces of Darkness will consume your mind."}
             [/not]
         [/filter]
         {IF ano_bridge_questions equals yes}
-        [message]
-            speaker=unit
-            message= _"Milord, should I destroy this bridge?"
-        [/message]
-        # FIXME: change "any bridges" to "any more bridges" when one has already been destroyed,
-        # and also adjust "today" based on passage of time (scenario usually lasts more than one day):
-        {MSGOPTI3 (Gawen Hagarthen) (portraits/gawen_matured.png)
-        (_"Well...")
-        (_"Yes!") (yes)
-        (_"No, but I might want a bridge destroyed later...") (no1)
-        (_"No, we won't be destroying any bridges today.") (no2)
-        }
+        [if]
+            [variable]
+                name=$unit.id
+                equals=Lady Lorin
+            [/variable]
+            [then]
+                {MSGm_Lorin _"Gawen, I'm going to destroy this bridge."}
+                {VARIABLE ano_opt yes}
+            [/then]
+            [else]
+                [message]
+                    speaker=unit
+                    message= _"Milord, should I destroy this bridge?"
+                [/message]
+                # FIXME: change "any bridges" to "any more bridges" when one has already been destroyed,
+                # and also adjust "today" based on passage of time (scenario usually lasts more than one day):
+                {MSGOPTI3 (Gawen Hagarthen) (portraits/gawen_matured.png)
+                (_"Well...")
+                (_"Yes!") (yes)
+                (_"No, but I might want a bridge destroyed later...") (no1)
+                (_"No, we won't be destroying any bridges today.") (no2)
+                }
+            [/else]
+        [/if]
         {IF ano_opt equals yes}
         [scroll_to_unit]
             id=$unit.id

--- a/translations/wesnoth-A_New_Order.pot
+++ b/translations/wesnoth-A_New_Order.pot
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
-"POT-Creation-Date: 2024-05-19 06:53 UTC\n"
+"POT-Creation-Date: 2024-05-21 03:57 UTC\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17435,159 +17435,164 @@ msgstr ""
 msgid "Rarg"
 msgstr ""
 
-#. [message]: type=Akladian Clansman,Akladian Wiseman,Akladian Holyman,Akladian Warrior,Akladian Raider,Akladian Homeguard,Akladian Light Infantry,Akladian Fastfoot,Akladian Pikeneer,Akladian Shieldguard,Akladian Protector,Akladian Sturmknight,Akladian Darknite
-#: A_New_Order/scenarios/10_Siege_of_Haeltin.cfg:734
-msgid "Run for your life! They are too many of them!!"
+#. [message]: role=scaredycat
+#: A_New_Order/scenarios/10_Siege_of_Haeltin.cfg:790
+msgid "Run for your life! There are too many of them!!"
 msgstr ""
 
-#. [event]
-#: A_New_Order/scenarios/10_Siege_of_Haeltin.cfg:736
+#. [message]: role=scaredycat
+#: A_New_Order/scenarios/10_Siege_of_Haeltin.cfg:795
+msgid "Sheesh, no matter how many of them we kill, they just keep coming!"
+msgstr ""
+
+#. [event]: id=penultimate_turn
+#: A_New_Order/scenarios/10_Siege_of_Haeltin.cfg:798
 msgid "Keep fighting! Don't give up! At least kill as many of them as you can! They will surely have to withdraw soon!"
 msgstr ""
 
 #. [message]: type=Orcish Warlord
-#: A_New_Order/scenarios/10_Siege_of_Haeltin.cfg:742
+#: A_New_Order/scenarios/10_Siege_of_Haeltin.cfg:806
 msgid "We have no more supplies... we have to withdraw! We will return, she-wolf!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/10_Siege_of_Haeltin.cfg:756
+#: A_New_Order/scenarios/10_Siege_of_Haeltin.cfg:820
 msgid "Well fought, men! The enemy is withdrawing! They have no more supplies!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/10_Siege_of_Haeltin.cfg:771
+#: A_New_Order/scenarios/10_Siege_of_Haeltin.cfg:835
 msgid "This was an incredibly difficult ordeal. I felt sure this would be my final battle."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/10_Siege_of_Haeltin.cfg:772
+#: A_New_Order/scenarios/10_Siege_of_Haeltin.cfg:836
 msgid "Lorin, have you heard what our people are calling you? A she-wolf. The She-Wolf of Haeltin."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/10_Siege_of_Haeltin.cfg:773
+#: A_New_Order/scenarios/10_Siege_of_Haeltin.cfg:837
 msgid "LADY Lorin. Why would I want to be called a She-Wolf? Do they expect me to howl or something?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/10_Siege_of_Haeltin.cfg:774
+#: A_New_Order/scenarios/10_Siege_of_Haeltin.cfg:838
 msgid "Lorin, you are an able commander, a strong warrior, and have a lovely... tactical mind. If you are a wolf, it would be quite the feat for a man to tame you... but I have to try anyway."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/10_Siege_of_Haeltin.cfg:775
+#: A_New_Order/scenarios/10_Siege_of_Haeltin.cfg:839
 msgid "Listen underling, I am not an animal to be tamed or a prize to be won. The only thing which stays my hand from snuffing out your life after hearing such a remark is that I still need you. But you are dangerously close to the line, so..."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/10_Siege_of_Haeltin.cfg:776
+#: A_New_Order/scenarios/10_Siege_of_Haeltin.cfg:840
 msgid "I am no fool, Lorin. I understand that you suffer my presence now only of necessity. But perhaps there will come a time when you no longer suffer my presence of necessity, but welcome it by choice?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/10_Siege_of_Haeltin.cfg:777
+#: A_New_Order/scenarios/10_Siege_of_Haeltin.cfg:841
 msgid "You may not see it, but you are a fool. An honorable fool, but a fool nonetheless."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/10_Siege_of_Haeltin.cfg:778
+#: A_New_Order/scenarios/10_Siege_of_Haeltin.cfg:842
 msgid "What do you mean?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/10_Siege_of_Haeltin.cfg:779
+#: A_New_Order/scenarios/10_Siege_of_Haeltin.cfg:843
 msgid "First of all, you forgot to say 'one more reference to underling and I'm leaving'. Look, Yahyazad, I am many things, but I am not blind. I've noticed the way you look at me. At first, I couldn't figure out what it meant; I am not used to those kinds of glances. I can easily recognise fear, hatred, loathing, and disdain. But this... "
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/10_Siege_of_Haeltin.cfg:780
+#: A_New_Order/scenarios/10_Siege_of_Haeltin.cfg:844
 msgid "...all of the worst emotions of a true warrior, and yet none of the worthy ones... the true warrior fights not for fear or for hate, but for love."
 msgstr ""
 
 #. [event]
 #. unused:
-#: A_New_Order/scenarios/10_Siege_of_Haeltin.cfg:783
+#: A_New_Order/scenarios/10_Siege_of_Haeltin.cfg:847
 msgid "No! Don't even speak of that! You know nothing of what it takes to be a warrior! What it takes for a woman to be a warrior! Love cannot drive you hard enough, only pain, only fear, only hate!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/10_Siege_of_Haeltin.cfg:787
+#: A_New_Order/scenarios/10_Siege_of_Haeltin.cfg:851
 msgid "For love?! You really believe that?! You can't be serious. You speak like... Wesnothians have a special word for that kind of people. A rhymeister?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/10_Siege_of_Haeltin.cfg:788
+#: A_New_Order/scenarios/10_Siege_of_Haeltin.cfg:852
 msgid "I am serious. And I think you meant to say 'poet'. So you think I speak like a poet? Thank you."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/10_Siege_of_Haeltin.cfg:789
+#: A_New_Order/scenarios/10_Siege_of_Haeltin.cfg:853
 msgid "That was not a compliment. A 'poet' is just a fancy word for 'idiot'. You Dunefolk fight for love? Ha! No wonder you have lost."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/10_Siege_of_Haeltin.cfg:790
+#: A_New_Order/scenarios/10_Siege_of_Haeltin.cfg:854
 msgid "Listen to me carefully. I know now what you are thinking. Do not have any hope. Do not try ANYTHING. First, I am an Akladian and you are not. Second, I am a bad woman. You have no idea how bad. Avoid me. Third, you are not my type. Fourth, there are some Akladian customs of which you are seemingly unaware."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/10_Siege_of_Haeltin.cfg:791
+#: A_New_Order/scenarios/10_Siege_of_Haeltin.cfg:855
 msgid "Let us suppose, for a moment, I submit to your wishes and cast these thoughts from my mind. What do we do going forward? Armies are still out there. Our dooms, for now, are still entwined for good or ill."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/10_Siege_of_Haeltin.cfg:792
+#: A_New_Order/scenarios/10_Siege_of_Haeltin.cfg:856
 msgid "Let's make a deal: I will not call you 'underling,' and you may call me 'Lady Lorin.' Agreed?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/10_Siege_of_Haeltin.cfg:793
+#: A_New_Order/scenarios/10_Siege_of_Haeltin.cfg:857
 msgid "'Lady Lorin' it is then. But if you will not call me 'underling' you must call me something. If you like, you may simply call me 'Majid.' "
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/10_Siege_of_Haeltin.cfg:794
+#: A_New_Order/scenarios/10_Siege_of_Haeltin.cfg:858
 msgid "Whatever. Go to your people, see what they need. I will check our wounded."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/10_Siege_of_Haeltin.cfg:888
+#: A_New_Order/scenarios/10_Siege_of_Haeltin.cfg:952
 msgid "My soldiers! That bastard is killing my soldiers!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/10_Siege_of_Haeltin.cfg:889
+#: A_New_Order/scenarios/10_Siege_of_Haeltin.cfg:953
 msgid "I never knew you cared so much for your warriors."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/10_Siege_of_Haeltin.cfg:890
+#: A_New_Order/scenarios/10_Siege_of_Haeltin.cfg:954
 msgid "I always care for my people... besides, you have no idea how difficult it was to train them."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/10_Siege_of_Haeltin.cfg:894
+#: A_New_Order/scenarios/10_Siege_of_Haeltin.cfg:958
 msgid "Lorin, what are you doing?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/10_Siege_of_Haeltin.cfg:895
+#: A_New_Order/scenarios/10_Siege_of_Haeltin.cfg:959
 msgid "Maybe we could try to withdraw to the mountains?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/10_Siege_of_Haeltin.cfg:896
+#: A_New_Order/scenarios/10_Siege_of_Haeltin.cfg:960
 msgid "Wait a moment. Are you running away?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/10_Siege_of_Haeltin.cfg:897
+#: A_New_Order/scenarios/10_Siege_of_Haeltin.cfg:961
 msgid "The correct term is strategical relocation of the forces, impertinent underling."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/10_Siege_of_Haeltin.cfg:898
+#: A_New_Order/scenarios/10_Siege_of_Haeltin.cfg:962
 msgid "One more reference to underling... ah, what the hey..."
 msgstr ""
 

--- a/translations/wesnoth-A_New_Order.pot
+++ b/translations/wesnoth-A_New_Order.pot
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
-"POT-Creation-Date: 2024-05-21 03:57 UTC\n"
+"POT-Creation-Date: 2024-06-07 01:33 UTC\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1355,57 +1355,78 @@ msgstr ""
 msgid "That's why I suggest we visit the Oracle, who, being a mage herself, may know where Deorien is."
 msgstr ""
 
-#. [event]
+#. [event]: id=reme_last_breath_n
+#. [event]: id=reme_last_breath
 #. Reme's "last breath" message:
-#: A_New_Order/macros/deaths.cfg:12
-#: A_New_Order/macros/deaths.cfg:106
+#: A_New_Order/macros/deaths.cfg:13
+#: A_New_Order/macros/deaths.cfg:116
 msgid "I can't hold my sword anymore... I can't..."
 msgstr ""
 
-#. [event]
+#. [event]: id=reumario_last_breath
 #. Reumario's "last breath" message:
-#: A_New_Order/macros/deaths.cfg:23
+#: A_New_Order/macros/deaths.cfg:25
 msgid "My ancestors, I am coming to you! I hope I have not failed you..."
 msgstr ""
 
-#. [event]
+#. [event]: id=regven_last_breath
 #. Karl Regven's "last breath" message:
-#: A_New_Order/macros/deaths.cfg:34
+#: A_New_Order/macros/deaths.cfg:37
 msgid "I'm not afraid... I would just want to smoke a little longer..."
 msgstr ""
 
+#. [event]: id=yahyazad_last_breath
 #. [event]
 #. "last breath" message shared by multiple Dunefolk
 #. (both Majid Yahyazad campaign-wide, and Arsham Mahouri in S23, "Trapped")
-#: A_New_Order/macros/deaths.cfg:46
+#: A_New_Order/macros/deaths.cfg:50
 #: A_New_Order/scenarios/23_Trapped.cfg:605
 #: A_New_Order/scenarios/23_Trapped.cfg:618
 msgid "Dunefolk die without fear!"
 msgstr ""
 
-#. [event]
+#. [event]: id=gawen_last_breath
 #. Gawen's "last breath" message:
-#: A_New_Order/macros/deaths.cfg:66
+#: A_New_Order/macros/deaths.cfg:72
 msgid "No! It's impossible! I have just started!"
 msgstr ""
 
-#. [event]
+#. [event]: id=lorin_last_breath
 #. Lorin's "last breath" message:
-#: A_New_Order/macros/deaths.cfg:86
+#: A_New_Order/macros/deaths.cfg:94
 msgid "That's not fair!"
 msgstr ""
 
-#. [event]
+#. [event]: id=karen_last_breath
 #. unsure how to complete this sentence... "life" seems the most obvious, but "sight" and "blood" also work
 #. (plus my mind can't stop completing it with "virginity" even though that makes no sense)
-#: A_New_Order/macros/deaths.cfg:127
+#: A_New_Order/macros/deaths.cfg:139
 msgid "Father! Father! I am losing my..."
 msgstr ""
 
-#. [event]
+#. [event]: id=ruvio_last_breath
 #. Ruvio's "last breath" message:
-#: A_New_Order/macros/deaths.cfg:147
+#: A_New_Order/macros/deaths.cfg:161
 msgid "No! I have still so much to do!"
+msgstr ""
+
+#. [event]: id=rob_roe_last_breath
+#. [event]
+#. [side]: id=Outlaw Leader, type=Outlaw
+#. [unit]: id=Rob Roe, type=$ano_robroe_unit.type
+#. [scenario]: id=08_Outlaw_Base
+#: A_New_Order/macros/deaths.cfg:182
+#: A_New_Order/macros/ano-20macros.cfg:527
+#: A_New_Order/scenarios/08_Outlaw_Base.cfg:44
+#: A_New_Order/scenarios/08_Outlaw_Base.cfg:457
+#: A_New_Order/scenarios/08_Outlaw_Base.cfg:171
+msgid "Rob Roe"
+msgstr ""
+
+#. [event]: id=rob_roe_last_breath
+#. Rob Roe's "last breath" message:
+#: A_New_Order/macros/deaths.cfg:184
+msgid "You'd think I'd have learned not to underestimate my enemies by now, but... argh..."
 msgstr ""
 
 #. [event]
@@ -2648,17 +2669,6 @@ msgstr ""
 #. use of "me" instead of "my" here (and in Rob Roe's response) is to give him a bit of an accent:
 #: A_New_Order/macros/ano-20macros.cfg:526
 msgid "Wait a minute... Rob Roe? What are you doing, me fellow Rob? What happened to our bandit fellowship?"
-msgstr ""
-
-#. [event]
-#. [side]: id=Outlaw Leader, type=Outlaw
-#. [unit]: id=Rob Roe, type=$ano_robroe_unit.type
-#. [scenario]: id=08_Outlaw_Base
-#: A_New_Order/macros/ano-20macros.cfg:527
-#: A_New_Order/scenarios/08_Outlaw_Base.cfg:44
-#: A_New_Order/scenarios/08_Outlaw_Base.cfg:457
-#: A_New_Order/scenarios/08_Outlaw_Base.cfg:171
-msgid "Rob Roe"
 msgstr ""
 
 #. [event]

--- a/translations/wesnoth-A_New_Order.pot
+++ b/translations/wesnoth-A_New_Order.pot
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
-"POT-Creation-Date: 2024-04-02 12:18 UTC\n"
+"POT-Creation-Date: 2024-05-19 06:53 UTC\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -92,10 +92,10 @@ msgstr ""
 #: A_New_Order/units/others/Ruvios_Daughter.cfg:4
 #: A_New_Order/macros/messages.cfg:70
 #: A_New_Order/macros/messages.cfg:74
-#: A_New_Order/scenarios/13_Scouting.cfg:715
-#: A_New_Order/scenarios/13_Scouting.cfg:725
-#: A_New_Order/scenarios/13_Scouting.cfg:736
-#: A_New_Order/scenarios/13_Scouting.cfg:744
+#: A_New_Order/scenarios/13_Scouting.cfg:716
+#: A_New_Order/scenarios/13_Scouting.cfg:726
+#: A_New_Order/scenarios/13_Scouting.cfg:737
+#: A_New_Order/scenarios/13_Scouting.cfg:745
 #: A_New_Order/scenarios/07_Ally_From_the_Past.cfg:94
 msgid "Karen"
 msgstr ""
@@ -134,17 +134,17 @@ msgstr ""
 #: A_New_Order/scenarios/20_Okladia.cfg:446
 #: A_New_Order/scenarios/20_Okladia.cfg:456
 #: A_New_Order/scenarios/20_Okladia.cfg:464
-#: A_New_Order/scenarios/13_Scouting.cfg:714
-#: A_New_Order/scenarios/13_Scouting.cfg:724
-#: A_New_Order/scenarios/13_Scouting.cfg:735
-#: A_New_Order/scenarios/13_Scouting.cfg:743
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:646
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:686
+#: A_New_Order/scenarios/13_Scouting.cfg:715
+#: A_New_Order/scenarios/13_Scouting.cfg:725
+#: A_New_Order/scenarios/13_Scouting.cfg:736
+#: A_New_Order/scenarios/13_Scouting.cfg:744
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:650
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:690
 #: A_New_Order/scenarios/07_Ally_From_the_Past.cfg:78
 #: A_New_Order/scenarios/21a_Abducted_Bride.cfg:622
 #: A_New_Order/scenarios/21a_Abducted_Bride.cfg:637
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:561
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:569
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:562
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:570
 msgid "Ruvio"
 msgstr ""
 
@@ -413,7 +413,7 @@ msgstr ""
 #. [event]
 #. [campaign]: id=A_New_Order
 #: A_New_Order/units/akladians/Akladian_Clansman.cfg:4
-#: A_New_Order/scenarios/02_Fighting_for_Passage.cfg:956
+#: A_New_Order/scenarios/02_Fighting_for_Passage.cfg:960
 #: A_New_Order/_main.cfg:57
 msgid "Akladian Clansman"
 msgstr ""
@@ -779,7 +779,7 @@ msgstr ""
 #: A_New_Order/macros/messages.cfg:144
 #: A_New_Order/scenarios/21a_Abducted_Bride.cfg:335
 #: A_New_Order/scenarios/21a_Abducted_Bride.cfg:341
-#: A_New_Order/scenarios/12_Leaving_Raedwood.cfg:330
+#: A_New_Order/scenarios/12_Leaving_Raedwood.cfg:332
 #: A_New_Order/scenarios/11_Council_in_Freetown.cfg:318
 #: A_New_Order/scenarios/11_Council_in_Freetown.cfg:372
 msgid "Elorain"
@@ -793,7 +793,9 @@ msgstr ""
 
 #. [event]
 #. [then]
+#. [event]: id=Kyobaine_post_advance_clothing_banter
 #. [else]
+#. [event]: id=Kyobaine_recall_clothing_banter
 #. [unit]: type=Elvish Shaman, id=Kyobaine
 #. [unit]: type=Elvish Scout, id=Kyobaine
 #. [unit]: type=Elvish Fighter, id=Kyobaine
@@ -802,26 +804,26 @@ msgstr ""
 #: A_New_Order/macros/elvish_macros.cfg:139
 #: A_New_Order/macros/elvish_macros.cfg:142
 #: A_New_Order/macros/elvish_macros.cfg:146
-#: A_New_Order/macros/elvish_macros.cfg:176
-#: A_New_Order/macros/elvish_macros.cfg:165
-#: A_New_Order/macros/elvish_macros.cfg:205
-#: A_New_Order/macros/elvish_macros.cfg:209
-#: A_New_Order/macros/elvish_macros.cfg:214
-#: A_New_Order/macros/elvish_macros.cfg:218
-#: A_New_Order/macros/elvish_macros.cfg:195
-#: A_New_Order/macros/elvish_macros.cfg:228
-#: A_New_Order/macros/elvish_macros.cfg:305
-#: A_New_Order/macros/elvish_macros.cfg:307
-#: A_New_Order/macros/elvish_macros.cfg:310
-#: A_New_Order/macros/elvish_macros.cfg:320
+#: A_New_Order/macros/elvish_macros.cfg:177
+#: A_New_Order/macros/elvish_macros.cfg:166
+#: A_New_Order/macros/elvish_macros.cfg:207
+#: A_New_Order/macros/elvish_macros.cfg:211
+#: A_New_Order/macros/elvish_macros.cfg:216
+#: A_New_Order/macros/elvish_macros.cfg:220
+#: A_New_Order/macros/elvish_macros.cfg:197
+#: A_New_Order/macros/elvish_macros.cfg:230
+#: A_New_Order/macros/elvish_macros.cfg:314
+#: A_New_Order/macros/elvish_macros.cfg:316
+#: A_New_Order/macros/elvish_macros.cfg:319
+#: A_New_Order/macros/elvish_macros.cfg:329
 #: A_New_Order/macros/messages.cfg:161
 #: A_New_Order/macros/messages.cfg:164
 #: A_New_Order/macros/messages.cfg:174
-#: A_New_Order/scenarios/16_Choosing_the_Best.cfg:313
-#: A_New_Order/scenarios/16_Choosing_the_Best.cfg:315
-#: A_New_Order/scenarios/16_Choosing_the_Best.cfg:320
-#: A_New_Order/scenarios/16_Choosing_the_Best.cfg:327
-#: A_New_Order/scenarios/16_Choosing_the_Best.cfg:332
+#: A_New_Order/scenarios/16_Choosing_the_Best.cfg:314
+#: A_New_Order/scenarios/16_Choosing_the_Best.cfg:316
+#: A_New_Order/scenarios/16_Choosing_the_Best.cfg:321
+#: A_New_Order/scenarios/16_Choosing_the_Best.cfg:328
+#: A_New_Order/scenarios/16_Choosing_the_Best.cfg:333
 #: A_New_Order/scenarios/11_Council_in_Freetown.cfg:239
 #: A_New_Order/scenarios/11_Council_in_Freetown.cfg:255
 #: A_New_Order/scenarios/11_Council_in_Freetown.cfg:276
@@ -830,12 +832,13 @@ msgid "Kyobaine"
 msgstr ""
 
 #. [event]
+#. [event]: id=Kyobaine_recall_clothing_banter
 #. [then]
 #: A_New_Order/macros/elvish_macros.cfg:134
-#: A_New_Order/macros/elvish_macros.cfg:255
+#: A_New_Order/macros/elvish_macros.cfg:264
 #: A_New_Order/macros/conversations.cfg:43
-#: A_New_Order/scenarios/07_Ally_From_the_Past.cfg:674
-#: A_New_Order/scenarios/02_Fighting_for_Passage.cfg:737
+#: A_New_Order/scenarios/07_Ally_From_the_Past.cfg:676
+#: A_New_Order/scenarios/02_Fighting_for_Passage.cfg:741
 msgid "What?"
 msgstr ""
 
@@ -872,320 +875,328 @@ msgstr ""
 msgid "No offense, but... it's not like I have something against males in general. It's more like I like them less hairy. And less... human. Anything more? No? Good. Let's get back to the business. And don't forget about my 20 gold pieces."
 msgstr ""
 
-#. [event]
+#. [event]: id=Kyobaine_post_advance_clothing_banter
 #. Kyobaine advances to Elvish Druid
-#: A_New_Order/macros/elvish_macros.cfg:167
+#: A_New_Order/macros/elvish_macros.cfg:168
 msgid "How on earth I am supposed to walk in these clothes during winter? It's frigging cold!"
 msgstr ""
 
 #. [then]
 #. Gawen speaking to Kyobaine:
-#: A_New_Order/macros/elvish_macros.cfg:175
+#: A_New_Order/macros/elvish_macros.cfg:176
 msgid "But you're wearing snowshoes though."
 msgstr ""
 
 #. [then]
 #. Kyobaine speaking to Gawen:
-#: A_New_Order/macros/elvish_macros.cfg:178
+#: A_New_Order/macros/elvish_macros.cfg:179
 msgid "Do you seriously think that helps with the fact that it's my <b><i>BARE FEET</i></b> I have strapped into them? The holes in their webbing are enormous! The snow gets right through!"
 msgstr ""
 
-#. [event]
+#. [event]: id=Kyobaine_recall_clothing_banter
 #. The talk between Kyobaine as Elvish Druid and Gawen, during winter
-#: A_New_Order/macros/elvish_macros.cfg:197
+#: A_New_Order/macros/elvish_macros.cfg:199
 msgid "Oooh, no. I refuse to fight in these conditions, as long as I'm clad as such."
 msgstr ""
 
-#. [event]
-#: A_New_Order/macros/elvish_macros.cfg:198
+#. [event]: id=Kyobaine_recall_clothing_banter
+#: A_New_Order/macros/elvish_macros.cfg:200
 msgid "What do you mean? Your clothes are just fine."
 msgstr ""
 
 #. [then]
 #. Kyobaine asks Gawen for different clothes when she's wearing snowshoes:
-#: A_New_Order/macros/elvish_macros.cfg:207
+#: A_New_Order/macros/elvish_macros.cfg:209
 msgid "Except for the snowshoes, these are clothes <i>for the spring</i>. The least you can do is to give me a proper cloak. You expect me to fight when I'm shivering and have goosebumps??"
 msgstr ""
 
 #. [then]
 #. [else]
-#: A_New_Order/macros/elvish_macros.cfg:208
-#: A_New_Order/macros/elvish_macros.cfg:217
+#: A_New_Order/macros/elvish_macros.cfg:210
+#: A_New_Order/macros/elvish_macros.cfg:219
 msgid "That's ridiculous."
 msgstr ""
 
 #. [then]
 #. Kyobaine asks Gawen for different clothes when she's wearing snowshoes:
-#: A_New_Order/macros/elvish_macros.cfg:211
+#: A_New_Order/macros/elvish_macros.cfg:213
 msgid "I couldn't agree more. Call me when you have a new cloak."
 msgstr ""
 
 #. [else]
 #. the old version of Kyobaine's request to Gawen:
-#: A_New_Order/macros/elvish_macros.cfg:216
+#: A_New_Order/macros/elvish_macros.cfg:218
 msgid "<i>For the spring</i>. The least you can do is to give me proper shoes. You expect me to walk in this snow <i>barefoot</i>??"
 msgstr ""
 
 #. [else]
 #. the old version of Kyobaine's request to Gawen:
-#: A_New_Order/macros/elvish_macros.cfg:220
+#: A_New_Order/macros/elvish_macros.cfg:222
 msgid "I couldn't agree more. Call me when you have new shoes."
 msgstr ""
 
+#. [event]: id=Kyobaine_recall_clothing_banter
 #. [event]
 #. [scenario]: id=25_The_Awakening
 #. [scenario]: id=22_Leaving_Okladia
+#. [else]
 #. [scenario]: id=14e_Saorduc_Swamps
-#: A_New_Order/macros/elvish_macros.cfg:224
+#: A_New_Order/macros/elvish_macros.cfg:226
 #: A_New_Order/macros/ano-20macros.cfg:331
 #: A_New_Order/scenarios/25_The_Awakening.cfg:23
 #: A_New_Order/scenarios/15a_The_Preparations.cfg:199
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:420
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:422
 #: A_New_Order/scenarios/23_Trapped.cfg:28
 #: A_New_Order/scenarios/22_Leaving_Okladia.cfg:603
 #: A_New_Order/scenarios/22_Leaving_Okladia.cfg:150
 #: A_New_Order/scenarios/22_Leaving_Okladia.cfg:158
 #: A_New_Order/scenarios/22_Leaving_Okladia.cfg:173
-#: A_New_Order/scenarios/27_Orannon.cfg:1436
+#: A_New_Order/scenarios/27_Orannon.cfg:1447
 #: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:16
 msgid "Well..."
 msgstr ""
 
-#. [event]
-#: A_New_Order/macros/elvish_macros.cfg:225
+#. [event]: id=Kyobaine_recall_clothing_banter
+#: A_New_Order/macros/elvish_macros.cfg:227
 msgid "All right, how about I give you 25 gold pieces instead of 20?"
 msgstr ""
 
-#. [event]
-#: A_New_Order/macros/elvish_macros.cfg:226
+#. [event]: id=Kyobaine_recall_clothing_banter
+#: A_New_Order/macros/elvish_macros.cfg:228
 msgid "All right, we will wait for the spring."
 msgstr ""
 
-#. [event]
-#: A_New_Order/macros/elvish_macros.cfg:228
+#. [event]: id=Kyobaine_recall_clothing_banter
+#: A_New_Order/macros/elvish_macros.cfg:230
 msgid "You think you can bribe me, an elvish druid, with gold? Oh well. This will allow me to buy better winter clothes."
 msgstr ""
 
-#. [event]
-#: A_New_Order/macros/elvish_macros.cfg:229
+#. [event]: id=Kyobaine_recall_clothing_banter
+#: A_New_Order/macros/elvish_macros.cfg:231
 msgid "Maybe I should act gentlemanly here?"
 msgstr ""
 
-#. [event]
-#: A_New_Order/macros/elvish_macros.cfg:230
+#. [event]: id=Kyobaine_recall_clothing_banter
+#: A_New_Order/macros/elvish_macros.cfg:232
 msgid "(Offer to get the clothes for her - longer conversation)"
 msgstr ""
 
-#. [event]
-#: A_New_Order/macros/elvish_macros.cfg:231
+#. [event]: id=Kyobaine_recall_clothing_banter
+#: A_New_Order/macros/elvish_macros.cfg:233
 msgid "(Let her get the clothes herself - end event more quickly)"
 msgstr ""
 
-#. [event]
-#: A_New_Order/macros/elvish_macros.cfg:233
+#. [event]: id=Kyobaine_recall_clothing_banter
+#: A_New_Order/macros/elvish_macros.cfg:235
 msgid "Are you sure you wouldn't prefer it if I went and bought you better winter clothes instead? That way you could stay by a campfire while you wait."
 msgstr ""
 
-#. [event]
-#: A_New_Order/macros/elvish_macros.cfg:234
+#. [event]: id=Kyobaine_recall_clothing_banter
+#: A_New_Order/macros/elvish_macros.cfg:236
 msgid "To be honest, I don't really trust you after you called me out here like this. Someone with judgment like that can hardly be expected to correctly purchase the clothes I require."
 msgstr ""
 
-#. [event]
-#: A_New_Order/macros/elvish_macros.cfg:235
+#. [event]: id=Kyobaine_recall_clothing_banter
+#: A_New_Order/macros/elvish_macros.cfg:237
 msgid "What, do you require them in a particular size or something? What are your measurements?"
 msgstr ""
 
-#. [event]
-#: A_New_Order/macros/elvish_macros.cfg:236
+#. [event]: id=Kyobaine_recall_clothing_banter
+#: A_New_Order/macros/elvish_macros.cfg:238
 msgid "My... measurements? What do you mean by that? Do you mean you humans measure yourselves before deciding what clothing to purchase?"
 msgstr ""
 
-#. [event]
-#: A_New_Order/macros/elvish_macros.cfg:237
+#. [event]: id=Kyobaine_recall_clothing_banter
+#: A_New_Order/macros/elvish_macros.cfg:239
 msgid "I mean, yeah, we do; how do you elves make sure you get the proper fit?"
 msgstr ""
 
-#. [event]
-#: A_New_Order/macros/elvish_macros.cfg:238
+#. [event]: id=Kyobaine_recall_clothing_banter
+#: A_New_Order/macros/elvish_macros.cfg:240
 msgid "Why, we simply wander the woods hugging trees until -"
 msgstr ""
 
-#. [event]
-#: A_New_Order/macros/elvish_macros.cfg:239
+#. [event]: id=Kyobaine_recall_clothing_banter
+#: A_New_Order/macros/elvish_macros.cfg:241
 msgid "Wait, hold up, you literally HUG TREES?!"
 msgstr ""
 
-#. [event]
-#: A_New_Order/macros/elvish_macros.cfg:240
+#. [event]: id=Kyobaine_recall_clothing_banter
+#: A_New_Order/macros/elvish_macros.cfg:242
 msgid "Why yes, of course, haven't you ever tried it?"
 msgstr ""
 
-#. [event]
-#: A_New_Order/macros/elvish_macros.cfg:241
+#. [event]: id=Kyobaine_recall_clothing_banter
+#: A_New_Order/macros/elvish_macros.cfg:243
 msgid "Ha, that's hilarious! (*<i>catches breath from laughing</i>*) But, to answer your question, no, I haven't. Akladians raise their children to fear trees, and thus the only interaction we are allowed to have with trees is chopping them down."
 msgstr ""
 
-#. [event]
-#: A_New_Order/macros/elvish_macros.cfg:242
+#. [event]: id=Kyobaine_recall_clothing_banter
+#: A_New_Order/macros/elvish_macros.cfg:244
 msgid "How horrible! You really must try hugging a tree some day, for your own well-being. But, to return to the previous topic, the way we ensure our clothes fit is to wander the woods hugging trees until one lets the vines growing around it return our embrace in a way that feels just right, and then the vines will form new clothes for us based on this experience."
 msgstr ""
 
-#. [event]
-#: A_New_Order/macros/elvish_macros.cfg:243
+#. [event]: id=Kyobaine_recall_clothing_banter
+#: A_New_Order/macros/elvish_macros.cfg:245
 msgid "OK, well, it's winter, so I don't think any of the trees around here have vines that would really feel up to that... Could you please try the human measurement system instead just this one time?"
 msgstr ""
 
-#. [event]
-#: A_New_Order/macros/elvish_macros.cfg:244
+#. [event]: id=Kyobaine_recall_clothing_banter
+#: A_New_Order/macros/elvish_macros.cfg:246
 msgid "All right, what measurements do you require? The length of my ears?"
 msgstr ""
 
-#. [event]
-#: A_New_Order/macros/elvish_macros.cfg:245
+#. [event]: id=Kyobaine_recall_clothing_banter
+#: A_New_Order/macros/elvish_macros.cfg:250
 msgid "No, it's, ah, er... (*<i>blushes</i>*) ...you know what, maybe it would be better to have one of your fellow females explain this to you... look, there are Lorin and Karen over there; let's go ask one of them."
 msgstr ""
 
-#. [event]
-#: A_New_Order/macros/elvish_macros.cfg:246
+#. [event]: id=Kyobaine_recall_clothing_banter
+#: A_New_Order/macros/elvish_macros.cfg:251
 msgid "Let's ask..."
 msgstr ""
 
-#. [event]
-#: A_New_Order/macros/elvish_macros.cfg:247
+#. [event]: id=Kyobaine_recall_clothing_banter
+#: A_New_Order/macros/elvish_macros.cfg:252
 msgid "person_to_ask^Lorin."
 msgstr ""
 
-#. [event]
-#: A_New_Order/macros/elvish_macros.cfg:248
+#. [event]: id=Kyobaine_recall_clothing_banter
+#: A_New_Order/macros/elvish_macros.cfg:253
 msgid "person_to_ask^Karen."
 msgstr ""
 
-#. [event]
-#: A_New_Order/macros/elvish_macros.cfg:250
+#. [event]: id=Kyobaine_recall_clothing_banter
+#: A_New_Order/macros/elvish_macros.cfg:255
+msgid "No, it's, ah, er... (*<i>blushes</i>*) ...you know what, maybe it would be better to have someone female explain this to you... look, there's Karen over there; let's go ask her."
+msgstr ""
+
+#. [event]: id=Kyobaine_recall_clothing_banter
+#: A_New_Order/macros/elvish_macros.cfg:259
 msgid "Hi, mother, I was just wondering if you could help explain human measurements to Kyobaine here?"
 msgstr ""
 
-#. [event]
-#: A_New_Order/macros/elvish_macros.cfg:251
+#. [event]: id=Kyobaine_recall_clothing_banter
+#: A_New_Order/macros/elvish_macros.cfg:260
 msgid "Measurements? You mean like how far I can drive my knife into someone's back?"
 msgstr ""
 
-#. [event]
-#: A_New_Order/macros/elvish_macros.cfg:252
+#. [event]: id=Kyobaine_recall_clothing_banter
+#: A_New_Order/macros/elvish_macros.cfg:261
 msgid "No, of course not! I meant for clothing."
 msgstr ""
 
-#. [event]
-#: A_New_Order/macros/elvish_macros.cfg:253
+#. [event]: id=Kyobaine_recall_clothing_banter
+#: A_New_Order/macros/elvish_macros.cfg:262
 msgid "Oh right, THOSE kinds of measurements. I don't remember them myself. I usually let an underling servant take them, and then kill him after he has returned with the clothes, so that he can't go leaking my secrets to anyone else."
 msgstr ""
 
+#. [event]: id=Kyobaine_recall_clothing_banter
 #. [event]
 #. [scenario]: id=14b_Bontom
-#: A_New_Order/macros/elvish_macros.cfg:254
-#: A_New_Order/scenarios/12_Leaving_Raedwood.cfg:314
-#: A_New_Order/scenarios/12_Leaving_Raedwood.cfg:356
+#: A_New_Order/macros/elvish_macros.cfg:263
+#: A_New_Order/scenarios/12_Leaving_Raedwood.cfg:316
+#: A_New_Order/scenarios/12_Leaving_Raedwood.cfg:358
 #: A_New_Order/scenarios/14b_Bontom.cfg:76
 #: A_New_Order/scenarios/14b_Bontom.cfg:78
 msgid "..."
 msgstr ""
 
-#. [event]
-#: A_New_Order/macros/elvish_macros.cfg:256
+#. [event]: id=Kyobaine_recall_clothing_banter
+#: A_New_Order/macros/elvish_macros.cfg:265
 msgid "You know what, forget I asked. Kyobaine, maybe you should just go get your own clothes after all."
 msgstr ""
 
-#. [event]
-#: A_New_Order/macros/elvish_macros.cfg:257
+#. [event]: id=Kyobaine_recall_clothing_banter
+#: A_New_Order/macros/elvish_macros.cfg:266
 msgid "Well that was a waste of time. All that talk just to get back to what my original plan was in the first place..."
 msgstr ""
 
-#. [event]
-#: A_New_Order/macros/elvish_macros.cfg:260
+#. [event]: id=Kyobaine_recall_clothing_banter
+#: A_New_Order/macros/elvish_macros.cfg:269
 msgid "Hey Karen, I was just wondering if you could help explain human clothing measurements to Kyobaine here?"
 msgstr ""
 
-#. [event]
-#: A_New_Order/macros/elvish_macros.cfg:261
+#. [event]: id=Kyobaine_recall_clothing_banter
+#: A_New_Order/macros/elvish_macros.cfg:270
 msgid "Oooh, clothes shopping, are we? Got a big date coming up, eh, Kyobaine?"
 msgstr ""
 
-#. [event]
-#: A_New_Order/macros/elvish_macros.cfg:262
+#. [event]: id=Kyobaine_recall_clothing_banter
+#: A_New_Order/macros/elvish_macros.cfg:271
 msgid "What? No! I'm just cold and need a cloak."
 msgstr ""
 
-#. [event]
-#: A_New_Order/macros/elvish_macros.cfg:263
+#. [event]: id=Kyobaine_recall_clothing_banter
+#: A_New_Order/macros/elvish_macros.cfg:272
 msgid "Oh, a cloak, that's all? You don't even need sizes for those, they're mostly one-size-fits-all. Size info would really only be necessary if you were going to replace your entire robe."
 msgstr ""
 
-#. [event]
-#: A_New_Order/macros/elvish_macros.cfg:264
+#. [event]: id=Kyobaine_recall_clothing_banter
+#: A_New_Order/macros/elvish_macros.cfg:273
 msgid "Oh. So, what was this fuss about sizes all about again? ...Gawen?"
 msgstr ""
 
-#. [event]
-#: A_New_Order/macros/elvish_macros.cfg:265
+#. [event]: id=Kyobaine_recall_clothing_banter
+#: A_New_Order/macros/elvish_macros.cfg:274
 msgid "What? I was just trying to be helpful."
 msgstr ""
 
-#. [event]
-#: A_New_Order/macros/elvish_macros.cfg:266
+#. [event]: id=Kyobaine_recall_clothing_banter
+#: A_New_Order/macros/elvish_macros.cfg:275
 msgid "(*<i>snickers</i>*)"
 msgstr ""
 
-#. [event]
-#: A_New_Order/macros/elvish_macros.cfg:267
+#. [event]: id=Kyobaine_recall_clothing_banter
+#: A_New_Order/macros/elvish_macros.cfg:276
 msgid "Well, I think I shall be fine buying my own cloak, Gawen. You just stay here while I go find a tailor."
 msgstr ""
 
-#. [event]
-#: A_New_Order/macros/elvish_macros.cfg:270
+#. [event]: id=Kyobaine_recall_clothing_banter
+#: A_New_Order/macros/elvish_macros.cfg:279
 msgid "I think I saw a tailor just back that way that you could buy something from."
 msgstr ""
 
-#. [event]
-#: A_New_Order/macros/elvish_macros.cfg:298
+#. [event]: id=Kyobaine_recall_clothing_banter
+#: A_New_Order/macros/elvish_macros.cfg:307
 msgid "Uh... she <i>is</i> coming back, isn't she?"
 msgstr ""
 
-#. [event]
+#. [event]: id=Kyobaine_recall_clothing_banter
 #. [then]
-#: A_New_Order/macros/elvish_macros.cfg:305
-#: A_New_Order/scenarios/16_Choosing_the_Best.cfg:313
+#: A_New_Order/macros/elvish_macros.cfg:314
+#: A_New_Order/scenarios/16_Choosing_the_Best.cfg:314
 msgid "...yes?"
 msgstr ""
 
-#. [event]
-#: A_New_Order/macros/elvish_macros.cfg:306
+#. [event]: id=Kyobaine_recall_clothing_banter
+#: A_New_Order/macros/elvish_macros.cfg:315
 msgid "...!"
 msgstr ""
 
-#. [event]
-#: A_New_Order/macros/elvish_macros.cfg:307
+#. [event]: id=Kyobaine_recall_clothing_banter
+#: A_New_Order/macros/elvish_macros.cfg:316
 msgid "...why do you look so surprised? I <i>did</i> say I was going to buy better winter clothes, didn't I? I think this cloak shall do just fine."
 msgstr ""
 
-#. [event]
+#. [event]: id=Kyobaine_recall_clothing_banter
 #. Gawen is tongue-tied by Kyobaine's reappearance:
-#: A_New_Order/macros/elvish_macros.cfg:309
+#: A_New_Order/macros/elvish_macros.cfg:318
 msgid "...yes, well, indeed! Carry on, then!"
 msgstr ""
 
-#. [event]
-#: A_New_Order/macros/elvish_macros.cfg:310
+#. [event]: id=Kyobaine_recall_clothing_banter
+#: A_New_Order/macros/elvish_macros.cfg:319
 msgid "Humans... their reactions can be so strange sometimes..."
 msgstr ""
 
-#. [event]
-#: A_New_Order/macros/elvish_macros.cfg:316
+#. [event]: id=Kyobaine_recall_clothing_banter
+#: A_New_Order/macros/elvish_macros.cfg:325
 msgid "Hey, give back my gold!"
 msgstr ""
 
-#. [event]
-#: A_New_Order/macros/elvish_macros.cfg:320
+#. [event]: id=Kyobaine_recall_clothing_banter
+#: A_New_Order/macros/elvish_macros.cfg:329
 msgid "Stingy bastard."
 msgstr ""
 
@@ -1206,11 +1217,11 @@ msgstr ""
 msgid "This is a debug message. If you see it, then it means I forgot to delete it from the release scenario. "
 msgstr ""
 
-#: A_New_Order/macros/ano_macros.cfg:1112
+#: A_New_Order/macros/ano_macros.cfg:1116
 msgid "The unit $ano_loyal[0].name became LOYAL."
 msgstr ""
 
-#: A_New_Order/macros/ano_macros.cfg:1120
+#: A_New_Order/macros/ano_macros.cfg:1124
 msgid "Scenario notes:"
 msgstr ""
 
@@ -1296,7 +1307,7 @@ msgstr ""
 
 #. [event]
 #: A_New_Order/macros/conversations.cfg:45
-#: A_New_Order/scenarios/12_Leaving_Raedwood.cfg:254
+#: A_New_Order/scenarios/12_Leaving_Raedwood.cfg:256
 msgid "What?!?"
 msgstr ""
 
@@ -1567,72 +1578,77 @@ msgstr ""
 msgid "You fool! He is a mixling, he can't be our king!"
 msgstr ""
 
-#: A_New_Order/macros/ano-01_06macros.cfg:214
+#. [event]
+#: A_New_Order/macros/ano-01_06macros.cfg:220
+msgid "Please, feel free to use any villages I capture, my king! I have no plans for them myself!"
+msgstr ""
+
+#: A_New_Order/macros/ano-01_06macros.cfg:227
 msgid "No! That's impossible! You will pay for that, treacherous dogs! Your sons at Vattin are as good as dead!"
 msgstr ""
 
-#: A_New_Order/macros/ano-01_06macros.cfg:215
+#: A_New_Order/macros/ano-01_06macros.cfg:228
 msgid "You really thought I would send my son to Vattin? You are so easy to fool! That boy at Vattin is not of my blood. Now, prepare to go straight to hell."
 msgstr ""
 
-#: A_New_Order/macros/ano-01_06macros.cfg:216
+#: A_New_Order/macros/ano-01_06macros.cfg:229
 msgid "This isn't a total surprise to me. My king, we have to escape."
 msgstr ""
 
-#: A_New_Order/macros/ano-01_06macros.cfg:217
+#: A_New_Order/macros/ano-01_06macros.cfg:230
 msgid "How?"
 msgstr ""
 
 #. this was previously part of Reme's previous string, but I split it off to make the player pay more attention:
-#: A_New_Order/macros/ano-01_06macros.cfg:219
+#: A_New_Order/macros/ano-01_06macros.cfg:232
 msgid "We have two ways to out of this trap: there is one way to the west..."
 msgstr ""
 
-#: A_New_Order/macros/ano-01_06macros.cfg:233
+#: A_New_Order/macros/ano-01_06macros.cfg:246
 msgid "...and another way to the east."
 msgstr ""
 
-#: A_New_Order/macros/ano-01_06macros.cfg:247
+#: A_New_Order/macros/ano-01_06macros.cfg:260
 msgid "Which one is better?"
 msgstr ""
 
 #. the "silver saddle" here was golden previously, but I didn't want players getting confused with gold as in the currency, and plus "silver" gets us an alliteration:
-#: A_New_Order/macros/ano-01_06macros.cfg:249
+#: A_New_Order/macros/ano-01_06macros.cfg:262
 msgid "There is no difference, really. We can use either to reach Vattin. The eastern one leads amidst swamps and forests, while the western one leads through the hills and grasslands. God, I swear to sacrifice a horse if you will help us survive this. A whole, beautiful horse. And I will add a silver saddle!"
 msgstr ""
 
-#: A_New_Order/macros/ano-01_06macros.cfg:250
+#: A_New_Order/macros/ano-01_06macros.cfg:263
 msgid "Reme, take my step-mother and protect her. I will stay here to guard your rear during withdrawal."
 msgstr ""
 
-#: A_New_Order/macros/ano-01_06macros.cfg:251
+#: A_New_Order/macros/ano-01_06macros.cfg:264
 msgid "No! That's suicide! I won't let you!"
 msgstr ""
 
-#: A_New_Order/macros/ano-01_06macros.cfg:252
+#: A_New_Order/macros/ano-01_06macros.cfg:265
 msgid "Reme, take her and go. That is an order. And this is not suicide; I will follow you as soon as possible."
 msgstr ""
 
-#: A_New_Order/macros/ano-01_06macros.cfg:253
+#: A_New_Order/macros/ano-01_06macros.cfg:266
 msgid "I can't. I won't. I won't leave you, my lord."
 msgstr ""
 
-#: A_New_Order/macros/ano-01_06macros.cfg:254
+#: A_New_Order/macros/ano-01_06macros.cfg:267
 msgid "That's an order! Reme, if I run from a fight, who will respect me? I am not suicidal, believe me. And you must live; I order you to escort Lady Lorin safely out of this mess. And make sure to bring some loyal guards with you, too!"
 msgstr ""
 
 #. [objectives]
-#: A_New_Order/macros/ano-01_06macros.cfg:260
+#: A_New_Order/macros/ano-01_06macros.cfg:273
 msgid "Any unit which reaches either signpost will be evacuated and join Lorin and Reme's party. Gawen will be refunded the cost of evacuated loyal units. Units not recalled will be lost. Units that do not escape will also be lost. Gawen must not escape, or he would be considered an unworthy coward by his soldiers. Lorin will get a bonus applied to her own pool of gold for each turn Gawen resists beyond the required limit. Note that Lorin's gold is separate from Gawen's, so she will not be able to access any gold that he has left over after this scenario. Thus, it is better if Gawen spends all gold available to him now."
 msgstr ""
 
 #. [objective]: condition=lose
-#: A_New_Order/macros/ano-01_06macros.cfg:266
+#: A_New_Order/macros/ano-01_06macros.cfg:279
 #: A_New_Order/macros/ano-14macros.cfg:18
 #: A_New_Order/scenarios/25_The_Awakening.cfg:748
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:596
-#: A_New_Order/scenarios/05_Unexpected_Guests.cfg:246
-#: A_New_Order/scenarios/05_Unexpected_Guests.cfg:349
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:599
+#: A_New_Order/scenarios/05_Unexpected_Guests.cfg:283
+#: A_New_Order/scenarios/05_Unexpected_Guests.cfg:387
 #: A_New_Order/scenarios/21a_Abducted_Bride.cfg:399
 #: A_New_Order/scenarios/21a_Abducted_Bride.cfg:428
 #: A_New_Order/scenarios/23_Trapped.cfg:913
@@ -1642,68 +1658,68 @@ msgstr ""
 #: A_New_Order/scenarios/19c_The_Oracle.cfg:1574
 #: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:500
 #: A_New_Order/scenarios/27_Orannon.cfg:746
-#: A_New_Order/scenarios/27_Orannon.cfg:1146
-#: A_New_Order/scenarios/02_Fighting_for_Passage.cfg:351
+#: A_New_Order/scenarios/27_Orannon.cfg:1147
+#: A_New_Order/scenarios/02_Fighting_for_Passage.cfg:352
 #: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:540
-#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:262
+#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:298
 #: A_New_Order/scenarios/10_Siege_of_Haeltin.cfg:423
-#: A_New_Order/scenarios/09_Hired_Swords.cfg:254
+#: A_New_Order/scenarios/09_Hired_Swords.cfg:256
 msgid "Death of Lady Lorin"
 msgstr ""
 
 #. [objective]: condition=lose
-#: A_New_Order/macros/ano-01_06macros.cfg:270
-#: A_New_Order/scenarios/05_Unexpected_Guests.cfg:250
-#: A_New_Order/scenarios/05_Unexpected_Guests.cfg:353
+#: A_New_Order/macros/ano-01_06macros.cfg:283
+#: A_New_Order/scenarios/05_Unexpected_Guests.cfg:287
+#: A_New_Order/scenarios/05_Unexpected_Guests.cfg:391
 #: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:504
-#: A_New_Order/scenarios/02_Fighting_for_Passage.cfg:355
+#: A_New_Order/scenarios/02_Fighting_for_Passage.cfg:356
 #: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:544
-#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:266
+#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:302
 msgid "Death of Reme Carrenemoe"
 msgstr ""
 
 #. [objective]: condition=lose
-#: A_New_Order/macros/ano-01_06macros.cfg:274
+#: A_New_Order/macros/ano-01_06macros.cfg:287
 msgid "Cowardly escape of Gawen Hagarthen"
 msgstr ""
 
 #. [then]
-#: A_New_Order/macros/ano-01_06macros.cfg:388
+#: A_New_Order/macros/ano-01_06macros.cfg:414
 msgid "I can't just run away. I don't want to. I would prefer to die here, fighting."
 msgstr ""
 
 #. [then]
-#: A_New_Order/macros/ano-01_06macros.cfg:409
+#: A_New_Order/macros/ano-01_06macros.cfg:435
 msgid "Reme, you have to take care of Lorin! She went the other way"
 msgstr ""
 
 #. [else]
-#: A_New_Order/macros/ano-01_06macros.cfg:412
+#: A_New_Order/macros/ano-01_06macros.cfg:438
 msgid "Take care, Reme Carrenemoe."
 msgstr ""
 
 #. [else]
-#: A_New_Order/macros/ano-01_06macros.cfg:413
+#: A_New_Order/macros/ano-01_06macros.cfg:439
 msgid "Respect, my king. Follow us as soon as possible!"
 msgstr ""
 
 #. [else]
-#: A_New_Order/macros/ano-01_06macros.cfg:414
+#: A_New_Order/macros/ano-01_06macros.cfg:440
 msgid "Yes... of course. I'm afraid that means... never."
 msgstr ""
 
 #. [then]
-#: A_New_Order/macros/ano-01_06macros.cfg:447
+#: A_New_Order/macros/ano-01_06macros.cfg:473
 msgid "Mother, you have to go the other way. Reme is waiting for you there!"
 msgstr ""
 
 #. [else]
-#: A_New_Order/macros/ano-01_06macros.cfg:450
+#: A_New_Order/macros/ano-01_06macros.cfg:476
 msgid "No! I won't leave you! I don't want to! Let's die together!"
 msgstr ""
 
 #. [else]
-#: A_New_Order/macros/ano-01_06macros.cfg:451
+#: A_New_Order/macros/ano-01_06macros.cfg:477
 msgid "Take her to safety, men!"
 msgstr ""
 
@@ -1781,12 +1797,12 @@ msgstr ""
 #: A_New_Order/scenarios/20_Okladia.cfg:449
 #: A_New_Order/scenarios/20_Okladia.cfg:459
 #: A_New_Order/scenarios/20_Okladia.cfg:466
-#: A_New_Order/scenarios/13_Scouting.cfg:719
-#: A_New_Order/scenarios/13_Scouting.cfg:728
-#: A_New_Order/scenarios/13_Scouting.cfg:738
-#: A_New_Order/scenarios/13_Scouting.cfg:745
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:564
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:571
+#: A_New_Order/scenarios/13_Scouting.cfg:720
+#: A_New_Order/scenarios/13_Scouting.cfg:729
+#: A_New_Order/scenarios/13_Scouting.cfg:739
+#: A_New_Order/scenarios/13_Scouting.cfg:746
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:565
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:572
 msgid "I changed my mind"
 msgstr ""
 
@@ -1968,10 +1984,10 @@ msgstr ""
 #: A_New_Order/scenarios/23_Trapped.cfg:667
 #: A_New_Order/scenarios/22_Leaving_Okladia.cfg:679
 #: A_New_Order/scenarios/21b_Haunted_Place.cfg:346
-#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:2235
-#: A_New_Order/scenarios/09_Hired_Swords.cfg:367
-#: A_New_Order/scenarios/09_Hired_Swords.cfg:465
-#: A_New_Order/scenarios/09_Hired_Swords.cfg:614
+#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:2261
+#: A_New_Order/scenarios/09_Hired_Swords.cfg:370
+#: A_New_Order/scenarios/09_Hired_Swords.cfg:468
+#: A_New_Order/scenarios/09_Hired_Swords.cfg:617
 msgid "You have received $gold_amt gold pieces."
 msgstr ""
 
@@ -2048,7 +2064,7 @@ msgstr ""
 #. [event]
 #. [option]
 #: A_New_Order/macros/ano-20macros.cfg:282
-#: A_New_Order/scenarios/08_Outlaw_Base.cfg:391
+#: A_New_Order/scenarios/08_Outlaw_Base.cfg:392
 msgid "That's all I wanted to know"
 msgstr ""
 
@@ -2240,9 +2256,9 @@ msgstr ""
 #. [scenario]: id=13_Scouting
 #: A_New_Order/macros/ano-20macros.cfg:352
 #: A_New_Order/scenarios/13_Scouting.cfg:166
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:232
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:383
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:492
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:233
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:384
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:493
 msgid "Because..."
 msgstr ""
 
@@ -2304,8 +2320,8 @@ msgstr ""
 #: A_New_Order/scenarios/20_Okladia.cfg:409
 #: A_New_Order/scenarios/25_The_Awakening.cfg:1190
 #: A_New_Order/scenarios/25_The_Awakening.cfg:1218
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:57
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:92
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:58
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:93
 #: A_New_Order/scenarios/21a_Abducted_Bride.cfg:581
 #: A_New_Order/scenarios/21a_Abducted_Bride.cfg:26
 #: A_New_Order/scenarios/21a_Abducted_Bride.cfg:56
@@ -2314,10 +2330,10 @@ msgstr ""
 #: A_New_Order/scenarios/14b_Bontom.cfg:565
 #: A_New_Order/scenarios/14b_Bontom.cfg:608
 #: A_New_Order/scenarios/14b_Bontom.cfg:615
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:226
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:317
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:378
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:487
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:227
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:318
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:379
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:488
 msgid "That's all I wanted to know."
 msgstr ""
 
@@ -2640,7 +2656,7 @@ msgstr ""
 #. [scenario]: id=08_Outlaw_Base
 #: A_New_Order/macros/ano-20macros.cfg:527
 #: A_New_Order/scenarios/08_Outlaw_Base.cfg:44
-#: A_New_Order/scenarios/08_Outlaw_Base.cfg:456
+#: A_New_Order/scenarios/08_Outlaw_Base.cfg:457
 #: A_New_Order/scenarios/08_Outlaw_Base.cfg:171
 msgid "Rob Roe"
 msgstr ""
@@ -2943,8 +2959,8 @@ msgstr ""
 #: A_New_Order/macros/ano-14macros.cfg:4
 #: A_New_Order/scenarios/25_The_Awakening.cfg:744
 #: A_New_Order/scenarios/15c_Raedwood_East.cfg:220
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:592
-#: A_New_Order/scenarios/07_Ally_From_the_Past.cfg:360
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:595
+#: A_New_Order/scenarios/07_Ally_From_the_Past.cfg:361
 #: A_New_Order/scenarios/21a_Abducted_Bride.cfg:395
 #: A_New_Order/scenarios/21a_Abducted_Bride.cfg:424
 #: A_New_Order/scenarios/19a_The_Woods_of_Okladia.cfg:189
@@ -2954,8 +2970,8 @@ msgstr ""
 #: A_New_Order/scenarios/21b_Haunted_Place.cfg:217
 #: A_New_Order/scenarios/19c_The_Oracle.cfg:1570
 #: A_New_Order/scenarios/27_Orannon.cfg:754
-#: A_New_Order/scenarios/27_Orannon.cfg:1154
-#: A_New_Order/scenarios/12_Leaving_Raedwood.cfg:224
+#: A_New_Order/scenarios/27_Orannon.cfg:1155
+#: A_New_Order/scenarios/12_Leaving_Raedwood.cfg:225
 #: A_New_Order/scenarios/08_Outlaw_Base.cfg:219
 msgid "Death of Ruvio"
 msgstr ""
@@ -2964,8 +2980,8 @@ msgstr ""
 #: A_New_Order/macros/ano-14macros.cfg:8
 #: A_New_Order/scenarios/25_The_Awakening.cfg:740
 #: A_New_Order/scenarios/15c_Raedwood_East.cfg:224
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:588
-#: A_New_Order/scenarios/07_Ally_From_the_Past.cfg:356
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:591
+#: A_New_Order/scenarios/07_Ally_From_the_Past.cfg:357
 #: A_New_Order/scenarios/21a_Abducted_Bride.cfg:391
 #: A_New_Order/scenarios/21a_Abducted_Bride.cfg:420
 #: A_New_Order/scenarios/23_Trapped.cfg:905
@@ -2978,10 +2994,10 @@ msgstr ""
 #: A_New_Order/scenarios/19c_The_Oracle.cfg:1566
 #: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:496
 #: A_New_Order/scenarios/27_Orannon.cfg:742
-#: A_New_Order/scenarios/27_Orannon.cfg:1142
-#: A_New_Order/scenarios/12_Leaving_Raedwood.cfg:216
+#: A_New_Order/scenarios/27_Orannon.cfg:1143
+#: A_New_Order/scenarios/12_Leaving_Raedwood.cfg:217
 #: A_New_Order/scenarios/08_Outlaw_Base.cfg:215
-#: A_New_Order/scenarios/02_Fighting_for_Passage.cfg:347
+#: A_New_Order/scenarios/02_Fighting_for_Passage.cfg:348
 #: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:536
 msgid "Death of Gawen Hagarthen"
 msgstr ""
@@ -2989,9 +3005,9 @@ msgstr ""
 #. [objective]: condition=lose
 #: A_New_Order/macros/ano-14macros.cfg:12
 #: A_New_Order/scenarios/15c_Raedwood_East.cfg:228
-#: A_New_Order/scenarios/07_Ally_From_the_Past.cfg:364
+#: A_New_Order/scenarios/07_Ally_From_the_Past.cfg:365
 #: A_New_Order/scenarios/15b_Repelling_the_Orcs.cfg:104
-#: A_New_Order/scenarios/12_Leaving_Raedwood.cfg:220
+#: A_New_Order/scenarios/12_Leaving_Raedwood.cfg:221
 #: A_New_Order/scenarios/08_Outlaw_Base.cfg:223
 msgid "Death of Karen"
 msgstr ""
@@ -3228,9 +3244,9 @@ msgstr ""
 #: A_New_Order/macros/messages.cfg:19
 #: A_New_Order/macros/messages.cfg:23
 #: A_New_Order/macros/messages.cfg:27
-#: A_New_Order/scenarios/15c_Raedwood_East.cfg:290
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:650
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:693
+#: A_New_Order/scenarios/15c_Raedwood_East.cfg:294
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:654
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:697
 #: A_New_Order/scenarios/21a_Abducted_Bride.cfg:617
 #: A_New_Order/scenarios/21a_Abducted_Bride.cfg:632
 msgid "Gawen"
@@ -3294,7 +3310,7 @@ msgstr ""
 #: A_New_Order/scenarios/28_Lorin.cfg:162
 #: A_New_Order/scenarios/28_Lorin.cfg:227
 #: A_New_Order/scenarios/27_Orannon.cfg:95
-#: A_New_Order/scenarios/15_Back_in_Freetown.cfg:71
+#: A_New_Order/scenarios/15_Back_in_Freetown.cfg:72
 #: A_New_Order/scenarios/11_Council_in_Freetown.cfg:59
 #: A_New_Order/scenarios/24_Fall_of_Freetown.cfg:75
 #: A_New_Order/scenarios/26_Return_of_the_King.cfg:66
@@ -3316,13 +3332,13 @@ msgstr ""
 #: A_New_Order/scenarios/20_Okladia.cfg:448
 #: A_New_Order/scenarios/20_Okladia.cfg:458
 #: A_New_Order/scenarios/20_Okladia.cfg:465
-#: A_New_Order/scenarios/13_Scouting.cfg:717
-#: A_New_Order/scenarios/13_Scouting.cfg:726
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:702
+#: A_New_Order/scenarios/13_Scouting.cfg:718
+#: A_New_Order/scenarios/13_Scouting.cfg:727
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:706
 #: A_New_Order/scenarios/21a_Abducted_Bride.cfg:607
 #: A_New_Order/scenarios/28_Lorin.cfg:3
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:563
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:570
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:564
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:571
 msgid "Lorin"
 msgstr ""
 
@@ -3331,21 +3347,21 @@ msgstr ""
 #: A_New_Order/macros/messages.cfg:98
 #: A_New_Order/scenarios/20_Okladia.cfg:438
 #: A_New_Order/scenarios/20_Okladia.cfg:447
-#: A_New_Order/scenarios/13_Scouting.cfg:716
-#: A_New_Order/scenarios/13_Scouting.cfg:737
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:642
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:679
+#: A_New_Order/scenarios/13_Scouting.cfg:717
+#: A_New_Order/scenarios/13_Scouting.cfg:738
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:646
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:683
 #: A_New_Order/scenarios/21a_Abducted_Bride.cfg:612
 #: A_New_Order/scenarios/21a_Abducted_Bride.cfg:627
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:562
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:563
 msgid "Reme"
 msgstr ""
 
 #. [event]
 #: A_New_Order/macros/messages.cfg:117
 #: A_New_Order/macros/messages.cfg:122
-#: A_New_Order/scenarios/13_Scouting.cfg:718
-#: A_New_Order/scenarios/13_Scouting.cfg:727
+#: A_New_Order/scenarios/13_Scouting.cfg:719
+#: A_New_Order/scenarios/13_Scouting.cfg:728
 msgid "Yahyazad"
 msgstr ""
 
@@ -3358,14 +3374,14 @@ msgstr ""
 #. [unit]: id=Mithrandil, type=Elvish Lord
 #: A_New_Order/macros/messages.cfg:139
 #: A_New_Order/scenarios/15a_The_Preparations.cfg:53
-#: A_New_Order/scenarios/15_Back_in_Freetown.cfg:63
+#: A_New_Order/scenarios/15_Back_in_Freetown.cfg:64
 #: A_New_Order/scenarios/11_Council_in_Freetown.cfg:50
 msgid "Mithrandil"
 msgstr ""
 
 #. [unit]: type=Peasant, id=Matthew Eagles-Eye
 #: A_New_Order/macros/messages.cfg:178
-#: A_New_Order/scenarios/13_Scouting.cfg:894
+#: A_New_Order/scenarios/13_Scouting.cfg:895
 msgid "Matthew Eagle's-Eye"
 msgstr ""
 
@@ -3380,9 +3396,9 @@ msgstr ""
 #. [side]: id=Assassin
 #. [unit]: id=Assassin
 #: A_New_Order/macros/messages.cfg:186
-#: A_New_Order/scenarios/02_Fighting_for_Passage.cfg:657
+#: A_New_Order/scenarios/02_Fighting_for_Passage.cfg:659
 #: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:431
-#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:574
+#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:575
 msgid "Assassin"
 msgstr ""
 
@@ -3772,9 +3788,9 @@ msgstr ""
 #: A_New_Order/scenarios/15a_The_Preparations.cfg:32
 #: A_New_Order/scenarios/15c_Raedwood_East.cfg:35
 #: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:46
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:159
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:755
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:778
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:160
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:759
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:782
 #: A_New_Order/scenarios/21d_Ruins_of_Weldyn.cfg:58
 #: A_New_Order/scenarios/07_Ally_From_the_Past.cfg:67
 #: A_New_Order/scenarios/21a_Abducted_Bride.cfg:112
@@ -3796,12 +3812,12 @@ msgstr ""
 #: A_New_Order/scenarios/12_Leaving_Raedwood.cfg:71
 #: A_New_Order/scenarios/08_Outlaw_Base.cfg:29
 #: A_New_Order/scenarios/14b_Bontom.cfg:141
-#: A_New_Order/scenarios/15_Back_in_Freetown.cfg:44
+#: A_New_Order/scenarios/15_Back_in_Freetown.cfg:45
 #: A_New_Order/scenarios/30_Final.cfg:64
 #: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:76
 #: A_New_Order/scenarios/11_Council_in_Freetown.cfg:31
 #: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:45
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:299
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:300
 #: A_New_Order/scenarios/24_Fall_of_Freetown.cfg:62
 #: A_New_Order/scenarios/02_Fighting_for_Passage.cfg:63
 #: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:126
@@ -3889,13 +3905,12 @@ msgstr ""
 #: A_New_Order/scenarios/20_Okladia.cfg:208
 #: A_New_Order/scenarios/20_Okladia.cfg:228
 #: A_New_Order/scenarios/20_Okladia.cfg:253
-#: A_New_Order/scenarios/13_Scouting.cfg:526
-#: A_New_Order/scenarios/13_Scouting.cfg:550
-#: A_New_Order/scenarios/13_Scouting.cfg:586
-#: A_New_Order/scenarios/13_Scouting.cfg:883
-#: A_New_Order/scenarios/13_Scouting.cfg:915
-#: A_New_Order/scenarios/13_Scouting.cfg:946
-#: A_New_Order/scenarios/15a_The_Preparations.cfg:266
+#: A_New_Order/scenarios/13_Scouting.cfg:527
+#: A_New_Order/scenarios/13_Scouting.cfg:551
+#: A_New_Order/scenarios/13_Scouting.cfg:587
+#: A_New_Order/scenarios/13_Scouting.cfg:884
+#: A_New_Order/scenarios/13_Scouting.cfg:916
+#: A_New_Order/scenarios/13_Scouting.cfg:947
 #: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:463
 #: A_New_Order/scenarios/21a_Abducted_Bride.cfg:481
 #: A_New_Order/scenarios/14d_Avenging_Ruen.cfg:183
@@ -3907,13 +3922,13 @@ msgstr ""
 #: A_New_Order/scenarios/21b_Haunted_Place.cfg:441
 #: A_New_Order/scenarios/14b_Bontom.cfg:471
 #: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:486
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:150
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:174
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:198
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:249
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:391
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:415
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:502
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:151
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:175
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:199
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:250
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:392
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:416
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:503
 msgid "Yes, definitely."
 msgstr ""
 
@@ -3924,13 +3939,12 @@ msgstr ""
 #: A_New_Order/scenarios/20_Okladia.cfg:209
 #: A_New_Order/scenarios/20_Okladia.cfg:229
 #: A_New_Order/scenarios/20_Okladia.cfg:254
-#: A_New_Order/scenarios/13_Scouting.cfg:527
-#: A_New_Order/scenarios/13_Scouting.cfg:551
-#: A_New_Order/scenarios/13_Scouting.cfg:587
-#: A_New_Order/scenarios/13_Scouting.cfg:884
-#: A_New_Order/scenarios/13_Scouting.cfg:916
-#: A_New_Order/scenarios/13_Scouting.cfg:947
-#: A_New_Order/scenarios/15a_The_Preparations.cfg:267
+#: A_New_Order/scenarios/13_Scouting.cfg:528
+#: A_New_Order/scenarios/13_Scouting.cfg:552
+#: A_New_Order/scenarios/13_Scouting.cfg:588
+#: A_New_Order/scenarios/13_Scouting.cfg:885
+#: A_New_Order/scenarios/13_Scouting.cfg:917
+#: A_New_Order/scenarios/13_Scouting.cfg:948
 #: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:464
 #: A_New_Order/scenarios/21a_Abducted_Bride.cfg:482
 #: A_New_Order/scenarios/14d_Avenging_Ruen.cfg:184
@@ -3940,13 +3954,13 @@ msgstr ""
 #: A_New_Order/scenarios/21b_Haunted_Place.cfg:442
 #: A_New_Order/scenarios/14b_Bontom.cfg:472
 #: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:487
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:151
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:175
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:199
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:250
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:392
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:416
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:503
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:152
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:176
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:200
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:251
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:393
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:417
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:504
 msgid "Well, maybe not."
 msgstr ""
 
@@ -4014,64 +4028,64 @@ msgstr ""
 #: A_New_Order/scenarios/20_Okladia.cfg:414
 #: A_New_Order/scenarios/20_Okladia.cfg:416
 #: A_New_Order/scenarios/20_Okladia.cfg:418
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:216
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:218
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:230
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:238
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:240
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:242
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:244
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:246
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:272
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:277
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:281
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:283
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:285
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:287
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:297
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:304
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:307
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:322
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:337
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:340
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:343
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:345
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:347
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:349
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:217
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:219
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:231
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:239
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:241
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:243
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:245
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:247
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:273
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:278
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:282
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:284
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:286
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:288
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:298
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:305
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:308
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:323
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:338
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:341
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:344
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:346
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:348
 #: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:350
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:352
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:351
 #: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:353
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:357
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:359
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:370
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:382
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:389
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:413
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:437
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:439
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:441
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:446
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:449
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:453
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:456
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:458
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:462
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:464
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:467
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:477
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:479
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:491
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:498
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:500
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:524
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:526
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:528
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:532
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:536
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:538
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:541
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:543
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:546
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:354
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:358
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:360
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:371
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:383
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:390
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:414
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:438
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:440
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:442
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:447
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:450
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:454
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:457
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:459
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:463
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:465
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:468
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:478
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:480
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:492
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:499
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:501
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:525
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:527
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:529
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:533
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:537
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:539
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:542
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:544
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:547
 msgid "Village leader"
 msgstr ""
 
@@ -4130,30 +4144,30 @@ msgstr ""
 #: A_New_Order/scenarios/20_Okladia.cfg:308
 #: A_New_Order/scenarios/20_Okladia.cfg:358
 #: A_New_Order/scenarios/20_Okladia.cfg:405
-#: A_New_Order/scenarios/13_Scouting.cfg:609
-#: A_New_Order/scenarios/13_Scouting.cfg:622
-#: A_New_Order/scenarios/13_Scouting.cfg:647
-#: A_New_Order/scenarios/13_Scouting.cfg:660
-#: A_New_Order/scenarios/13_Scouting.cfg:680
-#: A_New_Order/scenarios/13_Scouting.cfg:693
+#: A_New_Order/scenarios/13_Scouting.cfg:610
+#: A_New_Order/scenarios/13_Scouting.cfg:623
+#: A_New_Order/scenarios/13_Scouting.cfg:648
+#: A_New_Order/scenarios/13_Scouting.cfg:661
+#: A_New_Order/scenarios/13_Scouting.cfg:681
+#: A_New_Order/scenarios/13_Scouting.cfg:694
 #: A_New_Order/scenarios/14b_Bontom.cfg:553
 #: A_New_Order/scenarios/14b_Bontom.cfg:561
 #: A_New_Order/scenarios/14b_Bontom.cfg:603
 #: A_New_Order/scenarios/14b_Bontom.cfg:611
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:221
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:312
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:373
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:482
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:222
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:313
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:374
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:483
 msgid "Please, tell me..."
 msgstr ""
 
 #. [event]
 #: A_New_Order/scenarios/20_Okladia.cfg:309
 #: A_New_Order/scenarios/20_Okladia.cfg:406
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:222
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:313
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:374
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:483
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:223
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:314
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:375
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:484
 msgid "Would you fight for me?"
 msgstr ""
 
@@ -4161,8 +4175,8 @@ msgstr ""
 #: A_New_Order/scenarios/20_Okladia.cfg:310
 #: A_New_Order/scenarios/20_Okladia.cfg:407
 #: A_New_Order/scenarios/21a_Abducted_Bride.cfg:580
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:375
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:484
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:376
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:485
 msgid "Do you know something about the mage Deorien?"
 msgstr ""
 
@@ -4170,10 +4184,10 @@ msgstr ""
 #: A_New_Order/scenarios/20_Okladia.cfg:311
 #: A_New_Order/scenarios/20_Okladia.cfg:361
 #: A_New_Order/scenarios/20_Okladia.cfg:408
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:225
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:316
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:377
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:486
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:226
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:317
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:378
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:487
 msgid "Have you heard any interesting news recently?"
 msgstr ""
 
@@ -4259,8 +4273,8 @@ msgstr ""
 #: A_New_Order/scenarios/20_Okladia.cfg:360
 #: A_New_Order/scenarios/21a_Abducted_Bride.cfg:25
 #: A_New_Order/scenarios/21a_Abducted_Bride.cfg:55
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:223
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:314
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:224
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:315
 msgid "Do you know anything about the mage Deorien?"
 msgstr ""
 
@@ -4331,24 +4345,24 @@ msgstr ""
 #: A_New_Order/scenarios/20_Okladia.cfg:445
 #: A_New_Order/scenarios/20_Okladia.cfg:455
 #: A_New_Order/scenarios/20_Okladia.cfg:463
-#: A_New_Order/scenarios/13_Scouting.cfg:713
-#: A_New_Order/scenarios/13_Scouting.cfg:723
-#: A_New_Order/scenarios/13_Scouting.cfg:734
-#: A_New_Order/scenarios/13_Scouting.cfg:742
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:560
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:568
+#: A_New_Order/scenarios/13_Scouting.cfg:714
+#: A_New_Order/scenarios/13_Scouting.cfg:724
+#: A_New_Order/scenarios/13_Scouting.cfg:735
+#: A_New_Order/scenarios/13_Scouting.cfg:743
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:561
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:569
 msgid "I would love to talk to..."
 msgstr ""
 
 #. [event]
 #: A_New_Order/scenarios/20_Okladia.cfg:473
-#: A_New_Order/scenarios/13_Scouting.cfg:753
+#: A_New_Order/scenarios/13_Scouting.cfg:754
 msgid "Ruvio, please tell me.."
 msgstr ""
 
 #. [event]
 #: A_New_Order/scenarios/20_Okladia.cfg:474
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:578
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:579
 msgid "Why do you dislike Lorin?"
 msgstr ""
 
@@ -4359,7 +4373,7 @@ msgstr ""
 
 #. [event]
 #: A_New_Order/scenarios/20_Okladia.cfg:476
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:580
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:581
 msgid "Tell me about Karen"
 msgstr ""
 
@@ -4385,26 +4399,26 @@ msgstr ""
 
 #. [event]
 #: A_New_Order/scenarios/20_Okladia.cfg:485
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:591
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:592
 msgid "Well, she is my oldest daughter. From her youth she always wanted to be a great fighter, and she always tried to be the best."
 msgstr ""
 
 #. [event]
 #: A_New_Order/scenarios/20_Okladia.cfg:486
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:592
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:593
 msgid "I'm kind of surprised that she is not here with us."
 msgstr ""
 
 #. [event]
 #: A_New_Order/scenarios/20_Okladia.cfg:487
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:593
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:594
 msgid "I ordered Karl to tie her up and lock her room. I think that gave us enough time to escape. This journey is really too dangerous for her. I hope she will remain safe in Freetown."
 msgstr ""
 
 #. [event]
 #: A_New_Order/scenarios/20_Okladia.cfg:492
 #: A_New_Order/scenarios/20_Okladia.cfg:496
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:597
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:598
 msgid "Hey Reme, what's going on?"
 msgstr ""
 
@@ -4415,7 +4429,7 @@ msgstr ""
 
 #. [event]
 #: A_New_Order/scenarios/20_Okladia.cfg:494
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:600
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:601
 msgid "Nice to hear that."
 msgstr ""
 
@@ -4431,27 +4445,27 @@ msgstr ""
 
 #. [event]
 #: A_New_Order/scenarios/20_Okladia.cfg:501
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:603
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:604
 msgid "Mother, what's going on?"
 msgstr ""
 
 #. [event]
 #: A_New_Order/scenarios/20_Okladia.cfg:504
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:605
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:606
 msgid "Mother? I thought you said I was not your real mother?"
 msgstr ""
 
 #. [event]
 #: A_New_Order/scenarios/20_Okladia.cfg:505
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:606
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:607
 msgid "I'm sorry. I was really angry."
 msgstr ""
 
 #. [event]
 #: A_New_Order/scenarios/20_Okladia.cfg:510
-#: A_New_Order/scenarios/13_Scouting.cfg:828
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:612
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:620
+#: A_New_Order/scenarios/13_Scouting.cfg:829
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:613
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:621
 msgid "Mother, can I have a word with you?"
 msgstr ""
 
@@ -4468,10 +4482,10 @@ msgstr ""
 #. [event]
 #: A_New_Order/scenarios/20_Okladia.cfg:513
 #: A_New_Order/scenarios/20_Okladia.cfg:530
-#: A_New_Order/scenarios/13_Scouting.cfg:824
-#: A_New_Order/scenarios/13_Scouting.cfg:832
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:616
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:623
+#: A_New_Order/scenarios/13_Scouting.cfg:825
+#: A_New_Order/scenarios/13_Scouting.cfg:833
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:617
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:624
 msgid "Never mind"
 msgstr ""
 
@@ -4487,7 +4501,7 @@ msgstr ""
 
 #. [event]
 #: A_New_Order/scenarios/20_Okladia.cfg:520
-#: A_New_Order/scenarios/15_Back_in_Freetown.cfg:186
+#: A_New_Order/scenarios/15_Back_in_Freetown.cfg:187
 msgid "I don't understand."
 msgstr ""
 
@@ -4751,7 +4765,7 @@ msgstr ""
 
 #. [objective]: condition=win
 #: A_New_Order/scenarios/25_The_Awakening.cfg:736
-#: A_New_Order/scenarios/05_Unexpected_Guests.cfg:345
+#: A_New_Order/scenarios/05_Unexpected_Guests.cfg:383
 #: A_New_Order/scenarios/14d_Avenging_Ruen.cfg:152
 #: A_New_Order/scenarios/14d_Avenging_Ruen.cfg:164
 #: A_New_Order/scenarios/15b_Repelling_the_Orcs.cfg:92
@@ -4760,10 +4774,10 @@ msgstr ""
 #: A_New_Order/scenarios/19c_The_Oracle.cfg:1558
 #: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:492
 #: A_New_Order/scenarios/27_Orannon.cfg:738
-#: A_New_Order/scenarios/27_Orannon.cfg:1138
+#: A_New_Order/scenarios/27_Orannon.cfg:1139
 #: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:243
 #: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:255
-#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:258
+#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:294
 msgid "Kill all enemy leaders"
 msgstr ""
 
@@ -4774,14 +4788,14 @@ msgstr ""
 #: A_New_Order/scenarios/22_Leaving_Okladia.cfg:476
 #: A_New_Order/scenarios/21b_Haunted_Place.cfg:200
 #: A_New_Order/scenarios/27_Orannon.cfg:750
-#: A_New_Order/scenarios/27_Orannon.cfg:1150
+#: A_New_Order/scenarios/27_Orannon.cfg:1151
 msgid "Death of Deorien"
 msgstr ""
 
 #. [objective]: condition=lose
 #: A_New_Order/scenarios/25_The_Awakening.cfg:756
 #: A_New_Order/scenarios/27_Orannon.cfg:758
-#: A_New_Order/scenarios/27_Orannon.cfg:1158
+#: A_New_Order/scenarios/27_Orannon.cfg:1159
 msgid "Death of Huon Ryedric"
 msgstr ""
 
@@ -4793,14 +4807,14 @@ msgstr ""
 #. [event]
 #. this string is both the usual "time over" message, and a fakeout here in S22:
 #: A_New_Order/scenarios/25_The_Awakening.cfg:869
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:960
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:964
 #: A_New_Order/scenarios/21a_Abducted_Bride.cfg:547
 #: A_New_Order/scenarios/22_Leaving_Okladia.cfg:856
 #: A_New_Order/scenarios/22_Leaving_Okladia.cfg:929
 #: A_New_Order/scenarios/19a_The_Woods_of_Okladia.cfg:314
 #: A_New_Order/scenarios/19b_Entering_Okladia.cfg:304
 #: A_New_Order/scenarios/19c_The_Oracle.cfg:1813
-#: A_New_Order/scenarios/08_Outlaw_Base.cfg:590
+#: A_New_Order/scenarios/08_Outlaw_Base.cfg:591
 msgid "All is lost! Enemy reinforcements have arrived! We have no chance to win now!"
 msgstr ""
 
@@ -4933,13 +4947,13 @@ msgstr ""
 
 #. [event]
 #: A_New_Order/scenarios/25_The_Awakening.cfg:1019
-#: A_New_Order/scenarios/27_Orannon.cfg:1612
+#: A_New_Order/scenarios/27_Orannon.cfg:1625
 msgid "My king, we could really use some help here."
 msgstr ""
 
 #. [event]
 #: A_New_Order/scenarios/25_The_Awakening.cfg:1025
-#: A_New_Order/scenarios/27_Orannon.cfg:1618
+#: A_New_Order/scenarios/27_Orannon.cfg:1631
 msgid "We are under heavy assault, my king. We really could use some help here."
 msgstr ""
 
@@ -5203,7 +5217,7 @@ msgstr ""
 #. [scenario]: id=13_Scouting
 #. [message]: speaker=Lady Lorin
 #: A_New_Order/scenarios/13_Scouting.cfg:154
-#: A_New_Order/scenarios/09_Hired_Swords.cfg:495
+#: A_New_Order/scenarios/09_Hired_Swords.cfg:498
 msgid "What about this:"
 msgstr ""
 
@@ -5465,12 +5479,12 @@ msgstr ""
 
 #. [event]
 #: A_New_Order/scenarios/13_Scouting.cfg:438
-#: A_New_Order/scenarios/15a_The_Preparations.cfg:275
+#: A_New_Order/scenarios/15a_The_Preparations.cfg:287
 #: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:466
 #: A_New_Order/scenarios/14b_Bontom.cfg:656
 #: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:421
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:346
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:457
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:347
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:458
 msgid "Why?"
 msgstr ""
 
@@ -5511,107 +5525,97 @@ msgid "This is a large-scale map, where you may choose a way to go. Move Gawen t
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:504
+#: A_New_Order/scenarios/13_Scouting.cfg:505
 msgid "My lord, we cannot go back to Freetown. We have nothing to report, and we have not found anything about the orcs."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:507
+#: A_New_Order/scenarios/13_Scouting.cfg:508
 msgid "My lord, I do not think we should go back to Freetown already. We haven't met with the She-wolf of Haeltin west of here. She may have some great insight, having fought with orcs already."
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/13_Scouting.cfg:521
+#: A_New_Order/scenarios/13_Scouting.cfg:522
 msgid "We were in Haeltin already. Where would you like to go now?"
 msgstr ""
 
 #. [else]
-#: A_New_Order/scenarios/13_Scouting.cfg:525
+#: A_New_Order/scenarios/13_Scouting.cfg:526
 msgid "Are you sure you want to go there?"
 msgstr ""
 
 #. [else]
-#: A_New_Order/scenarios/13_Scouting.cfg:531
+#: A_New_Order/scenarios/13_Scouting.cfg:532
 msgid "As you wish, my lord."
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/13_Scouting.cfg:545
+#: A_New_Order/scenarios/13_Scouting.cfg:546
 msgid "We already were in Saorduc. Where to now?"
 msgstr ""
 
 #. [else]
-#: A_New_Order/scenarios/13_Scouting.cfg:549
+#: A_New_Order/scenarios/13_Scouting.cfg:550
 msgid "Are you sure you want to go there? I've told you that I doubt Saurians know anything useful."
 msgstr ""
 
 #. [else]
-#: A_New_Order/scenarios/13_Scouting.cfg:554
-#: A_New_Order/scenarios/13_Scouting.cfg:556
+#: A_New_Order/scenarios/13_Scouting.cfg:555
+#: A_New_Order/scenarios/13_Scouting.cfg:557
 msgid "So, on to Saorduc! Hopefully it is a wise decision and lizard men know something about orcs."
 msgstr ""
 
 #. [else]
-#: A_New_Order/scenarios/13_Scouting.cfg:560
+#: A_New_Order/scenarios/13_Scouting.cfg:561
 msgid "Lizards? We already fought with them. I hate lizards."
 msgstr ""
 
 #. [else]
-#: A_New_Order/scenarios/13_Scouting.cfg:565
+#: A_New_Order/scenarios/13_Scouting.cfg:566
 msgid "That was wise decision, my lord."
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/13_Scouting.cfg:581
+#: A_New_Order/scenarios/13_Scouting.cfg:582
 msgid "We already scouted near Barnon. Where should we go now?"
 msgstr ""
 
 #. [else]
-#: A_New_Order/scenarios/13_Scouting.cfg:585
+#: A_New_Order/scenarios/13_Scouting.cfg:586
 msgid "Are you sure you want to go there? A lot of enemy soldiers could be near Barnon."
 msgstr ""
 
 #. [else]
-#: A_New_Order/scenarios/13_Scouting.cfg:589
+#: A_New_Order/scenarios/13_Scouting.cfg:590
 msgid "This could be dangerous... but also extremely valuable. We can definitely find out something about orcs there."
 msgstr ""
 
 #. [else]
-#: A_New_Order/scenarios/13_Scouting.cfg:592
+#: A_New_Order/scenarios/13_Scouting.cfg:593
 msgid "Yes, on other hand, maybe we should search elsewhere."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:602
+#: A_New_Order/scenarios/13_Scouting.cfg:603
 msgid "Who is comin' here? What d'ya wanna from us?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:603
-#: A_New_Order/scenarios/13_Scouting.cfg:642
+#: A_New_Order/scenarios/13_Scouting.cfg:604
+#: A_New_Order/scenarios/13_Scouting.cfg:643
 msgid "Don't be afraid, I want ask you few question and then I will go."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:604
+#: A_New_Order/scenarios/13_Scouting.cfg:605
 msgid "So go on an' ask us, then."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:610
-#: A_New_Order/scenarios/13_Scouting.cfg:648
-#: A_New_Order/scenarios/13_Scouting.cfg:681
-msgid "Do you know where the place called Bontom is?"
-msgstr ""
-
-#. [event]
 #: A_New_Order/scenarios/13_Scouting.cfg:611
-#: A_New_Order/scenarios/13_Scouting.cfg:623
 #: A_New_Order/scenarios/13_Scouting.cfg:649
-#: A_New_Order/scenarios/13_Scouting.cfg:661
 #: A_New_Order/scenarios/13_Scouting.cfg:682
-#: A_New_Order/scenarios/13_Scouting.cfg:694
-msgid "Do you know anything about Reme Carrenemoe?"
+msgid "Do you know where the place called Bontom is?"
 msgstr ""
 
 #. [event]
@@ -5621,7 +5625,7 @@ msgstr ""
 #: A_New_Order/scenarios/13_Scouting.cfg:662
 #: A_New_Order/scenarios/13_Scouting.cfg:683
 #: A_New_Order/scenarios/13_Scouting.cfg:695
-msgid "Have you heard anything about orcs?"
+msgid "Do you know anything about Reme Carrenemoe?"
 msgstr ""
 
 #. [event]
@@ -5631,7 +5635,7 @@ msgstr ""
 #: A_New_Order/scenarios/13_Scouting.cfg:663
 #: A_New_Order/scenarios/13_Scouting.cfg:684
 #: A_New_Order/scenarios/13_Scouting.cfg:696
-msgid "Would you want to fight for me?"
+msgid "Have you heard anything about orcs?"
 msgstr ""
 
 #. [event]
@@ -5641,434 +5645,444 @@ msgstr ""
 #: A_New_Order/scenarios/13_Scouting.cfg:664
 #: A_New_Order/scenarios/13_Scouting.cfg:685
 #: A_New_Order/scenarios/13_Scouting.cfg:697
+msgid "Would you want to fight for me?"
+msgstr ""
+
+#. [event]
+#: A_New_Order/scenarios/13_Scouting.cfg:615
+#: A_New_Order/scenarios/13_Scouting.cfg:627
+#: A_New_Order/scenarios/13_Scouting.cfg:653
+#: A_New_Order/scenarios/13_Scouting.cfg:665
+#: A_New_Order/scenarios/13_Scouting.cfg:686
+#: A_New_Order/scenarios/13_Scouting.cfg:698
 msgid "Go and work, good man."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:637
+#: A_New_Order/scenarios/13_Scouting.cfg:638
 msgid "Ah, welcome, we've heard about your victories, Gaumhaldric."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:639
+#: A_New_Order/scenarios/13_Scouting.cfg:640
 msgid "I still can't get used to them calling him Gaumhaldric."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:640
+#: A_New_Order/scenarios/13_Scouting.cfg:641
 msgid "Cute name, isn't it?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:643
+#: A_New_Order/scenarios/13_Scouting.cfg:644
 msgid "Anything for you, young knight."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:676
+#: A_New_Order/scenarios/13_Scouting.cfg:677
 msgid "Free men from Raedwood forest! You are always welcome here."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:754
+#: A_New_Order/scenarios/13_Scouting.cfg:755
 msgid "Where Reme Carrenemoe could possibly be?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:755
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:579
+#: A_New_Order/scenarios/13_Scouting.cfg:756
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:580
 msgid "Advise me what could we do now."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:756
+#: A_New_Order/scenarios/13_Scouting.cfg:757
 msgid "Tell me about my mother."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:761
+#: A_New_Order/scenarios/13_Scouting.cfg:762
 msgid "You are joking, right? He is in our camp!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:763
+#: A_New_Order/scenarios/13_Scouting.cfg:764
 msgid "Probably still in that Bontom place the peasants told us about."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:765
+#: A_New_Order/scenarios/13_Scouting.cfg:766
 msgid "In some place called Bontom. We could ask peasants about it."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:768
+#: A_New_Order/scenarios/13_Scouting.cfg:769
 msgid "I have no idea where your friend may be; I fear we may have already missed our chance to find out about him..."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:770
+#: A_New_Order/scenarios/13_Scouting.cfg:771
 msgid "I have no idea where your friend may be; maybe we could ask around some more about him."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:776
+#: A_New_Order/scenarios/13_Scouting.cfg:777
 msgid "About your mother? What do you want to know about her?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:777
+#: A_New_Order/scenarios/13_Scouting.cfg:778
 msgid "Everything."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:778
+#: A_New_Order/scenarios/13_Scouting.cfg:779
 msgid "Well, she was from a royal house. The Akladian king gave her a simple choice: marry him or he would unleash his anger on her family. So, she agreed. I visited her from time to time, singing songs, bringing her news from home... "
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:779
+#: A_New_Order/scenarios/13_Scouting.cfg:780
 msgid "I think eventually she even warmed up to your father, the king. When she gave birth to you, she gave everything she had for you. But behind her back Akladian clans were conspiring... and finally someone gave her a poisoned cup. She died, slowly, and painfully. I was able to be near her in her final hours. I promised her that I would take care of you."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:780
+#: A_New_Order/scenarios/13_Scouting.cfg:781
 msgid "Who poisoned her?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:781
+#: A_New_Order/scenarios/13_Scouting.cfg:782
 msgid "I don't know. No one knows."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:783
+#: A_New_Order/scenarios/13_Scouting.cfg:784
 msgid "Rob Roe mentioned Lorin's clan once bought some special poison from Outlaws... "
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:784
+#: A_New_Order/scenarios/13_Scouting.cfg:785
 msgid "And you think that..."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:785
+#: A_New_Order/scenarios/13_Scouting.cfg:786
 msgid "Why shouldn't I think that?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:786
+#: A_New_Order/scenarios/13_Scouting.cfg:787
 msgid "You are right, Gawen. Akladians have a long history of poisoning each other. You might say it's their national sport. But still... yes, it had escaped my attention before."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:788
+#: A_New_Order/scenarios/13_Scouting.cfg:789
 msgid "I wish I had asked around more about poison previously; it's probably too late to find out more now..."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:793
+#: A_New_Order/scenarios/13_Scouting.cfg:794
 msgid "Hey Karen, what's up?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:794
+#: A_New_Order/scenarios/13_Scouting.cfg:795
 msgid "I just made up a new song about you, want to hear it?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:795
+#: A_New_Order/scenarios/13_Scouting.cfg:796
 msgid "You are a gifted girl... fighting, singing, what else can you do?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:796
+#: A_New_Order/scenarios/13_Scouting.cfg:797
 msgid "I can also dance. Gawen. When we return to Freetown I could dance for you... "
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:797
+#: A_New_Order/scenarios/13_Scouting.cfg:798
 msgid "I'm sure I would enjoy watching you dance."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:798
+#: A_New_Order/scenarios/13_Scouting.cfg:799
 msgid "Oh, I bet you would!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:800
+#: A_New_Order/scenarios/13_Scouting.cfg:801
 msgid "Thank you, Gawen, once again. You have saved my life. I will never forget it, and I will never be able to repay my debt. Earlier my life belonged to you because of duty; now it is yours by choice."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:802
+#: A_New_Order/scenarios/13_Scouting.cfg:803
 msgid "Gaumhaldric, an interesting mother you have. Can I ask you a question?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:803
+#: A_New_Order/scenarios/13_Scouting.cfg:804
 msgid "Sure, go ahead."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:804
+#: A_New_Order/scenarios/13_Scouting.cfg:805
 msgid "Is she spoken for? I mean, is there someone she loves? I have often noticed her gazing up at the sky, far, far away, as if she were thinking about someone... or something."
 msgstr ""
 
 #. [event]
 #. this is just Gawen's assumption; my own assumption is that she is thinking about what the Oracle told her:
-#: A_New_Order/scenarios/13_Scouting.cfg:806
+#: A_New_Order/scenarios/13_Scouting.cfg:807
 msgid "I think she must be remembering my father. She has no one else I know about."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:807
+#: A_New_Order/scenarios/13_Scouting.cfg:808
 msgid "That is fortunate for me. She seems to have locked her heart up in an unbreakable fortress... but I think I can find a way into her heart. With time and patience, I'm sure I can discover a way to break down those walls. "
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:808
+#: A_New_Order/scenarios/13_Scouting.cfg:809
 msgid "Majid Yahyazad, Lorin is my step-mother, but she has never really shown any tenderness, even to me. I have always known her to be a harsh and unforgiving woman."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:809
+#: A_New_Order/scenarios/13_Scouting.cfg:810
 msgid "I'm afraid pursuing her will come with a heavy price. I think she thinks love is a weakness... she seems more interested in war and finding new ways to cause pain to others."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:810
+#: A_New_Order/scenarios/13_Scouting.cfg:811
 msgid "Ah, Gaumhaldric, perhaps you are right, but if it will be as a war to unlock her heart, I am prepared to wage it. I am well-acquainted with the ways of war."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:811
+#: A_New_Order/scenarios/13_Scouting.cfg:812
 msgid "Besides, in the end, the war for the affection of a worthy woman is the only war where the price to win is a privilege, not a burden, to pay."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:812
+#: A_New_Order/scenarios/13_Scouting.cfg:813
 msgid "You find my step-mother... a worthy challenge, then? "
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:813
+#: A_New_Order/scenarios/13_Scouting.cfg:814
 msgid "I do... and shall gladly pay the price to try to win her heart. "
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:814
+#: A_New_Order/scenarios/13_Scouting.cfg:815
 msgid "You have my blessing, noble Majid, for what it's worth. Sometimes the ruthlessness of the 'She-Wolf of Haeltin' still scares even me. "
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:819
+#: A_New_Order/scenarios/13_Scouting.cfg:820
 msgid "Mother, may I have a word with you?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:820
-msgid "Your clan once bought poison from outlaws. Why?"
-msgstr ""
-
-#. [event]
 #: A_New_Order/scenarios/13_Scouting.cfg:821
-#: A_New_Order/scenarios/13_Scouting.cfg:829
-msgid "What do you think about Yahyazad?"
+msgid "Your clan once bought poison from outlaws. Why?"
 msgstr ""
 
 #. [event]
 #: A_New_Order/scenarios/13_Scouting.cfg:822
 #: A_New_Order/scenarios/13_Scouting.cfg:830
-msgid "What do you know about orcs?"
+msgid "What do you think about Yahyazad?"
 msgstr ""
 
 #. [event]
 #: A_New_Order/scenarios/13_Scouting.cfg:823
 #: A_New_Order/scenarios/13_Scouting.cfg:831
+msgid "What do you know about orcs?"
+msgstr ""
+
+#. [event]
+#: A_New_Order/scenarios/13_Scouting.cfg:824
+#: A_New_Order/scenarios/13_Scouting.cfg:832
 msgid "How did my real mother die?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:837
+#: A_New_Order/scenarios/13_Scouting.cfg:838
 msgid "Why do you ask?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:838
+#: A_New_Order/scenarios/13_Scouting.cfg:839
 msgid "Well, he seems to be interested in you."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:839
+#: A_New_Order/scenarios/13_Scouting.cfg:840
 msgid "Yes, I noticed that. I think one would have to be blind NOT to notice that. But I am not interested in him."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:840
+#: A_New_Order/scenarios/13_Scouting.cfg:841
 msgid "Why not? He seems to be a good man."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:841
+#: A_New_Order/scenarios/13_Scouting.cfg:842
 msgid "He is an underling."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:842
+#: A_New_Order/scenarios/13_Scouting.cfg:843
 msgid "Underling? Mother, why do you still use such words? I am 'underling' too, after all."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:843
+#: A_New_Order/scenarios/13_Scouting.cfg:844
 msgid "No! I could never call you that. You are not... I mean... I... oh, you are too young to understand!"
 msgstr ""
 
 #. [event]
 #. cross-reference to dialogue in S16, Choosing the Best:
-#: A_New_Order/scenarios/13_Scouting.cfg:845
+#: A_New_Order/scenarios/13_Scouting.cfg:846
 msgid "Besides, you have lost your memory, so you probably do not remember what our customs are regarding widows that betray their dead husbands. I will explain it to you another time."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:847
+#: A_New_Order/scenarios/13_Scouting.cfg:848
 msgid "Orcs? They are good fighters. Strong, disciplined, I wish I had such soldiers."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:848
+#: A_New_Order/scenarios/13_Scouting.cfg:849
 msgid "Mother, orcs just burn, pillage, and murder! They hate us, and yet you seem to respect them?!?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:849
+#: A_New_Order/scenarios/13_Scouting.cfg:850
 msgid "Well, we are burning, pillaging, murdering and hate our enemies too. What's the difference?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:851
+#: A_New_Order/scenarios/13_Scouting.cfg:852
 msgid "Poison? What poison? My clan has never bought any poison!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:852
+#: A_New_Order/scenarios/13_Scouting.cfg:853
 msgid "Rob Roe told me about it."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:853
+#: A_New_Order/scenarios/13_Scouting.cfg:854
 msgid "Can you repeat that name? Rob - Roe. Rob Roe... No, I can't say I remember that name. I don't know anything about my clan buying a poison. But then, I am only a woman, and our clan lord didn't tell me everything."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:856
+#: A_New_Order/scenarios/13_Scouting.cfg:857
 msgid "Your mother? Your... why you are asking ME about your mother?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:857
+#: A_New_Order/scenarios/13_Scouting.cfg:858
 msgid "I can't remember anything about her. I would love to hear something about her. Did you know her?"
 msgstr ""
 
 #. [event]
 #. this is a Suspiciously Specific Denial: https://tvtropes.org/pmwiki/pmwiki.php/Main/SuspiciouslySpecificDenial
-#: A_New_Order/scenarios/13_Scouting.cfg:859
+#: A_New_Order/scenarios/13_Scouting.cfg:860
 msgid "No! I did not know her! I... I'm sorry Gawen, but I don't know how your mother died or who poisoned her."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:860
+#: A_New_Order/scenarios/13_Scouting.cfg:861
 msgid "I wasn't asking you about that."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:877
+#: A_New_Order/scenarios/13_Scouting.cfg:878
 msgid "There are no more orcs near this ruins of the village."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:880
+#: A_New_Order/scenarios/13_Scouting.cfg:881
 msgid "My lord! This time for sure you will chase off that orcish band, kill all the orcs, and free my people!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:882
+#: A_New_Order/scenarios/13_Scouting.cfg:883
 msgid "So, should we take on the orcs?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:902
+#: A_New_Order/scenarios/13_Scouting.cfg:903
 msgid "Someone is hiding here!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:904
+#: A_New_Order/scenarios/13_Scouting.cfg:905
 msgid "Ah! Humans! And Akladians with them?! Still, what good fortune!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:906
+#: A_New_Order/scenarios/13_Scouting.cfg:907
 msgid "Ah! Humans! And not Akladians! What good fortune!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:908
+#: A_New_Order/scenarios/13_Scouting.cfg:909
 msgid "Who are you, and what are you doing here?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:909
+#: A_New_Order/scenarios/13_Scouting.cfg:910
 msgid "The orcs burned down my village, Ruen, and they left not long ago. They took many prisoners. I was hiding here, waiting for a miracle. And now the miracle has come!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:910
+#: A_New_Order/scenarios/13_Scouting.cfg:911
 msgid "Oh my. It's so funny I think I'm gonna die laughing. Gaumhaldric the Miracle-maker, how about the sound of that?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:911
+#: A_New_Order/scenarios/13_Scouting.cfg:912
 msgid "Miracle? What do you mean?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:912
+#: A_New_Order/scenarios/13_Scouting.cfg:913
 msgid "You of course will chase that orcish band, kill all the orcs and free my people!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:914
+#: A_New_Order/scenarios/13_Scouting.cfg:915
 msgid "Hm, my lord, do you think we should fullfill this peasant's request?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:921
+#: A_New_Order/scenarios/13_Scouting.cfg:922
 msgid "Well, I hope it's wise decision."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:922
+#: A_New_Order/scenarios/13_Scouting.cfg:923
 msgid "Of course it is. We are searching for orcs, and those are orcs, isn't it?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:925
-#: A_New_Order/scenarios/13_Scouting.cfg:953
+#: A_New_Order/scenarios/13_Scouting.cfg:926
+#: A_New_Order/scenarios/13_Scouting.cfg:954
 msgid "Yes, on other hand maybe we should search elsewhere."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:936
+#: A_New_Order/scenarios/13_Scouting.cfg:937
 msgid "We already fought with outlaws from Bontom, my lord."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:945
+#: A_New_Order/scenarios/13_Scouting.cfg:946
 msgid "So, should we go into Bontom?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:950
+#: A_New_Order/scenarios/13_Scouting.cfg:951
 msgid "Yes, we should save Reme now."
 msgstr ""
 
@@ -6084,14 +6098,14 @@ msgstr ""
 
 #. [label]
 #: A_New_Order/scenarios/15a_The_Preparations.cfg:26
-#: A_New_Order/scenarios/15_Back_in_Freetown.cfg:39
+#: A_New_Order/scenarios/15_Back_in_Freetown.cfg:40
 #: A_New_Order/scenarios/11_Council_in_Freetown.cfg:26
 msgid "Freetown"
 msgstr ""
 
 #. [side]: id=Gwidle Turlin, type=General
 #: A_New_Order/scenarios/15a_The_Preparations.cfg:44
-#: A_New_Order/scenarios/15_Back_in_Freetown.cfg:55
+#: A_New_Order/scenarios/15_Back_in_Freetown.cfg:56
 #: A_New_Order/scenarios/11_Council_in_Freetown.cfg:41
 msgid "Gwidle Turlin"
 msgstr ""
@@ -6293,61 +6307,107 @@ msgid "Spearman"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/15a_The_Preparations.cfg:265
+#: A_New_Order/scenarios/15a_The_Preparations.cfg:263
 msgid "My lord, we know an orcish group attacked a few villages north of here. Huon Ryedric was going to go there to defend the villages, but I thought you might want to use the occasion, you know, to check out our troops before you make any final decisions on which soldiers to choose for our quest."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/15a_The_Preparations.cfg:273
+#: A_New_Order/scenarios/15a_The_Preparations.cfg:264
+msgid "Alternatively, we also know of an Elvish settlement to the east of here that has sent us a distress signal. It said something about the nearby forest being in danger of burning down. I don't know quite what the story is there, but it should also provide for an opportunity to get in some training as well."
+msgstr ""
+
+#. [event]
+#. a bit of dramatic irony here, for those who know what's to come:
+#: A_New_Order/scenarios/15a_The_Preparations.cfg:266
+msgid "Don't worry too much about which one you choose, as I'm sure we'll be able to get someone else to handle these minor problems, if you can't do so yourself. The forces of Freetown are highly independent, and plenty capable of handling any situations in your absence."
+msgstr ""
+
+#. [event]
+#: A_New_Order/scenarios/15a_The_Preparations.cfg:267
+msgid "Got it."
+msgstr ""
+
+#. [event]
+#: A_New_Order/scenarios/15a_The_Preparations.cfg:269
+msgid "So, which way should we go?"
+msgstr ""
+
+#. [event]
+#: A_New_Order/scenarios/15a_The_Preparations.cfg:270
+msgid "Let's go north, to fight the orcs."
+msgstr ""
+
+#. [event]
+#: A_New_Order/scenarios/15a_The_Preparations.cfg:271
+msgid "Let's go east, to help the elves."
+msgstr ""
+
+#. [event]
+#: A_New_Order/scenarios/15a_The_Preparations.cfg:272
+msgid "Let's just stay here and pick our troops."
+msgstr ""
+
+#. [event]
+#: A_New_Order/scenarios/15a_The_Preparations.cfg:279
+msgid "So, north to fight the orcs, then?"
+msgstr ""
+
+#. [event]
+#: A_New_Order/scenarios/15a_The_Preparations.cfg:281
+msgid "So, east to help the elves, then?"
+msgstr ""
+
+#. [event]
+#: A_New_Order/scenarios/15a_The_Preparations.cfg:285
 msgid "Yes, I think that's a great idea."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/15a_The_Preparations.cfg:274
+#: A_New_Order/scenarios/15a_The_Preparations.cfg:286
 msgid "I have to stay here."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/15a_The_Preparations.cfg:276
+#: A_New_Order/scenarios/15a_The_Preparations.cfg:288
 msgid "It is the way of the woman. Don't ask."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/15a_The_Preparations.cfg:277
+#: A_New_Order/scenarios/15a_The_Preparations.cfg:289
 msgid "I shall remain with her, just in case it is something serious."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/15a_The_Preparations.cfg:292
+#: A_New_Order/scenarios/15a_The_Preparations.cfg:304
 msgid "Karen, you will stay here, with your mother and sisters. It's too dangerous for you."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/15a_The_Preparations.cfg:293
+#: A_New_Order/scenarios/15a_The_Preparations.cfg:305
 msgid "Of courrrrrse."
 msgstr ""
 
 #. [event]
 #. EASY difficulty:
-#: A_New_Order/scenarios/15a_The_Preparations.cfg:302
+#: A_New_Order/scenarios/15a_The_Preparations.cfg:318
 msgid "So, let's choose our eighteen very best, most experienced troops."
 msgstr ""
 
 #. [event]
 #. NORMAL difficulty:
-#: A_New_Order/scenarios/15a_The_Preparations.cfg:306
+#: A_New_Order/scenarios/15a_The_Preparations.cfg:322
 msgid "So, let's choose our fifteen best troops."
 msgstr ""
 
 #. [event]
 #. HARD difficulty:
-#: A_New_Order/scenarios/15a_The_Preparations.cfg:310
+#: A_New_Order/scenarios/15a_The_Preparations.cfg:326
 msgid "So, let's choose twelve troops."
 msgstr ""
 
 #. [event]
 #. NIGHTMARE difficulty:
-#: A_New_Order/scenarios/15a_The_Preparations.cfg:314
+#: A_New_Order/scenarios/15a_The_Preparations.cfg:330
 msgid "So, nine troops."
 msgstr ""
 
@@ -6357,6 +6417,7 @@ msgid "Raedwood East"
 msgstr ""
 
 #. [part]
+#. TODO: rewrite (will need to form a smooth transition from the updated dialogue I added in S15a):
 #: A_New_Order/scenarios/15c_Raedwood_East.cfg:22
 msgid "And so Gawen and his party went to the eastern part of Raedwood."
 msgstr ""
@@ -6371,9 +6432,9 @@ msgstr ""
 #. [then]
 #: A_New_Order/scenarios/15c_Raedwood_East.cfg:144
 #: A_New_Order/scenarios/15c_Raedwood_East.cfg:193
-#: A_New_Order/scenarios/15c_Raedwood_East.cfg:315
-#: A_New_Order/scenarios/15c_Raedwood_East.cfg:653
-#: A_New_Order/scenarios/15c_Raedwood_East.cfg:665
+#: A_New_Order/scenarios/15c_Raedwood_East.cfg:319
+#: A_New_Order/scenarios/15c_Raedwood_East.cfg:657
+#: A_New_Order/scenarios/15c_Raedwood_East.cfg:669
 msgid "Quësel"
 msgstr ""
 
@@ -6426,27 +6487,27 @@ msgid "Woses standing on campfires will take damage every turn."
 msgstr ""
 
 #. [message]: speaker=Gawen Hagarthen
-#: A_New_Order/scenarios/15c_Raedwood_East.cfg:288
+#: A_New_Order/scenarios/15c_Raedwood_East.cfg:292
 msgid "I thought you said that it was drakes that were attacking you?"
 msgstr ""
 
 #. [message]: speaker=Quësel
-#: A_New_Order/scenarios/15c_Raedwood_East.cfg:295
+#: A_New_Order/scenarios/15c_Raedwood_East.cfg:299
 msgid "Well, yes, but they seem to have attracted fire-lovers of all kinds to their side..."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/15c_Raedwood_East.cfg:315
+#: A_New_Order/scenarios/15c_Raedwood_East.cfg:319
 msgid "Those blasted woodburners have overrun us! Raedwood is doomed now!"
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/15c_Raedwood_East.cfg:653
+#: A_New_Order/scenarios/15c_Raedwood_East.cfg:657
 msgid "Oh no! Our dear Raedwood, burned to ash! The free peoples of the forest shall no longer have a refuge from Akladian tyranny! We have failed!"
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/15c_Raedwood_East.cfg:665
+#: A_New_Order/scenarios/15c_Raedwood_East.cfg:669
 msgid "Be careful! Our forest is almost gone!"
 msgstr ""
 
@@ -6907,7 +6968,7 @@ msgstr ""
 
 #. [side]: id=Raban Harnen, type=Akladian Lord
 #. [scenario]: id=17_Sneaking_out_of_Raedwood
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:294
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:295
 #: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:13
 msgid "Raban Harnen"
 msgstr ""
@@ -6918,671 +6979,680 @@ msgid "MY KING! Forgive me, no... kill me now, how could I fight against you? I 
 msgstr ""
 
 #. [scenario]: id=17_Sneaking_out_of_Raedwood
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:20
+#. It's okay for Ruvio to use Gawen's real name here, since he just went and revealed it anyways:
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:21
 msgid "Gawen, I thought I told you to keep your identity a secret."
 msgstr ""
 
 #. [scenario]: id=17_Sneaking_out_of_Raedwood
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:21
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:22
 msgid "It is for advisors to advise, and the leader to choose whether to follow that advice. Raban, there can be no treachery in ignorance. If you didn't know it was me, you are no traitor."
 msgstr ""
 
 #. [scenario]: id=17_Sneaking_out_of_Raedwood
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:24
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:25
 msgid "I've heard that name... a new, skilled underling leader. My honor is intact, even in defeat."
 msgstr ""
 
 #. [scenario]: id=17_Sneaking_out_of_Raedwood
 #. [message]: speaker=Lady Lorin
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:26
-#: A_New_Order/scenarios/09_Hired_Swords.cfg:281
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:27
+#: A_New_Order/scenarios/09_Hired_Swords.cfg:284
 msgid "And now..."
 msgstr ""
 
 #. [scenario]: id=17_Sneaking_out_of_Raedwood
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:27
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:28
 msgid "I will spare your life."
 msgstr ""
 
 #. [scenario]: id=17_Sneaking_out_of_Raedwood
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:28
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:29
 msgid "Go to your ancestors."
 msgstr ""
 
 #. [scenario]: id=17_Sneaking_out_of_Raedwood
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:31
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:32
 msgid "I will order my people to try to cure your wounds. And then I will release you."
 msgstr ""
 
 #. [scenario]: id=17_Sneaking_out_of_Raedwood
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:34
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:35
 msgid "Prepare to meet your ancestors, brave warrior; I cannot leave you alive."
 msgstr ""
 
 #. [side]: id=Bar O Raednon, type=Akladian Lord
 #. [scenario]: id=17_Sneaking_out_of_Raedwood
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:179
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:39
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:180
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:40
 msgid "Bar O Raednon"
 msgstr ""
 
 #. [scenario]: id=17_Sneaking_out_of_Raedwood
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:43
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:44
 msgid "You can still hear me, can't you? I have some questions."
 msgstr ""
 
 #. [scenario]: id=17_Sneaking_out_of_Raedwood
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:44
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:45
 msgid "Then ask someone else... who might know the answers."
 msgstr ""
 
 #. [scenario]: id=17_Sneaking_out_of_Raedwood
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:45
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:46
 msgid "Wait! Don't die yet! Curses, he's already lost consciousness."
 msgstr ""
 
 #. [scenario]: id=17_Sneaking_out_of_Raedwood
 #. [event]
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:52
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:87
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:53
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:88
 #: A_New_Order/scenarios/21a_Abducted_Bride.cfg:576
 msgid "Now, tell me..."
 msgstr ""
 
 #. [scenario]: id=17_Sneaking_out_of_Raedwood
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:53
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:88
-msgid "Why is Bor Cryne allied with orcs?"
-msgstr ""
-
-#. [scenario]: id=17_Sneaking_out_of_Raedwood
 #: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:54
 #: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:89
-msgid "What can you tell me about Grekulak?"
+msgid "Why is Bor Cryne allied with orcs?"
 msgstr ""
 
 #. [scenario]: id=17_Sneaking_out_of_Raedwood
 #: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:55
 #: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:90
-msgid "Do you know where the great mage Deorien is?"
+msgid "What can you tell me about Grekulak?"
 msgstr ""
 
 #. [scenario]: id=17_Sneaking_out_of_Raedwood
 #: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:56
 #: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:91
+msgid "Do you know where the great mage Deorien is?"
+msgstr ""
+
+#. [scenario]: id=17_Sneaking_out_of_Raedwood
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:57
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:92
 msgid "Will you fight for us?"
 msgstr ""
 
 #. [scenario]: id=17_Sneaking_out_of_Raedwood
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:62
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:63
 msgid "Mage? Then he is surely burning in hell!"
 msgstr ""
 
 #. [scenario]: id=17_Sneaking_out_of_Raedwood
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:64
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:65
 msgid "I don't know. He leads the orcs, but he is not an orc. I am not sure who he is. There is gossip that a new messiah will come to lead us to conquer the world, and he might just be that new messiah, I think."
 msgstr ""
 
 #. [scenario]: id=17_Sneaking_out_of_Raedwood
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:65
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:66
 msgid "New messiah?"
 msgstr ""
 
 #. [scenario]: id=17_Sneaking_out_of_Raedwood
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:66
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:67
 msgid "Yes. The new messiah will show us how to renew our covenant with God, and he will reveal to us the new traditions and ways that this covenant will require. He won't be Akladian - at least not fully Akladian - the rumors are not totally clear about that."
 msgstr ""
 
 #. [scenario]: id=17_Sneaking_out_of_Raedwood
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:69
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:70
 msgid "It's because we need allies against the usurper mixling, Gawen Hagarthen."
 msgstr ""
 
 #. [scenario]: id=17_Sneaking_out_of_Raedwood
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:70
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:71
 msgid "And what are his plans for future?"
 msgstr ""
 
 #. [scenario]: id=17_Sneaking_out_of_Raedwood
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:71
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:72
 msgid "I think Bor wants to be king. He wants to try to unite all of the Akladian kingdoms and complete the conquest of Wesnoth. On the way, he will purify our race by killing every Akladian unworthy of the name."
 msgstr ""
 
 #. [scenario]: id=17_Sneaking_out_of_Raedwood
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:72
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:73
 msgid "Unworthy? What do you mean by that?"
 msgstr ""
 
 #. [scenario]: id=17_Sneaking_out_of_Raedwood
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:73
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:74
 msgid "Those who have offended our God by marrying Wesnothian women. Those who allowed their daughters to live when they chose another husband or married an underling. Those with underling friends. All of them will be sacrificed to God."
 msgstr ""
 
 #. [scenario]: id=17_Sneaking_out_of_Raedwood
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:77
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:78
 msgid "Never in my life or afterlife!"
 msgstr ""
 
 #. [scenario]: id=17_Sneaking_out_of_Raedwood
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:97
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:98
 msgid "I don't know who that is. If he is a mage, then he is an enemy of our God and as such, has no right to life."
 msgstr ""
 
 #. [scenario]: id=17_Sneaking_out_of_Raedwood
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:99
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:100
 msgid "I do not know that name."
 msgstr ""
 
 #. [scenario]: id=17_Sneaking_out_of_Raedwood
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:101
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:102
 msgid "I do not know why. I've heard they came here to purify the world before the new messiah comes, but right now it just seems like they are pillaging and murdering many good people, Akladian and Wesnothian alike."
 msgstr ""
 
 #. [scenario]: id=17_Sneaking_out_of_Raedwood
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:104
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:105
 msgid "I can't; your blow almost chopped my arm off. If you allow me to live, all I want is to return to my wife and children."
 msgstr ""
 
 #. [part]
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:141
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:142
 msgid "Gawen's soldiers left Freetown and swiftly entered the woods. They marched from dawn to dusk, until they found themselves at the border of Raedwood forest."
 msgstr ""
 
 #. [side]: id=Quivre O Raednon, type=Akladian Lord
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:237
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:238
 msgid "Quivre O Raednon"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:376
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:377
 msgid "I hate this forest. I REALLY hate it. Passionately."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:377
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:378
 msgid "Shut up, Bar. Over the last year I've heard more than enough of your whining about trees, woods, branches and so on."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:378
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:379
 msgid "It's the wind. And the noise... as if the green devils are whispering in the leaves. I really hate this forest."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:383
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:384
 msgid "Hold your tongue! Green devils... I've heard they appeared recently in Raedwood. My friend told me there were THOUSANDS of them. I wish I were somewhere else."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:384
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:385
 msgid "Like... in bed with your underling so-called 'wife'?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:385
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:386
 msgid "I've told you not to call her that! What's wrong with marrying Wesnothian women anyway? If our old king could do it, why not us lesser men?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:386
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:387
 msgid "The King is dead. I think God punished him for mixing our holy blood with that of the underlings. And Raban, you should really get rid of your, um, wife-thing."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:387
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:388
 msgid "Why? At least Wesnothian woman guarantee healthy children."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:388
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:389
 msgid "There is a gossip that this unknown curse put on our women will end. "
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:388
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:389
 msgid "Everyone who has forsaken our old ways and is too underling-friendly will soon be as dead as our old king. Or as that mixling, ten-days king, Gawen."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:389
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:390
 msgid "Cousin, do not utter that name! I've heard he was seen walking the face of the earth... as if... he had come back from the grave... or perhaps undead..."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:390
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:391
 msgid "We have to get past these guards. Akladians set up a line of guards around the forest some time ago, when our rebellion was more visible and having some success."
 msgstr ""
 
 #. [event]
 #. EASY difficulty:
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:394
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:395
 msgid "I want to avoid fighting. I only have eighteen seasoned troops, and in this neigborhood I can recruit only peasants. I won't be able to find replacements for any of my veterans, and this is just the beginning of our quest."
 msgstr ""
 
 #. [event]
 #. NORMAL difficulty:
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:398
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:399
 msgid "I want to avoid fighting. I only have fifteen seasoned troops, and in this neigborhood I can recruit only peasants. I won't be able to find replacements for any of my veterans, and this is just the beginning of our quest."
 msgstr ""
 
 #. [event]
 #. HARD difficulty:
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:402
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:403
 msgid "I want to avoid fighting. I only have twelve seasoned troops, and in this neigborhood I can recruit only peasants. I won't be able to find replacements for any of my veterans, and this is just the beginning of our quest."
 msgstr ""
 
 #. [event]
 #. NIGHTMARE difficulty:
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:406
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:407
 msgid "I want to avoid fighting. I barely have any seasoned troops, and in this neigborhood I can recruit only peasants. I won't be able to find replacements for any of my veterans, and this is just the beginning of our quest."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:408
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:409
 msgid "If so, then it is up to you to figure out a strategy which will avoid any losses. While we will have to pass near the guards, and may skirmish with them, there is no need to get into a stand-up fight with them."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:409
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:410
 msgid "How typical for an underling, trying to avoid conflict. My son, let's just slaughter them all! More enemies, more honor!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:410
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:411
 msgid "With that kind of attitude, how have you managed to survive this long? We'll want to manage our resources, too - my guess is that we should have at least 250 golden coins at the end of this battle."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:411
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:412
 msgid "Hm, there are certainly many decisions to be made here..."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:413
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:414
 msgid "Well, Gawen, which path will you take? The stealthy route proposed by Ruvio, or the violent route proposed by your stepmother?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:416
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:417
 msgid "Well, Gawen, which path will you take? The stealthy route proposed by the underling, or the violent route proposed by the 'She-Wolf of Haeltin'?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:418
-msgid "Well, Gawen, which path will you take? The stealthy route I proposed, or the violent route proposed by your stepmother?"
-msgstr ""
-
-#. [event]
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:421
-msgid "I think I'll take the stealthy strategy"
-msgstr ""
-
-#. [event]
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:422
-msgid "I think I'll take the violent strategy"
+#. Ruvio switches back to Gawen's codename here to emphasize that they're around enemies again, and need to be careful now:
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:420
+msgid "Well, Haldric, which path will you take? The stealthy route I proposed, or the violent route proposed by your stepmother?"
 msgstr ""
 
 #. [event]
 #: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:423
-msgid "I think I'll forge my own path"
+msgid "I think I'll take the stealthy strategy"
+msgstr ""
+
+#. [event]
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:424
+msgid "I think I'll take the violent strategy"
 msgstr ""
 
 #. [event]
 #: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:425
+msgid "I think I'll forge my own path"
+msgstr ""
+
+#. [event]
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:427
 msgid "Since you have chosen the stealthy strategy, for this scenario only, your units will be more stealthy than normal."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:478
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:480
 msgid "Since you have chosen the violent strategy, for this scenario only, your units will be more violent than normal."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:574
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:576
 msgid "By choosing neither Ruvio's path nor Lorin's path, you are choosing to leave your units in an unmodified state, as would have been the case before this choice existed."
 msgstr ""
 
 #. [objectives]
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:578
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:580
 msgid "You can interrogate enemy leaders in this scenario with Gawen, Ruvio, Reme, or Lorin, but the effects may - or may not - be different, depending on the enemy leader and interrogating hero."
 msgstr ""
 
 #. [objective]: condition=win
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:580
-msgid "Move Gawen to south-eastern signpost OR"
+#. trailing space is intentional, to pad the footnote a bit:
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:583
+msgid "Move Gawen to south-eastern signpost "
 msgstr ""
 
 #. [objective]: condition=win
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:584
-#: A_New_Order/scenarios/12_Leaving_Raedwood.cfg:212
-#: A_New_Order/scenarios/09_Hired_Swords.cfg:246
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:583
+#: A_New_Order/scenarios/12_Leaving_Raedwood.cfg:209
+#: A_New_Order/scenarios/02_Fighting_for_Passage.cfg:340
+msgid " OR"
+msgstr ""
+
+#. [objective]: condition=win
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:587
+#: A_New_Order/scenarios/12_Leaving_Raedwood.cfg:213
 msgid "Kill all enemy leaders."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:609
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:613
 msgid "Wait, Karl, why aren't you guarding Karen?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:610
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:614
 msgid "You asked me to come with you, remember?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:611
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:615
 msgid "Right, I did... I'm sure she'll be fine..."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:634
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:638
 msgid "Eeek! The green devils!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:635
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:639
 msgid "Kill them! Kill them all! Hurry! There are thousands of them, everywhere!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:654
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:658
 msgid "You are from the Raednon clan? So, the Raednons are also supporting the treachery of Bor Cryne. Why I am not surprised? I know you are all pig-eaters and swine..."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:655
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:659
 msgid "Cease your insults, witch. I know you: you are Lorin, the shrew from the Gallorae clan. You soon will be the last of your clan; how does it feel?"
 msgstr ""
 
 #. [event]
 #. Note to translators: A gelding is an animal that has been castrated.
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:657
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:661
 msgid "And you will be soon a gelding. How does IT feel?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:664
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:709
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:668
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:713
 msgid "He had some gold in his castle."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:666
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:670
 msgid "You receive $bar_gold_amt golden pieces."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:676
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:690
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:680
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:694
 msgid "You were a worthy opponent, Quivre of the Raednons. It was good fight."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:677
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:691
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:681
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:695
 msgid "Yes, it was."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:678
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:692
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:682
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:696
 msgid "If you were as delighted as I was with the fight, please answer a few questions."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:683
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:687
 msgid "Another self-important Akladian sent to his barbarian hell. How does it feel, mighty Akladian lord? To be killed by a mere underling?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:684
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:688
 msgid "You wouldn't have been able to do this if not for the magical support of that witch, Lorin. It was she who gave you courage, that traitor to her own race."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:685
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:689
 msgid "Hmm... Should I feel complimented, or offended?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:697
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:701
 msgid "Speak quickly, and I will allow you to go to your ancestors in one piece."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:698
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:702
 msgid "Do you think I am afraid of you, witch?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:699
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:703
 msgid "No, of course not. You are a brave warrior. I just thought the notion that you will enter heaven without hands, legs, or head might make you a little bit uneasy."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:700
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:704
 msgid "Stop it, witch. You can't scare me."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:701
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:705
 msgid "Perhaps not, but I think I am going to enjoy trying anyway. Let's start with this little knife you see here."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:711
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:715
 msgid "You receive $quivre_gold_amt golden pieces."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:739
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:743
 msgid "I killed this one, my lord."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:740
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:744
 msgid "A shame we didn't get a chance to interrogate him... oh well."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:746
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:750
 msgid "It was honor to fight such an excellent duel. Thank you. You should know, I have no ill feelings towards you. I will not damage your body after you die, so you will enter the afterlife in one piece."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:747
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:751
 msgid "Thank you, noble lord. I do not know your name, or how you could be allied with green devils and Wesnothians."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:748
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:752
 msgid "My name is Reme Carrenemoe. I think it answers both of your questions."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:749
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:753
 msgid "Yes, it does."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:751
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:755
 msgid "Gawen, my lord, I think he is still alive. What should we do with him?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:752
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:756
 msgid "Kill him!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:753
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:757
 msgid "What? Did I hear correctly? What is your name?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:754
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:777
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:298
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:758
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:781
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:299
 msgid "My name is..."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:756
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:779
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:300
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:760
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:783
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:301
 msgid "Gaumhaldric"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:762
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:766
 msgid "Another Akladian lord losing to an aged underling. How do you explain that?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:763
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:767
 msgid "My wife is Wesnothian, so I know many Wesnothians. Save your irony for another."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:764
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:768
 msgid "Fair enough. You will now answer a few questions."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:766
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:770
 msgid "You may now rest in peace."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:767
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:771
 msgid "You won't finish me?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:768
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:772
 msgid "No. If you're able to survive your wounds, you will be allowed to live."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:773
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:777
 msgid "Your face is familiar in some strange way... could it be..."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:774
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:778
 msgid "If you will answer my questions, I will answer yours."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:776
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:780
 msgid "Now, please tell me... Who are you?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:784
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:788
 msgid "Mother, do NOT harm this man."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:785
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:789
 msgid "But why, my son? He would have gladly harmed me, if given the chance."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:787
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:791
 msgid "Hm... you are still alive? There is strong spirit inside of your body. Stand and accept the final blow, but know that I won't damage your body further."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:816
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:820
 msgid "Where do we go from here?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:817
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:821
 msgid "I say to hell with that mage. Let's go to Vattin and announce that the king has returned..."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:818
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:822
 msgid "I strongly suggest we go to the Oracle."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:819
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:823
 msgid "...and the FIRST thing we will do in Vattin will be to kill all those who interrupt me when I speak."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:820
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:824
 msgid "Mother, Ruvio, could you please just TRY to pretend you like each other?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:821
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:825
 msgid "Not really."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:822
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:826
 msgid "Who or what is the Oracle anyway?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:823
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:827
 msgid "She's a woman, a mage with prophetic abilities. She was the only mage left in Vakladia by Akladians; I have no idea why. When one oracle dies, she is replaced by one of her apprentices. She may be able to sense where Deorien is, because she is also a mage."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:824
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:828
 msgid "The Oracle is not a mage, do not listen to him, my son. This worthless underling does not know God, that's why he is mistaken, as usual. If the Oracle knows the future, she is the voice of God on earth. If not, she is a tool of evil."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:825
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:829
 msgid "Stop calling him an underling. STOP using that word."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:826
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:830
 msgid "But what SHOULD I call him? He IS an underling."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:827
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:831
 msgid "And stop calling me your son. You are not my mother. My mother was an underling, wasn't she, Lorin? Poisoned by oh-so-noble Akladians, all full of their own hubris."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:828
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:832
 msgid "But why... why you are so angry at me? I... I... then what should I call you? My king? My lord?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:829
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:833
 msgid "At this point, I don't care."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:830
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:834
 msgid "Then maybe just... Gawen?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:831
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:835
 msgid "I told you, I don't care."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:832
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:836
 msgid "(<i>to herself</i>) But I... I think I care."
 msgstr ""
 
 #. [event]
 #. NIGHTMARE difficulty:
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:974
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:982
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:989
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:978
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:986
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:993
 msgid "This is not some skirmish! I think this is a situation which calls for using emergency reserves of gold."
 msgstr ""
 
@@ -7867,157 +7937,158 @@ msgid "My lord, we can't let anyone know that you live. No enemy should leave th
 msgstr ""
 
 #. [objective]: condition=win
-#: A_New_Order/scenarios/07_Ally_From_the_Past.cfg:352
-msgid "Kill the enemy leader and all enemy units. Don't allow any enemy unit to reach the north-western signpost, or the village nearby."
+#. trailing space is due to the appended footnote:
+#: A_New_Order/scenarios/07_Ally_From_the_Past.cfg:353
+msgid "Kill the enemy leader and all enemy units. Don't allow any enemy unit to reach the north-western signpost, or the village nearby. "
 msgstr ""
 
 #. [objective]: condition=lose
-#: A_New_Order/scenarios/07_Ally_From_the_Past.cfg:368
+#: A_New_Order/scenarios/07_Ally_From_the_Past.cfg:369
 msgid "Any enemy unit reaches north-western signpost"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/07_Ally_From_the_Past.cfg:400
+#: A_New_Order/scenarios/07_Ally_From_the_Past.cfg:402
 msgid "I will carry the message to Bor Cryne. He will reward me in gold!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/07_Ally_From_the_Past.cfg:401
+#: A_New_Order/scenarios/07_Ally_From_the_Past.cfg:403
 msgid "It's the end for us. We have no chance to escape now, for Bor Cryne will send his army."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/07_Ally_From_the_Past.cfg:513
+#: A_New_Order/scenarios/07_Ally_From_the_Past.cfg:515
 msgid "No! The Akladian reinforcements have arrived! We are surrounded!"
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/07_Ally_From_the_Past.cfg:555
+#: A_New_Order/scenarios/07_Ally_From_the_Past.cfg:557
 msgid "Wow."
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/07_Ally_From_the_Past.cfg:556
+#: A_New_Order/scenarios/07_Ally_From_the_Past.cfg:558
 msgid "What? Young women like me have to learn to defend ourselves."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/07_Ally_From_the_Past.cfg:571
+#: A_New_Order/scenarios/07_Ally_From_the_Past.cfg:573
 msgid "Isn't that the legendary Ruvio? It's a honour fighting for you! Command!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/07_Ally_From_the_Past.cfg:572
+#: A_New_Order/scenarios/07_Ally_From_the_Past.cfg:574
 msgid "Today you won't be commanded by me, but by this young man. I will only be his advisor."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/07_Ally_From_the_Past.cfg:573
+#: A_New_Order/scenarios/07_Ally_From_the_Past.cfg:575
 msgid "And who is he? Why should we fight under his command?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/07_Ally_From_the_Past.cfg:574
+#: A_New_Order/scenarios/07_Ally_From_the_Past.cfg:576
 msgid "Because I ask you to. Isn't my word enough?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/07_Ally_From_the_Past.cfg:575
+#: A_New_Order/scenarios/07_Ally_From_the_Past.cfg:577
 msgid "Well then, Ruvio. We'll listen to his orders. We hope you are not mistaken and this young boy can lead us to victory over the Akladian beasts."
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/07_Ally_From_the_Past.cfg:598
+#: A_New_Order/scenarios/07_Ally_From_the_Past.cfg:600
 msgid "Peasants and brawlers? How on earth am I supposed to win battle with those?"
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/07_Ally_From_the_Past.cfg:599
+#: A_New_Order/scenarios/07_Ally_From_the_Past.cfg:601
 msgid "You forgot about me!"
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/07_Ally_From_the_Past.cfg:600
+#: A_New_Order/scenarios/07_Ally_From_the_Past.cfg:602
 msgid "He didn't. He mentioned brawlers already."
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/07_Ally_From_the_Past.cfg:601
+#: A_New_Order/scenarios/07_Ally_From_the_Past.cfg:603
 msgid "True, they are not the best warriors, but you can recruit a lot of them, and they learn quickly. Our opponents are not numerous, and here they can't really recruit more soldiers. It'll be easy, believe me."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/07_Ally_From_the_Past.cfg:609
+#: A_New_Order/scenarios/07_Ally_From_the_Past.cfg:611
 msgid "See, I told you it would be easy."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/07_Ally_From_the_Past.cfg:610
+#: A_New_Order/scenarios/07_Ally_From_the_Past.cfg:612
 msgid "Yes, but only because they had limited soldiers and a fool for a commander. Where to go now?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/07_Ally_From_the_Past.cfg:611
+#: A_New_Order/scenarios/07_Ally_From_the_Past.cfg:613
 msgid "No one is left to inform Bor Cryne and his ilk that you survived the battle. We should go to Freetown next. The Akladians are all around us; we will have to cross the forests of Raedwood, and hope that the bandits living there won't attack us."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/07_Ally_From_the_Past.cfg:612
+#: A_New_Order/scenarios/07_Ally_From_the_Past.cfg:614
 msgid "It's a shame there weren't more Akladians to kill."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/07_Ally_From_the_Past.cfg:613
+#: A_New_Order/scenarios/07_Ally_From_the_Past.cfg:615
 msgid "There is one more left."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/07_Ally_From_the_Past.cfg:614
+#: A_New_Order/scenarios/07_Ally_From_the_Past.cfg:616
 msgid "Where?!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/07_Ally_From_the_Past.cfg:615
+#: A_New_Order/scenarios/07_Ally_From_the_Past.cfg:617
 msgid "I am Akladian. Do you want to kill me? Go ahead, I won't stop you."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/07_Ally_From_the_Past.cfg:616
+#: A_New_Order/scenarios/07_Ally_From_the_Past.cfg:618
 msgid "Stop it, kids! We've no time for fighting over poorly-chosen words. We have to reach Freetown as soon as possible. Haldric, Freetown is a rallying point for our people, where we are organizing our army. You'll meet the rest of my family there."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/07_Ally_From_the_Past.cfg:617
+#: A_New_Order/scenarios/07_Ally_From_the_Past.cfg:619
 msgid "Ruvio, call me 'Gawen.' I am not used to being called 'Haldric'. I've never heard about Freetown."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/07_Ally_From_the_Past.cfg:618
+#: A_New_Order/scenarios/07_Ally_From_the_Past.cfg:620
 msgid "It's hidden deep within the forests. Its location is our greatest secret. And, get used to being called 'Haldric'. I want everyone to swear they won't tell anyone that this man is the rightful king of Vakladia, Gawen Hagarthen. He is just 'Haldric' now. It'll be far better for you, Haldric, believe me. Much safer."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/07_Ally_From_the_Past.cfg:619
+#: A_New_Order/scenarios/07_Ally_From_the_Past.cfg:621
 msgid "Why? If Freetown's location is so secret, even if Akladian lords knew that I was still alive, they wouldn't be able to find me, right?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/07_Ally_From_the_Past.cfg:620
+#: A_New_Order/scenarios/07_Ally_From_the_Past.cfg:622
 msgid "I am thinking more about your safety amongst the Wesnothians inside of Freetown. Hagarthens were never really popular there. Let's go."
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/07_Ally_From_the_Past.cfg:673
+#: A_New_Order/scenarios/07_Ally_From_the_Past.cfg:675
 msgid "(<i>low whistle</i>)"
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/07_Ally_From_the_Past.cfg:675
+#: A_New_Order/scenarios/07_Ally_From_the_Past.cfg:677
 msgid "It's just a... you really know how to handle a blade."
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/07_Ally_From_the_Past.cfg:676
+#: A_New_Order/scenarios/07_Ally_From_the_Past.cfg:678
 msgid "If you want, I'll teach you a few things."
 msgstr ""
 
@@ -8026,12 +8097,19 @@ msgstr ""
 msgid "Unexpected Guests"
 msgstr ""
 
+#. [unit]: id=Reme Carrenemoe, type=Akladian Chieftain
+#: A_New_Order/scenarios/05_Unexpected_Guests.cfg:101
+#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:155
+#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:142
+msgid "Reme Carrenemoe"
+msgstr ""
+
 #. [side]: id=Lady Lorin, type=Akladian Lady
 #. [modify_side]
 #. [unit]: id=Lady Lorin, type=Akladian Lady
-#: A_New_Order/scenarios/05_Unexpected_Guests.cfg:155
+#: A_New_Order/scenarios/05_Unexpected_Guests.cfg:192
 #: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:25
-#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:1300
+#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:1326
 #: A_New_Order/scenarios/06_Separation.cfg:59
 #: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:138
 #: A_New_Order/scenarios/05_The_Swamp_Things.cfg:32
@@ -8042,189 +8120,189 @@ msgstr ""
 
 #. [side]: id=Uruk Maluf, type=Orcish Warrior
 #. [scenario]: id=05_Unexpected_Guests
-#: A_New_Order/scenarios/05_Unexpected_Guests.cfg:178
-#: A_New_Order/scenarios/05_Unexpected_Guests.cfg:257
+#: A_New_Order/scenarios/05_Unexpected_Guests.cfg:215
+#: A_New_Order/scenarios/05_Unexpected_Guests.cfg:295
 msgid "Uruk Maluf"
 msgstr ""
 
 #. [side]: id=Arlgor Maunarr, type=Orcish Warrior
 #. [scenario]: id=05_Unexpected_Guests
-#: A_New_Order/scenarios/05_Unexpected_Guests.cfg:201
-#: A_New_Order/scenarios/05_Unexpected_Guests.cfg:260
+#: A_New_Order/scenarios/05_Unexpected_Guests.cfg:238
+#: A_New_Order/scenarios/05_Unexpected_Guests.cfg:298
 msgid "Arlgor Maunarr"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/05_Unexpected_Guests.cfg:225
+#: A_New_Order/scenarios/05_Unexpected_Guests.cfg:262
 msgid "...anyway, this is the territory of my friend, who is loyal to Gawen Hagarthen. He will help us cure our wounded and provide us supplies to continue our journey."
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/05_Unexpected_Guests.cfg:236
+#: A_New_Order/scenarios/05_Unexpected_Guests.cfg:273
 msgid "I am not sure whether we have enough gold for this endeavour. I wish we'd gotten more in previous battles, at least 200."
 msgstr ""
 
 #. [objective]: condition=win
-#: A_New_Order/scenarios/05_Unexpected_Guests.cfg:242
+#: A_New_Order/scenarios/05_Unexpected_Guests.cfg:279
 msgid "Explore and try to find if Reme's friend is anywhere nearby"
 msgstr ""
 
 #. [event]
 #. discussion between two orcs
-#: A_New_Order/scenarios/05_Unexpected_Guests.cfg:292
+#: A_New_Order/scenarios/05_Unexpected_Guests.cfg:330
 msgid "Humans! Kill them all!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/05_Unexpected_Guests.cfg:305
+#: A_New_Order/scenarios/05_Unexpected_Guests.cfg:343
 msgid "No, no, no. We were told only to reconnoiter. We were given specific orders! We should withdraw to get the message back to headquarters. You know, da bosses."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/05_Unexpected_Guests.cfg:315
+#: A_New_Order/scenarios/05_Unexpected_Guests.cfg:353
 msgid "Kill them all! Kill them all! Humans!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/05_Unexpected_Guests.cfg:321
+#: A_New_Order/scenarios/05_Unexpected_Guests.cfg:359
 msgid "(<i>sigh</i>) Sometimes I feel I was born in the wrong time, wrong place, and wrong race."
 msgstr ""
 
 #. [event]
 #. This is a hint as to which orc Lorin should bother interrogating:
-#: A_New_Order/scenarios/05_Unexpected_Guests.cfg:328
+#: A_New_Order/scenarios/05_Unexpected_Guests.cfg:366
 msgid "It seems that the orc in the north is a bit more intelligent than the southern one."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/05_Unexpected_Guests.cfg:363
+#: A_New_Order/scenarios/05_Unexpected_Guests.cfg:402
 msgid "Wesnothian Peasant"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/05_Unexpected_Guests.cfg:363
+#: A_New_Order/scenarios/05_Unexpected_Guests.cfg:402
 msgid "We are liberated! Hurray! Wait a moment... those are Akladians. I never thought I would be glad to see them!"
 msgstr ""
 
 #. [event]
 #. some Akladian unit, possibly also Lorin
-#: A_New_Order/scenarios/05_Unexpected_Guests.cfg:374
+#: A_New_Order/scenarios/05_Unexpected_Guests.cfg:413
 msgid "My God! What happened here?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/05_Unexpected_Guests.cfg:376
+#: A_New_Order/scenarios/05_Unexpected_Guests.cfg:415
 msgid "One thing is for sure... we will find no shelter, no supplies, and none of Reme's friends here."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/05_Unexpected_Guests.cfg:388
+#: A_New_Order/scenarios/05_Unexpected_Guests.cfg:427
 msgid "You were a worthy opponent. My ancestors probably would decide to honour you by eating your heart. Now, die!"
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/05_Unexpected_Guests.cfg:395
+#: A_New_Order/scenarios/05_Unexpected_Guests.cfg:434
 msgid "Wait! I hate when you kill people before I have chance to interrogate them. Again."
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/05_Unexpected_Guests.cfg:396
+#: A_New_Order/scenarios/05_Unexpected_Guests.cfg:435
 msgid "'Again?' What do you mean?"
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/05_Unexpected_Guests.cfg:397
+#: A_New_Order/scenarios/05_Unexpected_Guests.cfg:436
 msgid "I had no time to play with that assassin sent to kill Gawen, don't you remember?"
 msgstr ""
 
 #. [else]
-#: A_New_Order/scenarios/05_Unexpected_Guests.cfg:400
+#: A_New_Order/scenarios/05_Unexpected_Guests.cfg:439
 msgid "Wait! I hate when you kill people before I have chance to interrogate them."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/05_Unexpected_Guests.cfg:412
+#: A_New_Order/scenarios/05_Unexpected_Guests.cfg:451
 msgid "Before I kill you, I want you to tell me everything you know! Why are you here? How come we have not heard about any Orcs?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/05_Unexpected_Guests.cfg:413
+#: A_New_Order/scenarios/05_Unexpected_Guests.cfg:452
 msgid "Kill the humans... good meat."
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/05_Unexpected_Guests.cfg:424
+#: A_New_Order/scenarios/05_Unexpected_Guests.cfg:463
 msgid "Sigh. We will get nothing more. The other one was far more intelligent."
 msgstr ""
 
 #. [else]
-#: A_New_Order/scenarios/05_Unexpected_Guests.cfg:427
+#: A_New_Order/scenarios/05_Unexpected_Guests.cfg:466
 msgid "Sigh. It seems we will get more from the second Orcish leader. This one is... I mean was... far less intelligent."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/05_Unexpected_Guests.cfg:441
+#: A_New_Order/scenarios/05_Unexpected_Guests.cfg:480
 msgid "Do not kill him! Leave the final blow to me, I have to interrogate him!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/05_Unexpected_Guests.cfg:451
+#: A_New_Order/scenarios/05_Unexpected_Guests.cfg:490
 msgid "Before I kill you, I want to ask you a question. Do you prefer to die painlessly or do you want me to think up some nightmarish way for you to die?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/05_Unexpected_Guests.cfg:452
+#: A_New_Order/scenarios/05_Unexpected_Guests.cfg:491
 msgid "Being killed by a human woman is already the most nightmarish way to die I can imagine."
 msgstr ""
 
 #. [event]
 #. Note to translators: A gelding is an animal that has been castrated.
-#: A_New_Order/scenarios/05_Unexpected_Guests.cfg:455
+#: A_New_Order/scenarios/05_Unexpected_Guests.cfg:494
 msgid "You are mistaken, my darling. I can prove it to you. I want you only to answer few questions. You said you are here to reconnoiter. Who sent you here? Answer now, or you will end your life as a miserable gelding!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/05_Unexpected_Guests.cfg:457
+#: A_New_Order/scenarios/05_Unexpected_Guests.cfg:496
 msgid "Wait, I will tell you. There is a large army to the north, preparing an assault on your kingdom. We were sent here to find a good path, destroy Castle Raumair and escort an envoy to our headquarters."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/05_Unexpected_Guests.cfg:458
+#: A_New_Order/scenarios/05_Unexpected_Guests.cfg:497
 msgid "Envoy? What envoy?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/05_Unexpected_Guests.cfg:459
+#: A_New_Order/scenarios/05_Unexpected_Guests.cfg:498
 msgid "A human. He hasn't appeared, though, we were waiting for him here."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/05_Unexpected_Guests.cfg:460
+#: A_New_Order/scenarios/05_Unexpected_Guests.cfg:499
 msgid "Wait - you were expecting human envoy here? And how did you make your way here through the underling realms?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/05_Unexpected_Guests.cfg:461
+#: A_New_Order/scenarios/05_Unexpected_Guests.cfg:500
 msgid "First question, yes, second, we weren't harassed. I don't know why. We were forbidden to pillage and attack anyone until we came into Vakladia. I know nothing more!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/05_Unexpected_Guests.cfg:462
+#: A_New_Order/scenarios/05_Unexpected_Guests.cfg:501
 msgid "Really? That's unfortunate for you. Reme, kill him quickly - I promised him a painless death if he would cooperate."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/05_Unexpected_Guests.cfg:470
+#: A_New_Order/scenarios/05_Unexpected_Guests.cfg:509
 msgid "My lady, it seems that those orcs had some gold with them."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/05_Unexpected_Guests.cfg:471
+#: A_New_Order/scenarios/05_Unexpected_Guests.cfg:510
 msgid "So I am still 'my lady' to you? This gold is probably the spoils from the burned homes of your friends. Doesn't that disturb you?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/05_Unexpected_Guests.cfg:472
+#: A_New_Order/scenarios/05_Unexpected_Guests.cfg:511
 msgid "I will bury part of the gold within Castle Raumair, along with the heads of the slain orcs. That should be recompense enough for my friends' ghosts. Besides, you shall have more need of the rest than they."
 msgstr ""
 
@@ -9352,10 +9430,10 @@ msgstr ""
 #: A_New_Order/scenarios/28_Lorin.cfg:215
 #: A_New_Order/scenarios/28_Lorin.cfg:221
 #: A_New_Order/scenarios/28_Lorin.cfg:264
-#: A_New_Order/scenarios/27_Orannon.cfg:819
-#: A_New_Order/scenarios/27_Orannon.cfg:864
-#: A_New_Order/scenarios/27_Orannon.cfg:866
-#: A_New_Order/scenarios/27_Orannon.cfg:869
+#: A_New_Order/scenarios/27_Orannon.cfg:820
+#: A_New_Order/scenarios/27_Orannon.cfg:865
+#: A_New_Order/scenarios/27_Orannon.cfg:867
+#: A_New_Order/scenarios/27_Orannon.cfg:870
 msgid "Luc Hagarthen"
 msgstr ""
 
@@ -9367,9 +9445,9 @@ msgstr ""
 #: A_New_Order/scenarios/28_Lorin.cfg:237
 #: A_New_Order/scenarios/28_Lorin.cfg:242
 #: A_New_Order/scenarios/28_Lorin.cfg:266
-#: A_New_Order/scenarios/27_Orannon.cfg:834
-#: A_New_Order/scenarios/27_Orannon.cfg:865
-#: A_New_Order/scenarios/27_Orannon.cfg:867
+#: A_New_Order/scenarios/27_Orannon.cfg:835
+#: A_New_Order/scenarios/27_Orannon.cfg:866
+#: A_New_Order/scenarios/27_Orannon.cfg:868
 msgid "Gauri Hagarthen"
 msgstr ""
 
@@ -10127,7 +10205,7 @@ msgstr ""
 
 #. [event]
 #: A_New_Order/scenarios/22_Leaving_Okladia.cfg:780
-#: A_New_Order/scenarios/15_Back_in_Freetown.cfg:158
+#: A_New_Order/scenarios/15_Back_in_Freetown.cfg:159
 msgid "What do you mean by that?"
 msgstr ""
 
@@ -10336,156 +10414,157 @@ msgid "My son, because you lost your memory, you probably forgot about some of o
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/16_Choosing_the_Best.cfg:201
+#. it's okay for Ruvio to use Gawen's real name here, since they are solely among allies here, with no need to worry about enemies overhearing them:
+#: A_New_Order/scenarios/16_Choosing_the_Best.cfg:202
 msgid "Wait a minute. Your father, Gawen, married Lorin after the death of your mother, didn't he?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/16_Choosing_the_Best.cfg:202
+#: A_New_Order/scenarios/16_Choosing_the_Best.cfg:203
 msgid "Who allowed you to listen, underling? This discussion is between two worthy people. Go and bother someone else."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/16_Choosing_the_Best.cfg:203
+#: A_New_Order/scenarios/16_Choosing_the_Best.cfg:204
 msgid "Your step-mother is really starting to get on my nerves."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/16_Choosing_the_Best.cfg:204
+#: A_New_Order/scenarios/16_Choosing_the_Best.cfg:205
 msgid "I said, a widow cannot have another man, whether it be another husband or in any other way. A man can. There was a time when men could even have a few wives at once. There are women who defy that old custom; some go unpunished. But I am wife to a king, and am held to a higher standard. What can perhaps be forgiven a normal woman cannot be tolerated of a king's wife."
 msgstr ""
 
 #. [event]
 #. EASY difficulty:
-#: A_New_Order/scenarios/16_Choosing_the_Best.cfg:207
+#: A_New_Order/scenarios/16_Choosing_the_Best.cfg:208
 msgid "My, what a wonderful culture you have. But we can speak on this later. Now, Gawen, choose the eighteen very best troops to take along with us."
 msgstr ""
 
 #. [event]
 #. NORMAL difficulty:
-#: A_New_Order/scenarios/16_Choosing_the_Best.cfg:211
+#: A_New_Order/scenarios/16_Choosing_the_Best.cfg:212
 msgid "My, what a wonderful culture you have. But we can speak on this later. Now, Gawen, choose the fifteen best troops to take along with us."
 msgstr ""
 
 #. [event]
 #. HARD difficulty; intentionally truncated a bit compared to the previous 2 difficulties:
-#: A_New_Order/scenarios/16_Choosing_the_Best.cfg:215
+#: A_New_Order/scenarios/16_Choosing_the_Best.cfg:216
 msgid "My, what a wonderful culture you have. But we can speak on this later. Now, Gawen, choose twelve troops."
 msgstr ""
 
 #. [event]
 #. NIGHTMARE difficulty:
-#: A_New_Order/scenarios/16_Choosing_the_Best.cfg:219
+#: A_New_Order/scenarios/16_Choosing_the_Best.cfg:220
 msgid "My, what a wonderful culture you have. But... well, anyways, Gawen, choose your nine troops."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/16_Choosing_the_Best.cfg:228
+#: A_New_Order/scenarios/16_Choosing_the_Best.cfg:229
 msgid "I want to join you in your quest."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/16_Choosing_the_Best.cfg:235
+#: A_New_Order/scenarios/16_Choosing_the_Best.cfg:236
 msgid "I will also join you in your quest."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/16_Choosing_the_Best.cfg:237
+#: A_New_Order/scenarios/16_Choosing_the_Best.cfg:238
 msgid "I will join you in your quest."
 msgstr ""
 
 #. [objectives]
 #. EASY difficulty:
-#: A_New_Order/scenarios/16_Choosing_the_Best.cfg:243
+#: A_New_Order/scenarios/16_Choosing_the_Best.cfg:244
 msgid "There is too little space to recall all 18 units at once. Move the units out of the castle to make room for others. The units will be able to move (in this scenario only!!) immediately after recalling, so do not push end turn button."
 msgstr ""
 
 #. [objectives]
 #. NORMAL difficulty; "this time" is supposed to be slightly more vague than "(in this scenario only!!)":
-#: A_New_Order/scenarios/16_Choosing_the_Best.cfg:247
+#: A_New_Order/scenarios/16_Choosing_the_Best.cfg:248
 msgid "There is too little space to recall all 15 units at once. Move the units out of the castle to make room for others. The units will be able to move this time immediately after recalling, so do not push end turn button."
 msgstr ""
 
 #. [objectives]
 #. HARD difficulty; supposed to be shorter and vaguer than on the two easier difficulties:
-#: A_New_Order/scenarios/16_Choosing_the_Best.cfg:251
+#: A_New_Order/scenarios/16_Choosing_the_Best.cfg:252
 msgid "There is too little space to recall all 12 units at once. Move the units away to make room. The units will have “haste” (to borrow a term from a famous trading card game), so avoid ending your turn prematurely."
 msgstr ""
 
 #. [note]
-#: A_New_Order/scenarios/16_Choosing_the_Best.cfg:256
+#: A_New_Order/scenarios/16_Choosing_the_Best.cfg:257
 msgid "Any units not recalled will be left behind in Freetown. Players who normally avoid recalling their level 3 units to save them for later in the campaign may want to forgo that strategy this time."
 msgstr ""
 
 #. [objective]: condition=win
 #. EASY difficulty:
-#: A_New_Order/scenarios/16_Choosing_the_Best.cfg:261
+#: A_New_Order/scenarios/16_Choosing_the_Best.cfg:262
 msgid "Recall eighteen troops. OR"
 msgstr ""
 
 #. [objective]: condition=win
 #. NORMAL difficulty:
-#: A_New_Order/scenarios/16_Choosing_the_Best.cfg:265
+#: A_New_Order/scenarios/16_Choosing_the_Best.cfg:266
 msgid "Recall fifteen troops. OR"
 msgstr ""
 
 #. [objective]: condition=win
 #. HARD difficulty:
-#: A_New_Order/scenarios/16_Choosing_the_Best.cfg:269
+#: A_New_Order/scenarios/16_Choosing_the_Best.cfg:270
 msgid "Recall twelve troops. OR"
 msgstr ""
 
 #. [objective]: condition=win
 #. NIGHTMARE difficulty:
-#: A_New_Order/scenarios/16_Choosing_the_Best.cfg:273
+#: A_New_Order/scenarios/16_Choosing_the_Best.cfg:274
 msgid "Recall nine troops. OR"
 msgstr ""
 
 #. [objective]: condition=win
-#: A_New_Order/scenarios/16_Choosing_the_Best.cfg:278
+#: A_New_Order/scenarios/16_Choosing_the_Best.cfg:279
 msgid "End turn if you do not want or can't recall more troops."
 msgstr ""
 
 #. [then]
 #. [else]
-#: A_New_Order/scenarios/16_Choosing_the_Best.cfg:312
-#: A_New_Order/scenarios/16_Choosing_the_Best.cfg:326
+#: A_New_Order/scenarios/16_Choosing_the_Best.cfg:313
+#: A_New_Order/scenarios/16_Choosing_the_Best.cfg:327
 msgid "Say, Kyobaine..."
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/16_Choosing_the_Best.cfg:314
+#: A_New_Order/scenarios/16_Choosing_the_Best.cfg:315
 msgid "It's getting to be spring now... do you think you still really need that winter cloak?"
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/16_Choosing_the_Best.cfg:315
+#: A_New_Order/scenarios/16_Choosing_the_Best.cfg:316
 msgid "You're right, it <i>is</i> starting to get rather warm with it on..."
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/16_Choosing_the_Best.cfg:320
+#: A_New_Order/scenarios/16_Choosing_the_Best.cfg:321
 msgid "...and, there we go."
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/16_Choosing_the_Best.cfg:321
+#: A_New_Order/scenarios/16_Choosing_the_Best.cfg:322
 msgid "Good, just making sure you're comfortable."
 msgstr ""
 
 #. [else]
 #. threateningly:
-#: A_New_Order/scenarios/16_Choosing_the_Best.cfg:329
+#: A_New_Order/scenarios/16_Choosing_the_Best.cfg:330
 msgid "Do you REALLY feel like trying your luck, human?"
 msgstr ""
 
 #. [else]
-#: A_New_Order/scenarios/16_Choosing_the_Best.cfg:330
+#: A_New_Order/scenarios/16_Choosing_the_Best.cfg:331
 msgid "...you're right, never mind."
 msgstr ""
 
 #. [else]
-#: A_New_Order/scenarios/16_Choosing_the_Best.cfg:332
+#: A_New_Order/scenarios/16_Choosing_the_Best.cfg:333
 msgid "Hm, I feel as though I may have missed out on something... oh well."
 msgstr ""
 
@@ -10626,7 +10705,7 @@ msgstr ""
 #. [event]
 #. [option]
 #: A_New_Order/scenarios/03_Coronation.cfg:258
-#: A_New_Order/scenarios/08_Outlaw_Base.cfg:349
+#: A_New_Order/scenarios/08_Outlaw_Base.cfg:350
 msgid "Uri van Roe?"
 msgstr ""
 
@@ -10639,7 +10718,7 @@ msgstr ""
 #. [event]
 #. [option]
 #: A_New_Order/scenarios/03_Coronation.cfg:267
-#: A_New_Order/scenarios/08_Outlaw_Base.cfg:355
+#: A_New_Order/scenarios/08_Outlaw_Base.cfg:356
 msgid "Bor Cryne?"
 msgstr ""
 
@@ -10684,7 +10763,7 @@ msgstr ""
 #. [event]
 #: A_New_Order/scenarios/19a_The_Woods_of_Okladia.cfg:212
 #: A_New_Order/scenarios/19b_Entering_Okladia.cfg:202
-msgid "We'd better get hurrying, Gawen! If we don't make it to the signpost in time, reinforcements could arrive and trap us!"
+msgid "We'd better get hurrying! If we don't make it to the signpost in time, reinforcements could arrive and trap us!"
 msgstr ""
 
 #. [event]
@@ -11544,482 +11623,482 @@ msgstr ""
 
 #. [option]
 #. debug option; completes sentence starting with "Set scenario status to...":
-#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:537
+#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:543
 msgid "Uri personally attacking Barnon."
 msgstr ""
 
 #. [option]
 #. debug option; completes sentence starting with "Set scenario status to...":
-#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:547
+#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:559
 msgid "moving on to Unexpected Guests."
 msgstr ""
 
 #. [option]
 #. debug option; completes sentence starting with "Set scenario status to...":
-#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:571
+#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:590
 msgid "moving on to The Swamp Things."
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:612
+#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:638
 msgid "It is a dark day indeed, to see Akladian lords siding with an underling bastard child. What will your ancestors say about this, Uri?"
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:613
+#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:639
 msgid "Hoyre, you have always been my friend. I would never fight against you. Rather, I join with you to kill that mixling!"
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:620
+#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:646
 msgid "I've never intended to fight against you, Hoyre. Let our swords instead cut that underling's head off! And slay that witch, his step-mother, as well!"
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:631
-#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:663
-#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:1382
-#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:2177
+#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:657
+#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:689
+#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:1408
+#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:2203
 msgid "Reach either the eastern or western signpost with both Lorin AND Reme. After that, hold on at least $ano_howmanyturns turns before the honorable death of Gawen Hagarthen."
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:649
+#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:675
 msgid "We spent so many days drinking and fighting together. Now you come with an army against me? What about our plans, Bor?"
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:650
+#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:676
 msgid "Our plans haven't changed, Hoyre. You were and are my friend. I only came here with the underling so we could trap him. I am with you!"
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:655
+#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:681
 msgid "Noble Lords, count on me too! Death to that scraggy mixling, that witch and all the traitors who support them against our own kin! God with us! Kill them all, let us eat their hearts!"
 msgstr ""
 
 #. [print]
-#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:712
+#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:738
 msgid "With this turn, you have met the survival requirement!"
 msgstr ""
 
 #. [print]
 #. FIXME: plurals; see: https://github.com/wesnoth/wesnoth/issues/1135
-#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:720
+#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:746
 msgid "Bonus for resisting $ano_tmp| turns above requirement"
 msgstr ""
 
 #. [print]
-#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:730
+#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:756
 msgid "Resisted $ano_barnon_turns| turns."
 msgstr ""
 
 #. [else]
-#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:747
+#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:773
 msgid "Gawen, you really ought to be getting us out of here..."
 msgstr ""
 
 #. [else]
-#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:751
+#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:777
 msgid "I thought I told my men to evacuate my step-mother, yet she remains on the battlefield... how stubborn..."
 msgstr ""
 
 #. [else]
-#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:755
+#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:781
 msgid "Wait a second, something odd seems to be happening here..."
 msgstr ""
 
 #. [else]
-#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:758
+#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:784
 msgid "At this moment, Gawen remembered what he was trying to do."
 msgstr ""
 
 #. [event]: id=Uri_gets_impatient
-#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:871
+#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:897
 msgid "This is taking too long. Men, gather me an escort, for I shall be taking this battle to the mixling myself!"
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:895
+#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:921
 msgid "To Barnon!"
 msgstr ""
 
 #. [else]
-#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:898
+#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:924
 msgid "You can't stay holed up there forever, Gawen!"
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:933
+#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:959
 msgid "The mixling resists my attack! Men, join me!"
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:1007
-#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:1127
+#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:1033
+#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:1153
 msgid "You'd better watch out, Gawen, because I've got more where that came from!"
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:1016
-#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:1136
+#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:1042
+#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:1162
 msgid "I told you I had more guards!"
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:1053
+#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:1079
 msgid "Men, join me in my attack!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:1165
+#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:1191
 msgid "Your city has fallen, Gawen! Surrender now, and I promise you that we won't torture you <small>(as much)</small> before killing you!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:1166
+#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:1192
 msgid "Never!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:1178
+#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:1204
 msgid "I tire of this. Men, the task now returns to you to kill that scraggy mixling!"
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:1275
+#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:1301
 msgid "I hope both Reme and Lorin have made it... Aaargh!"
 msgstr ""
 
 #. [message]: speaker=second_unit
-#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:1285
+#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:1311
 msgid "I think we killed him, my lord!"
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:1287
+#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:1313
 msgid "You 'think'!? Where is his body? Search for it, fools, I want to be sure!"
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:1364
+#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:1390
 msgid "...well, now that Gawen thinks he's won, there's no need to keep up this farce, is there, Bor?"
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:1371
-#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:2166
+#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:1397
+#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:2192
 msgid "Indeed, Uri, there isn't! Let our swords instead cut that underling's head off! And slay that witch, his step-mother, as well!"
 msgstr ""
 
 #. [else]
-#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:1387
+#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:1413
 msgid "Using debug mode to kill all the enemies is cheating!"
 msgstr ""
 
 #. [else]
-#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:1389
+#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:1415
 msgid "DEBUG_MODE is defined; that means you probably cheated to kill all the enemies!"
 msgstr ""
 
 #. [else]
-#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:1392
+#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:1418
 msgid "Despite the incredible odds stacked against him, Gawen somehow managed to defeat all of his enemies at Barnon."
 msgstr ""
 
 #. [else]
-#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:1393
+#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:1419
 msgid "However, this meant that he never managed to unite the warring factions of Wesnoth..."
 msgstr ""
 
 #. [else]
-#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:1395
+#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:1421
 msgid "This is an early end to the campaign. If you would like to see the rest of it, please replay this scenario and let Gawen be defeated as he is supposed to be."
 msgstr ""
 
 #. [else]
-#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:1396
+#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:1422
 msgid "For now, though, we shall skip ahead to the campaign wrap-up."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:1439
+#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:1465
 msgid "If this campaign were continuing normally from here, Lorin would receive a bonus of $bonus_amt|g per each turn above the minimum of $ano_howmanyturns extra turns: $ano_barnon_turns"
 msgstr ""
 
 #. [event]
 #. TODO: consider rewording to make it clearer what the last two variables are:
-#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:1442
+#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:1468
 msgid "Gawen's sacrifice successfully bought Lorin more time to escape! Thus, she gets a bonus for his resistance: Lorin receives $bonus_amt|g per each turn above $ano_howmanyturns: $ano_barnon_turns"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:1476
+#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:1502
 msgid "Oh no! Fresh enemy reinforcements have arrived, Reme, and you have no chance to escape! I can't hold them!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:1482
+#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:1508
 msgid "Oh no! Fresh enemy reinforcements have arrived, Lorin, and you have no chance to escape! I can't hold them!"
 msgstr ""
 
 #. [event]
 #. This in fact should be EXTREMELY hard. In fact, it ought to be impossible, as the turn limit becomes unlimited after Reme and Lorin escape:
-#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:1488
+#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:1514
 msgid "After the end of the day king's forces were defeated; however, no one could find the body of Gawen Hagarthen."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:1555
-#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:1576
+#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:1581
+#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:1602
 msgid "Argh! I am wounded!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:1556
-#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:1577
+#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:1582
+#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:1603
 msgid "They got Hoyre! My friend! You will be avenged!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:1557
+#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:1583
 msgid "I am alive, but I must run away! They try to kill me!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:1558
+#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:1584
 msgid "Run away? You are an Akladian Lord, stay and fight!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:1559
+#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:1585
 msgid "Fortunately I have a hideout here..."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:1563
+#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:1589
 msgid "Where is he? He must have hid somewhere!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:1578
+#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:1604
 msgid "No, he is not dead, he is just heavily wounded and has lost consciousness!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:1579
+#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:1605
 msgid "How did you manage to kill Hoyre? This shouldn't happen... Hoyre was supposed to run away when approached. Contact the maintainers with your savegame and replay for review!"
 msgstr ""
 
 #. [event]
 #. Bor Cryne shouldn't die either way, whether debug mode is on or not, so the fact that we recognize debug mode specially here is just an easter egg:
-#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:1595
-#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:1648
+#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:1621
+#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:1674
 msgid "Using debug mode to kill Bor Cryne is cheating!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:1597
+#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:1623
 msgid "It appears that debug mode either is on, or has been on in the past, so it's not clear if you're cheating to kill Bor Cryne or not... better restart just to be sure!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:1600
+#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:1626
 msgid "How did you manage to kill Bor Cryne? This shouldn't happen... it means the level is too easy. Stop what you are doing and contact the maintainers with your savegame and replay for review!"
 msgstr ""
 
 #. [event]
 #. This ought to be impossible, but just in case:
-#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:1629
+#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:1655
 msgid "How did Hoyre manage to kill Bor Cryne? This shouldn't happen... it means something went wrong. Contact the maintainers with your savegame and replay for review!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:1650
+#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:1676
 msgid "It appears that debug mode either is on, or has been on in the past, so it's not clear if you're cheating to cause Bor Cryne to die or not... better restart just to be sure!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:1653
+#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:1679
 msgid "How did Bor Cryne manage to die? This shouldn't happen... it means something went wrong. Contact the maintainers with your savegame and replay for review!"
 msgstr ""
 
 #. [event]
 #. Uri van Roe shouldn't die either way, whether debug mode is on or not, so the fact that we recognize debug mode specially here is just an easter egg:
-#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:1668
-#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:1721
+#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:1694
+#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:1747
 msgid "Using debug mode to kill Uri van Roe is cheating!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:1670
+#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:1696
 msgid "It appears that debug mode either is on, or has been on in the past, so it's not clear if you're cheating to kill Uri van Roe or not... better restart just to be sure!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:1673
+#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:1699
 msgid "How did you manage to kill Uri van Roe? This shouldn't happen... it means the level is too easy. Contact the maintainers with your savegame and replay for review!"
 msgstr ""
 
 #. [event]
 #. This ought to be impossible, but just in case:
-#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:1702
+#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:1728
 msgid "How did Hoyre manage to kill Uri van Roe? This shouldn't happen... it means something went wrong. Contact the maintainers with your savegame and replay for review!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:1723
+#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:1749
 msgid "It appears that debug mode either is on, or has been on in the past, so it's not clear if you're cheating to cause Uri van Roe to die or not... better restart just to be sure!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:1726
+#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:1752
 msgid "How did Uri van Roe manage to die? This shouldn't happen... it means something went wrong. Contact the maintainers with your savegame and replay for review!"
 msgstr ""
 
 #. [event]
 #. unused:
-#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:1744
+#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:1770
 msgid "Ah! He's coming for me! Time to use my reserves!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:1799
+#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:1825
 msgid "Ah! He's coming for me! What happened to my reserves?!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:1808
-#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:1974
+#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:1834
+#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:2000
 msgid "My lord, we really should try to escape, this battle is impossible to win!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:1814
+#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:1840
 msgid "Here are my reserves!"
 msgstr ""
 
 #. [event]
 #. unused:
-#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:1884
+#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:1910
 msgid "Ha! Come and get some! I have some nasty surprises for you!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:1967
+#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:1993
 msgid "Ha! Come and get some! I'm more than ready for you!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:1980
+#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:2006
 msgid "Time for some nasty surprises for you!"
 msgstr ""
 
 #. [event]: id=Hoyre_escapes
-#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:2079
+#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:2105
 msgid "My faithful warriors, it's time to show your loyalty to the clan!"
 msgstr ""
 
 #. [event]: id=Hoyre_escapes
-#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:2116
+#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:2142
 msgid "Do not worry, I will soon be back, with reinforcements!"
 msgstr ""
 
 #. [event]: id=Hoyre_escapes
 #. I'm guessing Bor Cryne is wondering if Hoyre's mother was actually Wesnothian?
-#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:2140
+#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:2166
 msgid "This Hoyre... Sometimes I wonder whether his mother... It seems, Uri, that we will have to finish this on our own."
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:2159
+#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:2185
 msgid "...well, now that Hoyre's no longer around, there's no need to keep up this farce, is there, Bor?"
 msgstr ""
 
 #. [event]: id=Hoyre_returns
-#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:2208
+#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:2234
 msgid "I'm back with the reinforcements, just as promised!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:2234
+#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:2260
 msgid "Ha! It seems Uri left behind some gold here after setting out from this encampment!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:2240
+#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:2266
 msgid "Now wait just a minute here! Men, look around and see if they dropped any of their own gold!"
 msgstr ""
 
 #. [event]
 #. Bor Cryne's response here assumes that Uri is still alive (which he ought to be) and said his line:
-#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:2242
+#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:2268
 msgid "Yes, gold for all true Akladians!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:2243
+#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:2269
 msgid "Bor Cryne and Uri van Roe have each received $gold_amt gold pieces."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:2273
+#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:2299
 msgid "yet he is still alive"
 msgstr ""
 
 #. [event]
 #. I was so sure our warriors will kill that
-#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:2276
+#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:2302
 msgid "pikeneer"
 msgstr ""
 
 #. [event]
 #. I was so sure our warriors will kill that
-#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:2279
+#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:2305
 msgid "protector"
 msgstr ""
 
 #. [event]
 #. I was so sure our warriors will kill that
-#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:2282
+#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:2308
 msgid "clansman"
 msgstr ""
 
 #. [event]
 #. I was so sure our warriors will kill that
-#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:2285
+#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:2311
 msgid "shieldguard"
 msgstr ""
 
 #. [event]
 #. I was so sure our warriors will kill that
-#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:2288
+#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:2314
 msgid "homeguard"
 msgstr ""
 
 #. [event]
 #. I was so sure our warriors will kill that
-#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:2291
+#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:2317
 msgid "raider"
 msgstr ""
 
 #. [event]
 #. I was so sure our warriors will kill that
-#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:2294
+#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:2320
 msgid "light infantryman"
 msgstr ""
 
 #. [event]
 #. I was so sure our warriors will kill that
 #. I was so sure our warriors will kill that
-#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:2297
-#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:2324
+#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:2323
+#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:2350
 msgid "warrior"
 msgstr ""
 
 #. [event]
 #. I was so sure our warriors will kill that
-#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:2300
+#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:2326
 msgid "fastfoot"
 msgstr ""
 
@@ -12027,9 +12106,9 @@ msgstr ""
 #. I was so sure our warriors will kill that
 #. I was so sure our warriors will kill that
 #. I was so sure our warriors will kill that
-#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:2303
-#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:2306
-#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:2309
+#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:2329
+#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:2332
+#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:2335
 msgid "underling"
 msgstr ""
 
@@ -12037,31 +12116,31 @@ msgstr ""
 #. I was so sure our warriors will kill that
 #. I was so sure our warriors will kill that
 #. I was so sure our warriors will kill that
-#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:2312
-#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:2316
-#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:2320
+#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:2338
+#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:2342
+#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:2346
 msgid "witch, his stepmother"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:2313
-#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:2317
-#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:2321
+#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:2339
+#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:2343
+#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:2347
 msgid "yet she is still alive"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:2330
+#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:2356
 msgid "This underling has incredible luck!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:2331
+#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:2357
 msgid "What do you mean, Bor?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:2332
+#: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:2358
 msgid "I don't know how to explain this. But... For example, I was so sure our warriors will kill that $tmp, $tmpg|!"
 msgstr ""
 
@@ -12384,129 +12463,129 @@ msgstr ""
 #. this hint is only present on EASY, NORMAL, and HARD, but not NIGHTMARE, though:
 #. this hint is only present on EASY, NORMAL, and HARD, but not NIGHTMARE, though:
 #: A_New_Order/scenarios/27_Orannon.cfg:735
-#: A_New_Order/scenarios/27_Orannon.cfg:1135
+#: A_New_Order/scenarios/27_Orannon.cfg:1136
 msgid "In this scenario, only Gawen and Lorin have full interrogations for enemy leaders."
 msgstr ""
 
 #. [option]
 #. debug option; completes sentence starting with "Set scenario status to...":
-#: A_New_Order/scenarios/27_Orannon.cfg:769
+#: A_New_Order/scenarios/27_Orannon.cfg:770
 msgid "Grekulak's arrival."
 msgstr ""
 
 #. [option]
 #. debug option; completes sentence starting with "Set scenario status to...":
-#: A_New_Order/scenarios/27_Orannon.cfg:779
+#: A_New_Order/scenarios/27_Orannon.cfg:780
 msgid "Grekulak's attempt at spreading darkness."
 msgstr ""
 
 #. [unit]: id=Lucs, type=Akladian Protector
-#: A_New_Order/scenarios/27_Orannon.cfg:805
-#: A_New_Order/scenarios/27_Orannon.cfg:843
-#: A_New_Order/scenarios/27_Orannon.cfg:851
-#: A_New_Order/scenarios/27_Orannon.cfg:859
+#: A_New_Order/scenarios/27_Orannon.cfg:806
+#: A_New_Order/scenarios/27_Orannon.cfg:844
+#: A_New_Order/scenarios/27_Orannon.cfg:852
+#: A_New_Order/scenarios/27_Orannon.cfg:860
 msgid "Lucs"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/27_Orannon.cfg:864
+#: A_New_Order/scenarios/27_Orannon.cfg:865
 msgid "Aww, we're too late! Our cousin had all the fun and left nothing for us!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/27_Orannon.cfg:865
+#: A_New_Order/scenarios/27_Orannon.cfg:866
 msgid "We would have been here earlier, if not for you, brother!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/27_Orannon.cfg:866
+#: A_New_Order/scenarios/27_Orannon.cfg:867
 msgid "Me? And who wanted to check whether the wine in Vakladia tastes different than in Guilcorta?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/27_Orannon.cfg:867
+#: A_New_Order/scenarios/27_Orannon.cfg:868
 msgid "And what about the girls in that town?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/27_Orannon.cfg:868
+#: A_New_Order/scenarios/27_Orannon.cfg:869
 msgid "Who are you? Friend or foe?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/27_Orannon.cfg:869
+#: A_New_Order/scenarios/27_Orannon.cfg:870
 msgid "We are Luc and Gauri Hagarthen, your loyal swords from Guilcorta, your cousins, dear... uhmm... how should we address you, your majesty, cousin, or maybe... messiah?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/27_Orannon.cfg:870
+#: A_New_Order/scenarios/27_Orannon.cfg:871
 msgid "'My king' would be enough. You are welcomed here, even if a bit late."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/27_Orannon.cfg:916
+#: A_New_Order/scenarios/27_Orannon.cfg:917
 msgid "Aaargh! I haven't avenged my family!"
 msgstr ""
 
 #. [event]: id=Grekulak_arrives
-#: A_New_Order/scenarios/27_Orannon.cfg:1103
+#: A_New_Order/scenarios/27_Orannon.cfg:1104
 msgid "Ha ha! Now you are doomed!"
 msgstr ""
 
 #. [event]: id=Grekulak_arrives
-#: A_New_Order/scenarios/27_Orannon.cfg:1120
+#: A_New_Order/scenarios/27_Orannon.cfg:1121
 msgid "I am your new messiah. Recognise me as your lord now and you shall be spared. Try to oppose me and you will be killed and raised as my mindless slaves."
 msgstr ""
 
 #. [event]: id=Grekulak_arrives
 #. Hint that Huon's recruits have changed:
-#: A_New_Order/scenarios/27_Orannon.cfg:1122
+#: A_New_Order/scenarios/27_Orannon.cfg:1123
 msgid "Never, foul lich! We may have to adjust our tactics, but we shall never surrender!"
 msgstr ""
 
 #. [event]: id=Grekulak_arrives
-#: A_New_Order/scenarios/27_Orannon.cfg:1123
+#: A_New_Order/scenarios/27_Orannon.cfg:1124
 msgid "Lady Lorin, are you sure you can participate in a battle?"
 msgstr ""
 
 #. [event]: id=Grekulak_arrives
-#: A_New_Order/scenarios/27_Orannon.cfg:1124
+#: A_New_Order/scenarios/27_Orannon.cfg:1125
 msgid "And why not, foul and rude mage?"
 msgstr ""
 
 #. [event]: id=Grekulak_arrives
-#: A_New_Order/scenarios/27_Orannon.cfg:1125
+#: A_New_Order/scenarios/27_Orannon.cfg:1126
 msgid "As I said before, I KNOW. I also know that ANY effort may be extremely dangerous for you."
 msgstr ""
 
 #. [event]: id=Grekulak_arrives
-#: A_New_Order/scenarios/27_Orannon.cfg:1126
+#: A_New_Order/scenarios/27_Orannon.cfg:1127
 msgid "First of all, I am LORIN, foul mage. Second of all, I am not a Wesnothian woman, the kind you are used to, but Akladian. I can fight until... for as long as I want."
 msgstr ""
 
 #. [event]: id=Grekulak_arrives
-#: A_New_Order/scenarios/27_Orannon.cfg:1127
+#: A_New_Order/scenarios/27_Orannon.cfg:1128
 msgid "My king, please take my advice. Order Lorin to withdraw into the castle. No matter how she boasts and flaunts her Akladian heritage, I am quite sure she shouldn't be here."
 msgstr ""
 
 #. [event]: id=Grekulak_arrives
-#: A_New_Order/scenarios/27_Orannon.cfg:1128
+#: A_New_Order/scenarios/27_Orannon.cfg:1129
 msgid "But why? I don't understand. Lorin is a fine warrior, and withdrawing her from battle may be..."
 msgstr ""
 
 #. [event]: id=Grekulak_arrives
-#: A_New_Order/scenarios/27_Orannon.cfg:1129
+#: A_New_Order/scenarios/27_Orannon.cfg:1130
 msgid "I am a mage attuned to life, my king, and can sense things you cannot. Believe me, withdraw her into our keep."
 msgstr ""
 
 #. [event]: id=Grekulak_arrives
-#: A_New_Order/scenarios/27_Orannon.cfg:1130
+#: A_New_Order/scenarios/27_Orannon.cfg:1131
 msgid "FOUL mage. You should have said: 'I am a FOUL mage'."
 msgstr ""
 
 #. [event]: id=Grekulak_darkens
 #. This incantation that Grekulak tries should sound (or at least look) poetic:
-#: A_New_Order/scenarios/27_Orannon.cfg:1185
+#: A_New_Order/scenarios/27_Orannon.cfg:1186
 msgid ""
 "\n"
 "Forces of Darkness, come to my aid -\n"
@@ -12519,181 +12598,186 @@ msgid ""
 msgstr ""
 
 #. [event]: id=Grekulak_darkens
-#: A_New_Order/scenarios/27_Orannon.cfg:1274
+#: A_New_Order/scenarios/27_Orannon.cfg:1275
 msgid "NO! Avaunt, the darkness, avaunt, the night!"
 msgstr ""
 
 #. [event]: id=Grekulak_darkens
-#: A_New_Order/scenarios/27_Orannon.cfg:1302
+#: A_New_Order/scenarios/27_Orannon.cfg:1303
 msgid "How is this possible? Who could possibly have broken my sorcery?"
 msgstr ""
 
 #. [event]: id=Grekulak_darkens
-#: A_New_Order/scenarios/27_Orannon.cfg:1303
+#: A_New_Order/scenarios/27_Orannon.cfg:1304
 msgid "Even a child could have done it, it was so weak... as is all of your heinous black magic; for all your power has been built solely on lies and deceit."
 msgstr ""
 
 #. [event]: id=Grekulak_darkens
-#: A_New_Order/scenarios/27_Orannon.cfg:1304
+#: A_New_Order/scenarios/27_Orannon.cfg:1305
 msgid "Brave words - and who dares to utter them?"
 msgstr ""
 
 #. [event]: id=Grekulak_darkens
 #. please preserve the cheesy rhyming here on translation, so that Grekulak's reply calling Deorien an "awful poet" makes sense:
-#: A_New_Order/scenarios/27_Orannon.cfg:1306
+#: A_New_Order/scenarios/27_Orannon.cfg:1307
 msgid "Deorien, mage of light - whose might will defeat the night."
 msgstr ""
 
 #. [event]: id=Grekulak_darkens
-#: A_New_Order/scenarios/27_Orannon.cfg:1307
+#: A_New_Order/scenarios/27_Orannon.cfg:1308
 msgid "You are a competent enough mage, but an awful poet. Deorien, you will be mine before this battle is through."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/27_Orannon.cfg:1348
+#: A_New_Order/scenarios/27_Orannon.cfg:1349
 msgid "Aaaah!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/27_Orannon.cfg:1349
+#: A_New_Order/scenarios/27_Orannon.cfg:1350
 msgid "What happened? Mother?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/27_Orannon.cfg:1350
+#: A_New_Order/scenarios/27_Orannon.cfg:1351
 msgid "It's nothing... It's nothing... I just... I can't..."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/27_Orannon.cfg:1351
+#: A_New_Order/scenarios/27_Orannon.cfg:1352
 msgid "Ahem."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/27_Orannon.cfg:1352
+#: A_New_Order/scenarios/27_Orannon.cfg:1353
 msgid "Shut up, mage. I will fight, I just have to rest for a moment..."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/27_Orannon.cfg:1353
+#: A_New_Order/scenarios/27_Orannon.cfg:1354
 msgid "No, you CAN'T. My lord, you must withdraw Lorin to our castle's keep immediately. She is unable to fight any longer."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/27_Orannon.cfg:1365
+#: A_New_Order/scenarios/27_Orannon.cfg:1366
 msgid "I AM in the castle's keep, you idiot."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/27_Orannon.cfg:1366
+#: A_New_Order/scenarios/27_Orannon.cfg:1367
 msgid "Good. Now, go to bedroom. I will send someone to take care of you immediately."
-msgstr ""
-
-#. [event]
-#: A_New_Order/scenarios/27_Orannon.cfg:1376
-#: A_New_Order/scenarios/27_Orannon.cfg:1381
-msgid "Shut up, I can fight, I just have to get some rest!"
 msgstr ""
 
 #. [event]
 #: A_New_Order/scenarios/27_Orannon.cfg:1377
 #: A_New_Order/scenarios/27_Orannon.cfg:1382
+msgid "Shut up, I can fight, I just have to get some rest!"
+msgstr ""
+
+#. [event]
+#: A_New_Order/scenarios/27_Orannon.cfg:1378
+#: A_New_Order/scenarios/27_Orannon.cfg:1383
 msgid "You have to withdraw Lady Lorin to your initial castle's keep within 6 turns."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/27_Orannon.cfg:1397
+#: A_New_Order/scenarios/27_Orannon.cfg:1398
 msgid "Are you prepared for a little surprise? Get them boys!"
 msgstr ""
 
+#. [then]
+#: A_New_Order/scenarios/27_Orannon.cfg:1436
+msgid "Gawen, I'm going to destroy this bridge."
+msgstr ""
+
 #. [message]: speaker=unit
-#: A_New_Order/scenarios/27_Orannon.cfg:1431
+#: A_New_Order/scenarios/27_Orannon.cfg:1442
 msgid "Milord, should I destroy this bridge?"
 msgstr ""
 
-#. [event]
-#: A_New_Order/scenarios/27_Orannon.cfg:1437
+#. [else]
+#: A_New_Order/scenarios/27_Orannon.cfg:1448
 msgid "Yes!"
 msgstr ""
 
-#. [event]
-#: A_New_Order/scenarios/27_Orannon.cfg:1438
+#. [else]
+#: A_New_Order/scenarios/27_Orannon.cfg:1449
 msgid "No, but I might want a bridge destroyed later..."
 msgstr ""
 
-#. [event]
-#: A_New_Order/scenarios/27_Orannon.cfg:1439
+#. [else]
+#: A_New_Order/scenarios/27_Orannon.cfg:1450
 msgid "No, we won't be destroying any bridges today."
 msgstr ""
 
 #. [message]: speaker=unit
-#: A_New_Order/scenarios/27_Orannon.cfg:1498
+#: A_New_Order/scenarios/27_Orannon.cfg:1511
 msgid "Ha, take that!"
 msgstr ""
 
 #. [message]: speaker=unit
-#: A_New_Order/scenarios/27_Orannon.cfg:1503
+#: A_New_Order/scenarios/27_Orannon.cfg:1516
 msgid "OK, I won't this time, but I really think we should destroy some bridges eventually, so I'll keep asking!"
 msgstr ""
 
 #. [message]: speaker=unit
-#: A_New_Order/scenarios/27_Orannon.cfg:1509
+#: A_New_Order/scenarios/27_Orannon.cfg:1522
 msgid "In that case I shall cease asking to do so."
 msgstr ""
 
 #. [message]: speaker=unit
-#: A_New_Order/scenarios/27_Orannon.cfg:1525
+#: A_New_Order/scenarios/27_Orannon.cfg:1538
 msgid "Let me set up an outpost here."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/27_Orannon.cfg:1550
+#: A_New_Order/scenarios/27_Orannon.cfg:1563
 msgid "I really can fight!"
 msgstr ""
 
 #. [event]
 #. "Note for translators: 'But what about IT?' refers to Lorin's child"
-#: A_New_Order/scenarios/27_Orannon.cfg:1552
+#: A_New_Order/scenarios/27_Orannon.cfg:1565
 msgid "Yes, you can fight. But what about IT?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/27_Orannon.cfg:1553
+#: A_New_Order/scenarios/27_Orannon.cfg:1566
 msgid "IT?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/27_Orannon.cfg:1572
+#: A_New_Order/scenarios/27_Orannon.cfg:1585
 msgid "Aaah! I can't handle this pain!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/27_Orannon.cfg:1573
+#: A_New_Order/scenarios/27_Orannon.cfg:1586
 msgid "What happened? What?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/27_Orannon.cfg:1574
+#: A_New_Order/scenarios/27_Orannon.cfg:1587
 msgid "I told you... she miscarried."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/27_Orannon.cfg:1575
+#: A_New_Order/scenarios/27_Orannon.cfg:1588
 msgid "She WHAT?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/27_Orannon.cfg:1576
+#: A_New_Order/scenarios/27_Orannon.cfg:1589
 msgid "Noooooo!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/27_Orannon.cfg:1581
+#: A_New_Order/scenarios/27_Orannon.cfg:1594
 msgid "I wish Lorin were still here to fight alongside us; we could use her help..."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/27_Orannon.cfg:1582
+#: A_New_Order/scenarios/27_Orannon.cfg:1595
 msgid "Trust me, Gawen, it is for the better that she is in the castle right now."
 msgstr ""
 
@@ -12876,109 +12960,110 @@ msgid ""
 msgstr ""
 
 #. [objective]: condition=win
-#: A_New_Order/scenarios/12_Leaving_Raedwood.cfg:208
-msgid "Move Gawen to southern edge of the map OR"
-msgstr ""
-
-#. [event]
-#: A_New_Order/scenarios/12_Leaving_Raedwood.cfg:253
-msgid "Uhmmm... I should interrogate him, right? So... uh... what did you eat for breakfast?"
+#. trailing space is intentional, to pad the footnote a bit:
+#: A_New_Order/scenarios/12_Leaving_Raedwood.cfg:209
+msgid "Move Gawen to southern edge of the map "
 msgstr ""
 
 #. [event]
 #: A_New_Order/scenarios/12_Leaving_Raedwood.cfg:255
-msgid "Oh, never mind."
-msgstr ""
-
-#. [event]
-#: A_New_Order/scenarios/12_Leaving_Raedwood.cfg:256
-msgid "Wait, don't kill him!"
+msgid "Uhmmm... I should interrogate him, right? So... uh... what did you eat for breakfast?"
 msgstr ""
 
 #. [event]
 #: A_New_Order/scenarios/12_Leaving_Raedwood.cfg:257
+msgid "Oh, never mind."
+msgstr ""
+
+#. [event]
+#: A_New_Order/scenarios/12_Leaving_Raedwood.cfg:258
+msgid "Wait, don't kill him!"
+msgstr ""
+
+#. [event]
+#: A_New_Order/scenarios/12_Leaving_Raedwood.cfg:259
 msgid "He's already dying. I don't think he can be of any more help to us."
 msgstr ""
 
 #. [event]
 #. FIXME: this wording is still kind of awkward; the "So" at the start implies he's continuing a previous conversation,
 #. but the player may have forgotten which conversation that was (it was the one at the start):
-#: A_New_Order/scenarios/12_Leaving_Raedwood.cfg:296
+#: A_New_Order/scenarios/12_Leaving_Raedwood.cfg:298
 msgid "So he had nothing to say after all."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/12_Leaving_Raedwood.cfg:297
+#: A_New_Order/scenarios/12_Leaving_Raedwood.cfg:299
 msgid "I know, I was only curious."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/12_Leaving_Raedwood.cfg:302
+#: A_New_Order/scenarios/12_Leaving_Raedwood.cfg:304
 msgid "Well, is your curiosity satisfied?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/12_Leaving_Raedwood.cfg:303
+#: A_New_Order/scenarios/12_Leaving_Raedwood.cfg:305
 msgid "I guess..."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/12_Leaving_Raedwood.cfg:319
+#: A_New_Order/scenarios/12_Leaving_Raedwood.cfg:321
 msgid "You just let him die?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/12_Leaving_Raedwood.cfg:320
+#: A_New_Order/scenarios/12_Leaving_Raedwood.cfg:322
 msgid "It seemed like he didn't have anything important to say."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/12_Leaving_Raedwood.cfg:321
+#: A_New_Order/scenarios/12_Leaving_Raedwood.cfg:323
 msgid "If you say so."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/12_Leaving_Raedwood.cfg:330
+#: A_New_Order/scenarios/12_Leaving_Raedwood.cfg:332
 msgid "Just as I've told you, I rarely miss!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/12_Leaving_Raedwood.cfg:338
+#: A_New_Order/scenarios/12_Leaving_Raedwood.cfg:340
 msgid "What the... elves!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/12_Leaving_Raedwood.cfg:346
+#: A_New_Order/scenarios/12_Leaving_Raedwood.cfg:348
 msgid "Eeek! Elves! The green devils are here!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/12_Leaving_Raedwood.cfg:351
+#: A_New_Order/scenarios/12_Leaving_Raedwood.cfg:353
 msgid "We fought our way out of forest. What now?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/12_Leaving_Raedwood.cfg:352
+#: A_New_Order/scenarios/12_Leaving_Raedwood.cfg:354
 msgid "Now Gaumhaldric the Great will accomplish all those amazing deeds that will cause bards to sing about him in the future!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/12_Leaving_Raedwood.cfg:353
+#: A_New_Order/scenarios/12_Leaving_Raedwood.cfg:355
 msgid "Ruvio, would you please send her back home?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/12_Leaving_Raedwood.cfg:354
+#: A_New_Order/scenarios/12_Leaving_Raedwood.cfg:356
 msgid "Stop it, kids. We've got to keep moving. We have a mission to accomplish."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/12_Leaving_Raedwood.cfg:355
+#: A_New_Order/scenarios/12_Leaving_Raedwood.cfg:357
 msgid "A GREAT mission. Hey, Gaumhaldric, I think I just came up with a song about this. Do you want to hear it?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/12_Leaving_Raedwood.cfg:361
+#: A_New_Order/scenarios/12_Leaving_Raedwood.cfg:363
 msgid "If you want my advice, I think you may want to use our elves. Six elves should be able to hold off the eastern leader on their own, especially using hit-and-run tactics. Alternatively, you may ignore one of the enemies entirely and concentrate all of your forces against the other one. There's no hurry; we've got quite a lot of time."
 msgstr ""
 
@@ -13091,236 +13176,236 @@ msgstr ""
 
 #. [objective]: condition=win
 #: A_New_Order/scenarios/08_Outlaw_Base.cfg:211
-#: A_New_Order/scenarios/02_Fighting_for_Passage.cfg:343
+#: A_New_Order/scenarios/02_Fighting_for_Passage.cfg:344
 msgid "Kill the enemy leader."
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/08_Outlaw_Base.cfg:242
+#: A_New_Order/scenarios/08_Outlaw_Base.cfg:243
 msgid "Wow! They actually know how to fight!"
 msgstr ""
 
 #. [then]
 #. Translation Note: "Marks" means easy targets/victims, usually of someone trying to rob or cheat them:
-#: A_New_Order/scenarios/08_Outlaw_Base.cfg:250
+#: A_New_Order/scenarios/08_Outlaw_Base.cfg:251
 msgid "Hmm... perhaps they are not such easy marks as I thought."
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/08_Outlaw_Base.cfg:257
+#: A_New_Order/scenarios/08_Outlaw_Base.cfg:258
 msgid "Heavens! They really know how to fight! Stop toying with them!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/08_Outlaw_Base.cfg:290
+#: A_New_Order/scenarios/08_Outlaw_Base.cfg:291
 msgid "Argh! Why would you not at least grant me the honor of death at the hand of your commander? I should have liked to learn his name..."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/08_Outlaw_Base.cfg:291
-#: A_New_Order/scenarios/08_Outlaw_Base.cfg:307
+#: A_New_Order/scenarios/08_Outlaw_Base.cfg:292
+#: A_New_Order/scenarios/08_Outlaw_Base.cfg:308
 msgid "My name is Ga... uhmm... Haldric."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/08_Outlaw_Base.cfg:292
+#: A_New_Order/scenarios/08_Outlaw_Base.cfg:293
 msgid "Gaumhaldric? Wow, every name is better than the last."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/08_Outlaw_Base.cfg:293
+#: A_New_Order/scenarios/08_Outlaw_Base.cfg:294
 msgid "It wouldn't have been so easy for you if the bulk of our army hadn't been elsewhere..."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/08_Outlaw_Base.cfg:304
+#: A_New_Order/scenarios/08_Outlaw_Base.cfg:305
 msgid "So you were worthy opponents, after all! It's a shame we didn't meet in other circumstances, or we might have been friends."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/08_Outlaw_Base.cfg:305
+#: A_New_Order/scenarios/08_Outlaw_Base.cfg:306
 msgid "You need not die, Rob Roe. I do not wish for your death. I will let you live."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/08_Outlaw_Base.cfg:306
+#: A_New_Order/scenarios/08_Outlaw_Base.cfg:307
 msgid "What's your name, noble stranger, so I can know whom to thank?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/08_Outlaw_Base.cfg:308
+#: A_New_Order/scenarios/08_Outlaw_Base.cfg:309
 msgid "So, Gaumhaldric, may I fight for you? I and my people too?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/08_Outlaw_Base.cfg:309
+#: A_New_Order/scenarios/08_Outlaw_Base.cfg:310
 msgid "Wow! Seems you have earned a new nickname, Gaumhaldric."
 msgstr ""
 
 #. [message]: speaker=Gawen Hagarthen
-#: A_New_Order/scenarios/08_Outlaw_Base.cfg:312
+#: A_New_Order/scenarios/08_Outlaw_Base.cfg:313
 msgid "After some thought..."
 msgstr ""
 
 #. [option]
-#: A_New_Order/scenarios/08_Outlaw_Base.cfg:314
+#: A_New_Order/scenarios/08_Outlaw_Base.cfg:315
 msgid "Yes, I shall accept you and any of your people who want to fight in my army."
 msgstr ""
 
 #. [option]
-#: A_New_Order/scenarios/08_Outlaw_Base.cfg:327
+#: A_New_Order/scenarios/08_Outlaw_Base.cfg:328
 msgid "No offense, but I don't trust you enough."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/08_Outlaw_Base.cfg:330
+#: A_New_Order/scenarios/08_Outlaw_Base.cfg:331
 msgid "You said most of your army is elsewhere?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/08_Outlaw_Base.cfg:331
+#: A_New_Order/scenarios/08_Outlaw_Base.cfg:332
 msgid "Yes. Our best units were hired to invade the Carrenemoe clan."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/08_Outlaw_Base.cfg:332
+#: A_New_Order/scenarios/08_Outlaw_Base.cfg:333
 msgid "The Carrenemoes? Ruvio, we have to..."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/08_Outlaw_Base.cfg:333
+#: A_New_Order/scenarios/08_Outlaw_Base.cfg:334
 msgid "We must get to Freetown as soon as possible. I'm sorry, kid."
 msgstr ""
 
 #. [then]
 #. Gawen is about to say "me" before remembering he's not supposed to reveal who he is, so instead he pretends "Gawen Hagarthen" is a different person:
-#: A_New_Order/scenarios/08_Outlaw_Base.cfg:338
+#: A_New_Order/scenarios/08_Outlaw_Base.cfg:339
 msgid "Rob Roe, there was assassin who was sent after m... Gawen Hagarthen. He was interrogated and he said he was sent from an 'Outlaw Place.' Do you know who hired him to kill king Gawen Hagarthen?"
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/08_Outlaw_Base.cfg:339
+#: A_New_Order/scenarios/08_Outlaw_Base.cfg:340
 msgid "I am not sure. Perhaps you can say a few names, and I will tell you if any of them rings a bell?"
 msgstr ""
 
 #. [message]: speaker=Gawen Hagarthen
-#: A_New_Order/scenarios/08_Outlaw_Base.cfg:347
+#: A_New_Order/scenarios/08_Outlaw_Base.cfg:348
 msgid "So, what about..."
 msgstr ""
 
 #. [command]
-#: A_New_Order/scenarios/08_Outlaw_Base.cfg:351
+#: A_New_Order/scenarios/08_Outlaw_Base.cfg:352
 msgid "No, I don't think it was him."
 msgstr ""
 
 #. [command]
 #. Konrad2 thinks the "a" before "father and son" should be removed, but maybe switching it (the "a") to "both" would make more sense? I dunno; leaving that part as-is for now:
-#: A_New_Order/scenarios/08_Outlaw_Base.cfg:358
+#: A_New_Order/scenarios/08_Outlaw_Base.cfg:359
 msgid "Yes! I remember that name now! He set a price on the head of a father and son. I think it was also he who paid us to invade the Carrenemoes' holdings."
 msgstr ""
 
 #. [option]
-#: A_New_Order/scenarios/08_Outlaw_Base.cfg:365
+#: A_New_Order/scenarios/08_Outlaw_Base.cfg:366
 msgid "Reme Carrenemoe?"
 msgstr ""
 
 #. [command]
-#: A_New_Order/scenarios/08_Outlaw_Base.cfg:367
+#: A_New_Order/scenarios/08_Outlaw_Base.cfg:368
 msgid "The noble and honorable Reme? You have got to be kidding."
 msgstr ""
 
 #. [option]
-#: A_New_Order/scenarios/08_Outlaw_Base.cfg:371
+#: A_New_Order/scenarios/08_Outlaw_Base.cfg:372
 msgid "Lady Lorin?"
 msgstr ""
 
 #. [command]
-#: A_New_Order/scenarios/08_Outlaw_Base.cfg:373
+#: A_New_Order/scenarios/08_Outlaw_Base.cfg:374
 msgid "No, it wasn't a woman. People from the Gallorae clan did contact us in the past about buying some poison, but that was years ago."
 msgstr ""
 
 #. [option]
-#: A_New_Order/scenarios/08_Outlaw_Base.cfg:379
+#: A_New_Order/scenarios/08_Outlaw_Base.cfg:380
 msgid "Graeme O Borraine?"
 msgstr ""
 
 #. [command]
-#: A_New_Order/scenarios/08_Outlaw_Base.cfg:381
+#: A_New_Order/scenarios/08_Outlaw_Base.cfg:382
 msgid "Who? Never heard of him."
 msgstr ""
 
 #. [option]
-#: A_New_Order/scenarios/08_Outlaw_Base.cfg:385
+#: A_New_Order/scenarios/08_Outlaw_Base.cfg:386
 msgid "Hoyre O Barnon?"
 msgstr ""
 
 #. [command]
-#: A_New_Order/scenarios/08_Outlaw_Base.cfg:387
+#: A_New_Order/scenarios/08_Outlaw_Base.cfg:388
 msgid "The guy from city of Barnon? No, it wasn't him, though from what I've heard about him he could do it - if he could think for himself."
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/08_Outlaw_Base.cfg:414
+#: A_New_Order/scenarios/08_Outlaw_Base.cfg:415
 msgid "There are no more trained, able-bodied young man in this small settlement to recruit as Spearman or Bowman. You may only recruit Peasants and Fencers now."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/08_Outlaw_Base.cfg:427
+#: A_New_Order/scenarios/08_Outlaw_Base.cfg:428
 msgid "Oh, there is a horse in this village. I can ride it!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/08_Outlaw_Base.cfg:439
+#: A_New_Order/scenarios/08_Outlaw_Base.cfg:440
 msgid "...see?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/08_Outlaw_Base.cfg:440
+#: A_New_Order/scenarios/08_Outlaw_Base.cfg:441
 msgid "You look different now."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/08_Outlaw_Base.cfg:441
+#: A_New_Order/scenarios/08_Outlaw_Base.cfg:442
 msgid "It's amazing the effect that getting on horseback can have on one's appearance, isn't it?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/08_Outlaw_Base.cfg:442
+#: A_New_Order/scenarios/08_Outlaw_Base.cfg:443
 msgid "Indeed."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/08_Outlaw_Base.cfg:591
+#: A_New_Order/scenarios/08_Outlaw_Base.cfg:592
 msgid "Ha! Our army has returned! You are doomed now!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/08_Outlaw_Base.cfg:604
+#: A_New_Order/scenarios/08_Outlaw_Base.cfg:605
 msgid "Hm, it seems there are some more people here, capable with spears and bows, who could be recruited."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/08_Outlaw_Base.cfg:605
+#: A_New_Order/scenarios/08_Outlaw_Base.cfg:606
 msgid "You may recruit four more archers and/or spearmen."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/08_Outlaw_Base.cfg:608
+#: A_New_Order/scenarios/08_Outlaw_Base.cfg:609
 msgid "It seems that the outlaws had a small treasury hidden here."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/08_Outlaw_Base.cfg:610
+#: A_New_Order/scenarios/08_Outlaw_Base.cfg:611
 msgid "You receive $gold_amt golden pieces."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/08_Outlaw_Base.cfg:631
+#: A_New_Order/scenarios/08_Outlaw_Base.cfg:632
 msgid "Haw haw haw, you thought we were here to fight <i><b>for</b></i> you? Think again, fools!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/08_Outlaw_Base.cfg:634
+#: A_New_Order/scenarios/08_Outlaw_Base.cfg:635
 msgid "$unit.name turned out to be an outlaw!"
 msgstr ""
 
@@ -13996,167 +14081,168 @@ msgid "The winter was just ending when we returned to Freetown. Soldiers were si
 msgstr ""
 
 #. [part]
-#: A_New_Order/scenarios/15_Back_in_Freetown.cfg:19
+#. This is all just Gawen being clueless here; he's missing that they're actually still passive-aggressively exchanging stealth insults:
+#: A_New_Order/scenarios/15_Back_in_Freetown.cfg:20
 msgid "Even Lorin and Karen seemed to finally be getting along. I thought they might have started to like each other. Karen had even promised to show Lorin a few easy exercises to help her to regain the slenderness of her youth."
 msgstr ""
 
 #. [part]
-#: A_New_Order/scenarios/15_Back_in_Freetown.cfg:25
+#: A_New_Order/scenarios/15_Back_in_Freetown.cfg:26
 msgid "Rob Roe disappeared one night and no one, not even the outlaws in my army, knew the reasons of Roe's sudden disappearance. Outlaws were startled by the event and many of them refused to follow my orders any more."
 msgstr ""
 
 #. [part]
-#: A_New_Order/scenarios/15_Back_in_Freetown.cfg:30
+#: A_New_Order/scenarios/15_Back_in_Freetown.cfg:31
 msgid "Ruvio insisted on leaving all Akladians in our army outside the city, in the forest, but I refused. Of course, the inhabitants of Freetown weren't eager to let Akladians into their city. But there were no serious incidents, much to Ruvio's surprise."
 msgstr ""
 
 #. [part]
-#: A_New_Order/scenarios/15_Back_in_Freetown.cfg:33
+#: A_New_Order/scenarios/15_Back_in_Freetown.cfg:34
 msgid "Huon and Mithrandil returned a few days after our arrival. When the time appointed for our next meeting came, nobody questioned my right to be there. Lorin also insisted on participating and, after a short quarrel, Gwidle, the most respected leader of the people of Freetown, agreed."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/15_Back_in_Freetown.cfg:147
+#: A_New_Order/scenarios/15_Back_in_Freetown.cfg:148
 msgid "Greetings and wishes of long life and luck for everyone, even for those who were not invited here and who really should never have entered this city. Mithrandil, you were one who insisted on this gathering, so please, begin."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/15_Back_in_Freetown.cfg:148
+#: A_New_Order/scenarios/15_Back_in_Freetown.cfg:149
 msgid "Yes, indeed. The news brought here by Ruvio and this brave young man is quite important."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/15_Back_in_Freetown.cfg:149
+#: A_New_Order/scenarios/15_Back_in_Freetown.cfg:150
 msgid "But why? All they brought back is a name: Grekulak.  What's so important about that?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/15_Back_in_Freetown.cfg:150
+#: A_New_Order/scenarios/15_Back_in_Freetown.cfg:151
 msgid "I think everyone here knows the legends about Wesnoth's past. When our kingdom was powerful and rich. You may also recall the old story about the invasion by evil forces from the east, led by the evil lich, Mal-Ravanal."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/15_Back_in_Freetown.cfg:151
+#: A_New_Order/scenarios/15_Back_in_Freetown.cfg:152
 msgid "What? Of course not, that would be a legend from WESNOTHIAN culture.  Is this yet another fairy tale?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/15_Back_in_Freetown.cfg:152
+#: A_New_Order/scenarios/15_Back_in_Freetown.cfg:153
 msgid "During this invasion, large parts of Wesnoth were turned into barren wasteland. The swamps of Saorduc were vast, fertile lands a mere three hundred years ago. But this was before a civil war that left Wesnoth divided."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/15_Back_in_Freetown.cfg:153
+#: A_New_Order/scenarios/15_Back_in_Freetown.cfg:154
 msgid "Yes, we know this story. That's why the Akladians were able to conquer us... we were splintered. They could never have been succesful had we been united."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/15_Back_in_Freetown.cfg:154
+#: A_New_Order/scenarios/15_Back_in_Freetown.cfg:155
 msgid "We won because this land was given to us by God. That's why he divided you and made you forget how to handle swords, why you became weak. When we came, mercenaries were doing all the fighting for you."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/15_Back_in_Freetown.cfg:155
+#: A_New_Order/scenarios/15_Back_in_Freetown.cfg:156
 msgid "So, as I was saying before you were so kind as to interrupt me, some time ago a new leader appeared amongst the orcs. His name was Grekulak. He united orcish tribes, one by one, using treachery and gold.  Right now he rules more than a third of the orcish hordes."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/15_Back_in_Freetown.cfg:156
+#: A_New_Order/scenarios/15_Back_in_Freetown.cfg:157
 msgid "Wait, wait. You were talking about Mal-Ravanal. What does he have to do with Grekulak?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/15_Back_in_Freetown.cfg:157
+#: A_New_Order/scenarios/15_Back_in_Freetown.cfg:158
 msgid "We believe that Grekulak is one of the last surviving adepts of Mal-Ravanal. We suspected that he was behind the sudden alliance of orcs and Akladians. Now we are certain. We are also sure that this orcish invasion is just the beginning."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/15_Back_in_Freetown.cfg:159
+#: A_New_Order/scenarios/15_Back_in_Freetown.cfg:160
 msgid "I mean you will face a full-scale invasion soon. An undead army, orcs, and who-knows-what else. You will need help from the mages."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/15_Back_in_Freetown.cfg:160
+#: A_New_Order/scenarios/15_Back_in_Freetown.cfg:161
 msgid "Great. Akladians, orcs, zombies... and we need the help of the mages. I imagine that, being a wise elf and all, you know of course that no mages exist anymore. Maybe a few on the Isle of Alduin, or in besieged Elensefar, but not enough to help us."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/15_Back_in_Freetown.cfg:161
+#: A_New_Order/scenarios/15_Back_in_Freetown.cfg:162
 msgid "Actually, I'm pretty sure that Mithrandil is thinking about ONE specific mage. Am I correct?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/15_Back_in_Freetown.cfg:162
+#: A_New_Order/scenarios/15_Back_in_Freetown.cfg:163
 msgid "Yes. Deorien. A white mage, living somewhere in eastern Wesnoth. You should go and find him. I will give you my soldiers and even gold, if you want. This should be all I need to tell you for now."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/15_Back_in_Freetown.cfg:163
+#: A_New_Order/scenarios/15_Back_in_Freetown.cfg:164
 msgid "Then this meeting is adjourned. Take the evening to ponder this counsel, and we will re-convene and discuss everything on the morrow."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/15_Back_in_Freetown.cfg:175
+#: A_New_Order/scenarios/15_Back_in_Freetown.cfg:176
 msgid "Great. The green devils advise us to seek the help of those who are a blight on the face of God's world. The MAGES."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/15_Back_in_Freetown.cfg:176
+#: A_New_Order/scenarios/15_Back_in_Freetown.cfg:177
 msgid "You often speak about something you call God, Lorin. Can you tell us more about your God?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/15_Back_in_Freetown.cfg:177
+#: A_New_Order/scenarios/15_Back_in_Freetown.cfg:178
 msgid "He is the force behind the universe. He created the world and is our father. He gave us the world to rule. One of his angels tried to stop us from doing that, deceiving us and trying to imprison us in his garden, but a messiah came from the Hagarthen clan. He told us that God desired us to wait no more..."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/15_Back_in_Freetown.cfg:178
+#: A_New_Order/scenarios/15_Back_in_Freetown.cfg:179
 msgid "So we killed that evil angel and his minions to journey west. We fought our way through the deserts and the swamps, fighting with nightmarish creatures, not to mention lizards and green elves. I was raised hearing songs about this epic journey."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/15_Back_in_Freetown.cfg:179
+#: A_New_Order/scenarios/15_Back_in_Freetown.cfg:180
 msgid "Finally, we reached Wesnoth, our people decimated but hardened because it was the wish of God that our weak should perish before we began our holy task. When we came from the east the underling armies were like dust before a wind. We conquered Wesnoth. Well, almost."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/15_Back_in_Freetown.cfg:180
+#: A_New_Order/scenarios/15_Back_in_Freetown.cfg:181
 msgid "As for mages, they are the main adversaries of God in his fight for the good of the universe, attempting to usurp his powers for themselves. Elves are minions of the fallen angels. They are to be exterminated."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/15_Back_in_Freetown.cfg:181
+#: A_New_Order/scenarios/15_Back_in_Freetown.cfg:182
 msgid "Oh my goodness. Wow. You are not joking, you actually believe all that?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/15_Back_in_Freetown.cfg:182
+#: A_New_Order/scenarios/15_Back_in_Freetown.cfg:183
 msgid "Anyway, if we are going to find that mage-trash, we need to know where he is. Any ideas where to find him?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/15_Back_in_Freetown.cfg:183
+#: A_New_Order/scenarios/15_Back_in_Freetown.cfg:184
 msgid "Well, we could ask the Oracle. Due to the prophetic nature of her abilities, she may know where to search for Deorien."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/15_Back_in_Freetown.cfg:184
+#: A_New_Order/scenarios/15_Back_in_Freetown.cfg:185
 msgid "The Oracle? The Oracle is a hoax. She knows nothing. She once told me... she... she deceived me. Her prophecy has not been, and cannot be, fullfilled."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/15_Back_in_Freetown.cfg:185
+#: A_New_Order/scenarios/15_Back_in_Freetown.cfg:186
 msgid "The Oracle never deceives anyone. She just looks into the sea of magic and sees everything that may happen. So, she is not saying what MUST, but what MAY happen."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/15_Back_in_Freetown.cfg:187
+#: A_New_Order/scenarios/15_Back_in_Freetown.cfg:188
 msgid "It means, if she tells you that you will be the best swimmer in the world, you will be a great swimmer if you put forth the effort. But the prophecy won't be fullfilled if you never get into the water, sit around, and wait. Also, sometimes people misinterpret her words."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/15_Back_in_Freetown.cfg:188
+#: A_New_Order/scenarios/15_Back_in_Freetown.cfg:189
 msgid "No. No. That's not true. That's... leave me alone."
 msgstr ""
 
@@ -15091,474 +15177,474 @@ msgid "To the Oracle"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:149
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:150
 msgid "So, should we go to the Oracle?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:159
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:160
 msgid "My lord, we already visited the Oracle."
-msgstr ""
-
-#. [event]
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:168
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:192
-msgid "My lord, I really insist we visit the Oracle first."
 msgstr ""
 
 #. [event]
 #: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:169
 #: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:193
-msgid "Well, I think that..."
+msgid "My lord, I really insist we visit the Oracle first."
 msgstr ""
 
 #. [event]
 #: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:170
 #: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:194
-msgid "I already know where Deorien may be."
+msgid "Well, I think that..."
 msgstr ""
 
 #. [event]
 #: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:171
 #: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:195
+msgid "I already know where Deorien may be."
+msgstr ""
+
+#. [event]
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:172
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:196
 msgid "You are right. Let's go to the Oracle first."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:173
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:174
 msgid "So, should we pick the route to Okladia that goes through the hills?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:179
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:203
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:180
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:204
 msgid "This option is mainly intended for players, who already played 'A New Order' in the past, or don't care much about the story. If you do not fall in either category, consider reloading."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:181
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:182
 msgid "All right, we shall take the path through the hills to Okladia. Note that we could have taken a different path through the woods to get to Okladia instead, but it is too late for that now!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:197
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:198
 msgid "So, should we pick the route to Okladia that goes through the woods?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:205
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:206
 msgid "All right, we shall take the path through the woods to Okladia. Note that we could have taken a different path through the hills to get to Okladia instead, but it is too late for that now!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:216
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:217
 msgid "Welcome to our village, noble travelers."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:217
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:218
 msgid "We are freedom fighters searching for the mage Deorien."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:218
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:219
 msgid "Freedom fighters? Yeah, sure... Just, please, do not fight for freedom here. We are honest, hardworking people."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:224
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:315
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:376
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:485
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:225
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:316
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:377
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:486
 msgid "Do you know where the Oracle lives?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:230
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:382
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:491
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:231
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:383
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:492
 msgid "Why anyone would want to fight for you?"
-msgstr ""
-
-#. [event]
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:233
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:384
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:493
-msgid "You have a chance to fight for your freedom."
 msgstr ""
 
 #. [event]
 #: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:234
 #: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:385
 #: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:494
-msgid "I may be your future king."
+msgid "You have a chance to fight for your freedom."
 msgstr ""
 
 #. [event]
 #: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:235
 #: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:386
 #: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:495
-msgid "In my army you may change your lot."
+msgid "I may be your future king."
 msgstr ""
 
 #. [event]
 #: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:236
 #: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:387
 #: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:496
+msgid "In my army you may change your lot."
+msgstr ""
+
+#. [event]
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:237
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:388
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:497
 msgid "Why not?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:238
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:239
 msgid "In this forest, we are free already."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:240
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:241
 msgid "No kidding. I mean, no kidding, your Majesty."
-msgstr ""
-
-#. [event]
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:242
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:437
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:524
-msgid "Change my lot? What do you mean?"
 msgstr ""
 
 #. [event]
 #: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:243
 #: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:438
 #: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:525
-msgid "Well, you know, you may earn some gold, and if you are lucky, you may even became a knight."
+msgid "Change my lot? What do you mean?"
 msgstr ""
 
 #. [event]
 #: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:244
-msgid "A knight? Ha, ha, I thought you were serious. There are only archers in this village."
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:439
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:526
+msgid "Well, you know, you may earn some gold, and if you are lucky, you may even became a knight."
 msgstr ""
 
 #. [event]
 #: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:245
-msgid "The best archers earn 45 gold pieces when hired, and twenty gold pieces for each battle."
+msgid "A knight? Ha, ha, I thought you were serious. There are only archers in this village."
 msgstr ""
 
 #. [event]
 #: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:246
+msgid "The best archers earn 45 gold pieces when hired, and twenty gold pieces for each battle."
+msgstr ""
+
+#. [event]
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:247
 msgid "Fourty-five gold pieces? Ok, I just found a volunteer here. He will fight for you."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:248
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:249
 msgid "My lord, will we accept this recruit into our army? It is not a loyal unit, just a normal Bowman."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:252
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:253
 msgid "A unit joined your cause."
 msgstr ""
 
 #. [unit]: type=Bowman, id=Roman
 #. caret is to intentionally break the translation of anyone who might have translated this as a demonym, which would have been wrong.
 #. wordplay note: say "Roman the Bowman" aloud (it rhymes!)
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:258
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:259
 msgid "firstname^Roman"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:272
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:441
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:528
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:273
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:442
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:529
 msgid "Because we have a lot to do in our own village, for example?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:277
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:340
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:446
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:532
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:278
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:341
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:447
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:533
 msgid "I already answered that question."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:281
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:282
 msgid "Well, I don't know. But I think he lives on the Isle of Alduin, where all mages live."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:283
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:284
 msgid "You mean you don't know? South from here, west from a larger village called Porkton. If I lived in that village, I would change its name into something different. Hogton, for example."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:285
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:286
 msgid "Something interesting? Well, young Henry is marrying Mary from Buckston. The last storm was so heavy that it broke all trees in Larry's orchard. Orcs and Akladians are slaughtering each other. Hmm... I think that's about it."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:287
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:359
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:467
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:546
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:288
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:360
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:468
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:547
 msgid "Have luck in your travels, stranger. You will need it."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:297
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:298
 msgid "Wesnothians! What are you doing here? If you thought you could pillage our village, you will be dissapointed!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:304
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:305
 msgid "Gawen Hagarthen? No! That would mean... my king!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:307
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:308
 msgid "Ah, the rebel from Freetown?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:322
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:323
 msgid "My king, you do not have to ask. You may order us to join you."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:323
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:394
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:418
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:505
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:324
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:395
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:419
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:506
 msgid "A loyal unit joined your cause."
 msgstr ""
 
 #. [unit]: type=Akladian Clansman, id=Har Barien
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:327
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:328
 msgid "Har Barien"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:337
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:338
 msgid "Fight for you? Against my own kin? No thanks."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:343
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:344
 msgid "Well, I don't know. But I think The Oracle may know, she knows everything."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:345
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:346
 msgid "God's voice is west from here. I've heard she will visit one of our lords soon."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:347
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:348
 msgid "How should I know? The lords live their own lives, as do we."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:349
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:350
 msgid "Well, Akladians from Easkladia were defeated by Wesnothians in battle near Broken Heart Runlet. I think it is because God hides his face from us. Their king escaped. If you ask me, I would say that Easkladia is finished."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:350
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:351
 msgid "We have no king now and because of that, according to custom, the other Hagarthens should wait one year until one of them is invited to rule Vakladia by either the regent or council of lords. But we have no regent and the lords are fighting amongst themselves. So I think sooner or later, Hagarthens from other kingdoms will invite themselves."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:351
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:352
 msgid "Other Hagarthens? How many of them?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:352
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:353
 msgid "There is old Perien from Easkladia, but he has troubles of his own. There are two brothers: Luc and Gauri from Guilcorta and there is Buffin from Okladia. Of course, there is also gossip that a new messiah will come and he will lead Akladians to true greatness..."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:353
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:354
 msgid "Maybe, if this messiah will come, our women will be able to give a birth to healthy children again; This winter three children were born, two of them dead."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:357
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:358
 msgid "Have luck in your travels, my king. You will need it."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:370
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:371
 msgid "My lord! Aren't you Gaumhaldric, about whom we've heard so many tales?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:389
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:390
 msgid "It would be honor to join your army."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:390
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:391
 msgid "My lord, should we accept that unit into our army? It is a loyal unit, but it's just a simple Peasant."
 msgstr ""
 
 #. [unit]: type=Peasant, id=Hans
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:398
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:422
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:399
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:423
 msgid "Hans"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:413
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:414
 msgid "Yes, that is a good enough reason."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:414
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:501
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:415
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:502
 msgid "My lord, will we accept that unit into our army? It is a loyal unit, but it's just a simple Peasant."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:439
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:440
 msgid "Gold? I thought you were fighting for freedom, not gold. I am so disappointed."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:449
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:450
 msgid "Well, I don't know. But I think the Oracle may know, she knows everything."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:453
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:454
 msgid "East from here."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:456
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:457
 msgid "East from here. But please, hurry."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:458
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:459
 msgid "A large army went there not long ago. Orcs, Akladians, Outlaws. I don't know what their intentions are, but I doubt they are good."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:462
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:463
 msgid "The greatest news of all is that you have saved the Oracle. This - this is so wonderful I can't find proper words to describe it."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:464
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:465
 msgid "Akladians from another kingdom were defeated by our people in battle near Broken Heart Runlet. Well, our people - this army was from Blackwater. A large army recently went west; I think they want to harm the Oracle."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:477
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:478
 msgid "Who's there? Friend or foe?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:478
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:479
 msgid "Friend."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:479
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:480
 msgid "A lot of 'friends' came to us recently. There are Akladians in your army, I think. Why should I trust you?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:498
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:499
 msgid "And die in the first fight? No, thank you."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:500
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:501
 msgid "Really? Well, If so, one of our boys wants to join your army."
 msgstr ""
 
 #. [unit]: type=Peasant, id=John
 #. since there is another John in this campaign (John Fasthood), I am making up a last name for this guy, too.
 #. see: https://tvtropes.org/pmwiki/pmwiki.php/Main/OneSteveLimit (which we are violating)
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:511
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:512
 msgid "John Tillerman"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:526
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:527
 msgid "Dead people do not bring gold home."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:536
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:537
 msgid "Well, I don't know. He may live in the free kingdom of Elensefar."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:538
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:539
 msgid "West from here. Near Porkton."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:541
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:542
 msgid "There was a battle west from here, in which Akladians, Outlaws and Orcs tried to captured the Oracle. But they were defeated by some young man, who... wait a minute. What was your name, again?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:543
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:544
 msgid "A lot of interesting things happened recently! Two girls were born in my village, on the same day and even in the same hour! Fat Robert lost a horse in the forest, stolen by outlaws, I think."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:577
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:578
 msgid "Ruvio, please tell me..."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:583
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:584
 msgid "You must be kidding. The woman is so hard to be around I cannot understand why Yahyazad has a crush on her."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:586
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:587
 msgid "I think I know what are 'ruins of the great city', my Lord. This could be our former capital, Weldyn. It is located in Okladia. We should go there."
 msgstr ""
 
 #. [event]
 #. Reme is about to say "underlings" here but catches himself:
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:599
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:600
 msgid "Nothing really. I think your under... Wesnothian soldiers are starting to - well, maybe not like - but to tolerate me."
-msgstr ""
-
-#. [event]
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:613
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:621
-msgid "What happened that night we left Freetown?"
 msgstr ""
 
 #. [event]
 #: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:614
 #: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:622
-msgid "What do you think about Karen?"
+msgid "What happened that night we left Freetown?"
 msgstr ""
 
 #. [event]
 #: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:615
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:623
+msgid "What do you think about Karen?"
+msgstr ""
+
+#. [event]
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:616
 msgid "What did the Oracle tell you?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:628
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:629
 msgid "I've told you before I'm not going to talk about it."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:630
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:631
 msgid "She's a cute child. In a few years she could even pretend to be a woman."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:632
+#: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:633
 msgid "When I was young, I visited her and she told me... no, I can't tell you. It was just between the Oracle and me. The first part of her prediction has already been fulfilled. As for the second part... I think I will know soon..."
 msgstr ""
 
@@ -15741,7 +15827,7 @@ msgstr ""
 #. [side]: id=Raul O Gaeltin, type=Akladian Lord
 #. [scenario]: id=02_Fighting_for_Passage
 #: A_New_Order/scenarios/02_Fighting_for_Passage.cfg:80
-#: A_New_Order/scenarios/02_Fighting_for_Passage.cfg:565
+#: A_New_Order/scenarios/02_Fighting_for_Passage.cfg:567
 msgid "Raul O Gaeltin"
 msgstr ""
 
@@ -15878,239 +15964,240 @@ msgid "Go and take the villages to earn more gold. Recruit as many Clansmen as y
 msgstr ""
 
 #. [objective]: condition=win
-#: A_New_Order/scenarios/02_Fighting_for_Passage.cfg:339
-msgid "Reach the northern signpost with Gawen Hagarthen OR"
+#. trailing space is intentional, to pad the footnote a bit:
+#: A_New_Order/scenarios/02_Fighting_for_Passage.cfg:340
+msgid "Reach the northern signpost with Gawen Hagarthen "
 msgstr ""
 
 #. [objectives]
 #. EASY difficulty, so this is more of a hint:
-#: A_New_Order/scenarios/02_Fighting_for_Passage.cfg:361
+#: A_New_Order/scenarios/02_Fighting_for_Passage.cfg:363
 msgid "This scenario is designed for grinding gold and EXP. Your income will increase if you use Gawen for fighting instead of recruiting, so be sure to move him off your keep and into the action!"
 msgstr ""
 
 #. [objectives]
 #. NORMAL, HARD, or NIGHTMARE difficulty, so instead of being a hint, this should just be a pure description of mechanics:
-#: A_New_Order/scenarios/02_Fighting_for_Passage.cfg:364
+#: A_New_Order/scenarios/02_Fighting_for_Passage.cfg:366
 msgid "Gawen's income depends on whether he is standing on his keep or not in this scenario."
 msgstr ""
 
 #. [animate_unit]
-#: A_New_Order/scenarios/02_Fighting_for_Passage.cfg:431
+#: A_New_Order/scenarios/02_Fighting_for_Passage.cfg:433
 msgid "Hm..."
 msgstr ""
 
 #. [event]
 #. "this" refers to the gallows to which Lorin has just moved:
-#: A_New_Order/scenarios/02_Fighting_for_Passage.cfg:438
+#: A_New_Order/scenarios/02_Fighting_for_Passage.cfg:440
 msgid "I suppose we will find some use for this in near future."
 msgstr ""
 
 #. [event]
 #. "this device" refers to the gallows to which the unit has just moved:
-#: A_New_Order/scenarios/02_Fighting_for_Passage.cfg:466
+#: A_New_Order/scenarios/02_Fighting_for_Passage.cfg:468
 msgid "I have no wish to become any better-acquainted with this device."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/02_Fighting_for_Passage.cfg:476
+#: A_New_Order/scenarios/02_Fighting_for_Passage.cfg:478
 msgid "So, how many days' journey from here to Vattin?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/02_Fighting_for_Passage.cfg:477
+#: A_New_Order/scenarios/02_Fighting_for_Passage.cfg:479
 msgid "We should arrive in two or three days."
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/02_Fighting_for_Passage.cfg:484
+#: A_New_Order/scenarios/02_Fighting_for_Passage.cfg:486
 msgid "It's a shame we had no time to finish those traitors off."
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/02_Fighting_for_Passage.cfg:485
+#: A_New_Order/scenarios/02_Fighting_for_Passage.cfg:487
 msgid "There is no time for that now. Others should be able to manage that job without us."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/02_Fighting_for_Passage.cfg:509
+#: A_New_Order/scenarios/02_Fighting_for_Passage.cfg:511
 msgid "Death to the traitors!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/02_Fighting_for_Passage.cfg:517
+#: A_New_Order/scenarios/02_Fighting_for_Passage.cfg:519
 msgid "Yes, death to you!"
 msgstr ""
 
 #. [event]
 #. NIGHTMARE difficulty; I just wanted to put *something* here:
-#: A_New_Order/scenarios/02_Fighting_for_Passage.cfg:525
+#: A_New_Order/scenarios/02_Fighting_for_Passage.cfg:527
 msgid "Hm, we're still alive. Good."
 msgstr ""
 
 #. [event]
 #. all other difficulties, so we can have hints:
-#: A_New_Order/scenarios/02_Fighting_for_Passage.cfg:528
+#: A_New_Order/scenarios/02_Fighting_for_Passage.cfg:530
 msgid "Seems to me it will be an easy battle. I guess it would be enough to have 250 gold pieces at the end of this fight; It is far more important, Gawen, to use this occassion to train our last loyal troops. We may need veteran units in future much more than gold."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/02_Fighting_for_Passage.cfg:546
+#: A_New_Order/scenarios/02_Fighting_for_Passage.cfg:548
 msgid "This is the end which awaits all traitors!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/02_Fighting_for_Passage.cfg:557
+#: A_New_Order/scenarios/02_Fighting_for_Passage.cfg:559
 msgid "Before I kill you, you ought to know that this is not because of the message you delivered to us."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/02_Fighting_for_Passage.cfg:558
+#: A_New_Order/scenarios/02_Fighting_for_Passage.cfg:560
 msgid "I was just a messenger!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/02_Fighting_for_Passage.cfg:559
+#: A_New_Order/scenarios/02_Fighting_for_Passage.cfg:561
 msgid "I just told you that I don't blame you for repeating words of your master."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/02_Fighting_for_Passage.cfg:560
+#: A_New_Order/scenarios/02_Fighting_for_Passage.cfg:562
 msgid "So you will allow me to live?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/02_Fighting_for_Passage.cfg:561
+#: A_New_Order/scenarios/02_Fighting_for_Passage.cfg:563
 msgid "Oh, I haven't said that. You see, I really don't like your face."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/02_Fighting_for_Passage.cfg:580
+#: A_New_Order/scenarios/02_Fighting_for_Passage.cfg:582
 msgid "You are lucky that I don't have more time, or I would play with you more, honorless dog."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/02_Fighting_for_Passage.cfg:581
+#: A_New_Order/scenarios/02_Fighting_for_Passage.cfg:583
 msgid "You are lucky that this underling whom you call your king does not know that..."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/02_Fighting_for_Passage.cfg:582
+#: A_New_Order/scenarios/02_Fighting_for_Passage.cfg:584
 msgid "Enough of that, go now to your ancestors!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/02_Fighting_for_Passage.cfg:583
+#: A_New_Order/scenarios/02_Fighting_for_Passage.cfg:585
 msgid " Hurkkh..."
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/02_Fighting_for_Passage.cfg:682
+#: A_New_Order/scenarios/02_Fighting_for_Passage.cfg:684
 msgid "Where is he? He is starting to get on my nerves..."
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/02_Fighting_for_Passage.cfg:736
+#: A_New_Order/scenarios/02_Fighting_for_Passage.cfg:740
 msgid "Oops."
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/02_Fighting_for_Passage.cfg:738
+#: A_New_Order/scenarios/02_Fighting_for_Passage.cfg:742
 msgid "It looks like he recruited a lot of units."
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/02_Fighting_for_Passage.cfg:739
+#: A_New_Order/scenarios/02_Fighting_for_Passage.cfg:743
 msgid "Yes indeed. This could be a bit harder than we expected."
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/02_Fighting_for_Passage.cfg:803
+#: A_New_Order/scenarios/02_Fighting_for_Passage.cfg:807
 msgid "My friends will arrive very soon! You are already doomed! Ha ha ha!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/02_Fighting_for_Passage.cfg:806
+#: A_New_Order/scenarios/02_Fighting_for_Passage.cfg:810
 msgid "Let's try to move a little faster. This traitor's friends may appear at any moment."
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/02_Fighting_for_Passage.cfg:833
+#: A_New_Order/scenarios/02_Fighting_for_Passage.cfg:837
 msgid "Ha ha ha! You are doomed! I can hear the trumpets of my friends coming to aid me!"
 msgstr ""
 
 #. [event]
 #. the "traitors" to which she refers are Akladian Warriors on side 2:
-#: A_New_Order/scenarios/02_Fighting_for_Passage.cfg:873
+#: A_New_Order/scenarios/02_Fighting_for_Passage.cfg:877
 msgid "No! More traitors are coming from every side! We cannot hope to deal with all them!"
 msgstr ""
 
 #. [event]
 #. Note to translators: Milksop is an older English term for 'coward.'
-#: A_New_Order/scenarios/02_Fighting_for_Passage.cfg:958
+#: A_New_Order/scenarios/02_Fighting_for_Passage.cfg:962
 msgid "Run for your life! That milksop cannot possibly lead us to victory!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/02_Fighting_for_Passage.cfg:972
+#: A_New_Order/scenarios/02_Fighting_for_Passage.cfg:976
 msgid "Poor fellow!"
 msgstr ""
 
 #. [event]
 #. be terser for NIGHTMARE difficulty:
-#: A_New_Order/scenarios/02_Fighting_for_Passage.cfg:981
+#: A_New_Order/scenarios/02_Fighting_for_Passage.cfg:985
 msgid "He dies an honorable death. You will have to get used to losing units."
 msgstr ""
 
 #. [event]
 #. all other difficulties; have this be more advice-like:
-#: A_New_Order/scenarios/02_Fighting_for_Passage.cfg:984
+#: A_New_Order/scenarios/02_Fighting_for_Passage.cfg:988
 msgid "He dies an honorable death. You cannot let the fear of losing units paralyse you; there are many more clansmen ready to fight for you."
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/02_Fighting_for_Passage.cfg:1012
+#: A_New_Order/scenarios/02_Fighting_for_Passage.cfg:1016
 msgid "But he was loyal to our cause though!"
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/02_Fighting_for_Passage.cfg:1013
+#: A_New_Order/scenarios/02_Fighting_for_Passage.cfg:1017
 msgid "Well, I suppose you do have a point there. Feel free to be more careful with our most loyal supporters."
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/02_Fighting_for_Passage.cfg:1038
+#: A_New_Order/scenarios/02_Fighting_for_Passage.cfg:1042
 msgid "Remember Gawen, that while most of our units don't care about the time of day, Homeguards, Shieldguards and Protectors prefer to fight during the day, and at night they should be used carefully."
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/02_Fighting_for_Passage.cfg:1046
+#: A_New_Order/scenarios/02_Fighting_for_Passage.cfg:1050
 msgid "Remember Gawen, that while most of our units don't care about the time of day, Homeguards, Shieldguards and Protectors prefer to fight during full daylight. Although there may still be some daylight left, night is coming, and when it arrives, they should be used carefully."
 msgstr ""
 
 #. [else]
-#: A_New_Order/scenarios/02_Fighting_for_Passage.cfg:1050
+#: A_New_Order/scenarios/02_Fighting_for_Passage.cfg:1054
 msgid "Yes! Attack!"
 msgstr ""
 
 #. [event]
 #. NIGHTMARE difficulty, so don't have Reme say as much:
-#: A_New_Order/scenarios/02_Fighting_for_Passage.cfg:1065
+#: A_New_Order/scenarios/02_Fighting_for_Passage.cfg:1069
 msgid "Ah, he is using Sturmknights. I expect we may have to fight many more of those in the future..."
 msgstr ""
 
 #. [event]
 #. all other difficulties, so make it more hint-like:
-#: A_New_Order/scenarios/02_Fighting_for_Passage.cfg:1068
+#: A_New_Order/scenarios/02_Fighting_for_Passage.cfg:1072
 msgid "Ah, he is using Sturmknights. Be wary of them, Gawen. They prefer to fight at night as they are accustomed to darkness. Counter them by assailing them with Shieldguards during the day."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/02_Fighting_for_Passage.cfg:1077
+#: A_New_Order/scenarios/02_Fighting_for_Passage.cfg:1081
 msgid "The traitorous ones attack me! Rise up, clansmen of Gaeltin, and drive them back!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/02_Fighting_for_Passage.cfg:1099
+#: A_New_Order/scenarios/02_Fighting_for_Passage.cfg:1103
 msgid "See how a true Akladian Lord fights!"
 msgstr ""
 
@@ -16198,12 +16285,12 @@ msgid "End turn if you do not want or can't recall or recruit troops."
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/06_Separation.cfg:157
+#: A_New_Order/scenarios/06_Separation.cfg:158
 msgid "You have less than 200 gold pieces. I am not sure if this will be enough for your future endeavours."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/06_Separation.cfg:172
+#: A_New_Order/scenarios/06_Separation.cfg:173
 msgid "You have neither choosen nor recruited five soldiers. I hope you know what you are doing, since in the future it may be hard to find battle-hardened units. Or, for that matter, Akladians."
 msgstr ""
 
@@ -16259,11 +16346,6 @@ msgstr ""
 #. [part]
 #: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:113
 msgid "And now you lie here, defenseless and vulnerable. Your father's death has shown me how tenuous my position is, and how despised you are. Behind your back they call you a mixling, a bastard, a creature not fit to live, let alone to sit on the throne. And as for me... if you die, I would be just the wife of a despised king, stepmother of a hated heir; my death will be all but assured. Had I given birth, I would be your mortal enemy, but I have not. I know there is no love between us, but only together is there any hope..."
-msgstr ""
-
-#. [unit]: id=Reme Carrenemoe, type=Akladian Chieftain
-#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:155
-msgid "Reme Carrenemoe"
 msgstr ""
 
 #. [unit]: id=Eol Areon, type=Akladian Protector, type=Akladian Shieldguard
@@ -16418,142 +16500,142 @@ msgstr ""
 
 #. [objectives]
 #. this description of mechanics is only present on EASY, NORMAL, and HARD, but not NIGHTMARE, though:
-#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:550
+#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:551
 msgid "You cannot recruit new units in this scenario."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:609
+#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:610
 msgid "These ashes are still warm... he has to be somewhere nearby..."
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:622
+#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:623
 msgid "I feel so sick, like poison is burning inside me..."
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:623
+#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:624
 msgid "Try to resist for just a bit longer, my son!"
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:630
+#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:631
 msgid "He will not make it!"
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:631
+#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:632
 msgid "My son! Please, don't give up!"
 msgstr ""
 
 #. [unit]: id=Medic, type=Mage
 #. [then]
-#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:672
-#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:695
-#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:697
-#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:734
+#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:673
+#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:696
+#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:698
+#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:735
 msgid "Medic"
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:684
+#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:685
 msgid "My lady, we have found a medic!"
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:693
+#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:694
 msgid "Underling! My son is dying. If you heal him, I will spare your life. If not, I will burn you and your family alive, do you understand?"
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:695
+#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:696
 msgid "Don't try to intimidate me. I am too old to be afraid of death, I have no family. I will try to heal your son because of my vows as a healer, not because of your threats, Akladian lady."
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:696
+#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:697
 msgid "Your motives are of no concern to me, just do it!"
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:697
+#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:698
 msgid "Hold on a moment."
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:734
+#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:735
 msgid "...and there you go."
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:735
+#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:736
 msgid "Thank you. (*<i>faints</i>*)"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:780
+#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:781
 msgid "Truly a shame we have no time to loot it or tax the inhabitants..."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:789
+#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:790
 msgid "Ah, a village..."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:790
+#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:791
 msgid "A medic! Somebody find a medic!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:791
+#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:792
 msgid "Unfortunately, it seems that there are no medics here... we will most likely have to wait until we reach the enemy encampment before we can cure Gawen's poison..."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:840
+#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:841
 msgid "I can't see... it's so cold..."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:841
+#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:842
 msgid "No! Don't you DARE die on me! Not now!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:857
+#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:858
 msgid "For freedom! Death to the Akladian beasts!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:858
+#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:859
 msgid "Umm... we are good guys, right?"
 msgstr ""
 
 #. [event]
 #. EASY difficulty, so have Reme give an additional hint:
-#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:861
+#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:862
 msgid "Do not forget to withdraw wounded units to villages, where they can rest and regain some of their health."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:874
+#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:875
 msgid "Get out of my way, filthy underling!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:886
+#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:887
 msgid "Poor fools! They have no chance, yet still they fight."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:899
+#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:900
 msgid "How dare you oppose us, heathen underling!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:907
+#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:908
 msgid "Their leader is dead, good! Now bring Gawen to their keep, men!"
 msgstr ""
 
@@ -16888,136 +16970,136 @@ msgstr ""
 #. [side]: type=Saurian Ambusher, id=Ssumar
 #. [scenario]: id=05_The_Swamp_Things
 #: A_New_Order/scenarios/05_The_Swamp_Things.cfg:83
-#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:225
+#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:261
 msgid "Ssumar"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:232
+#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:268
 msgid "I have the strangest feeling, as though someone was watching us from the bushes..."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:233
+#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:269
 msgid "Humanssss! Leave thessse foressts!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:234
+#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:270
 msgid "We can't! Our enemies are hot on our heels. We only wish to cross your swamp and then you will hear no more from us."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:235
+#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:271
 msgid "Ssswampss you leave now! Hear about you no more!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:236
+#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:272
 msgid "Reme, leave negotiations to me, I am far more experienced. Lizards! You are about to be exterminated! Prepare to meet your destiny!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:237
+#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:273
 msgid "(<i>To himself</i>) No wonder no one really liked her..."
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:252
+#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:288
 msgid "I am not sure whether we have enough gold for this endeavor. I wish we'd gotten more in previous battles, at least 200."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:279
-#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:321
+#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:316
+#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:358
 msgid "Wait! Ssspare my life, for I know sssomething..."
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:286
-#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:328
+#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:323
+#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:365
 msgid "Interesting. Speak, and maybe I will spare your worthless head, inhuman ungodly beast."
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:287
-#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:329
+#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:324
+#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:366
 msgid "The orcss are coming in great numbersss... They are numerousss, they are hiding in the hillss waiting for the right moment to come..."
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:288
-#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:330
+#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:325
+#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:367
 msgid "What moment?"
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:289
-#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:331
+#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:326
+#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:368
 msgid "What moment I do not know, but I know that they are expecting a human envoy."
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:290
-#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:332
+#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:327
+#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:369
 msgid "Human envoy? That's impossible."
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:291
-#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:333
+#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:328
+#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:370
 msgid "If it isss impossssible, then they will wait a long time... will you let me live now?"
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:292
-#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:334
+#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:329
+#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:371
 msgid "Hide in your quagmire, lizard thing."
 msgstr ""
 
 #. [else]
-#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:299
-#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:341
+#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:336
+#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:378
 msgid "We already know everything we need to know. Your friend had told us about a great army of orcs, what else you could possibly know?"
 msgstr ""
 
 #. [else]
-#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:300
-#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:342
+#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:337
+#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:379
 msgid "I know where we hide the gold. Humanss, you love gold, will you ssave my life if I show you?"
 msgstr ""
 
 #. [else]
 #. Lorin is mad that she is starting to pick up saurian speech patterns:
 #. Lorin is mad that she is starting to pick up saurian speech patterns:
-#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:302
-#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:344
+#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:339
+#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:381
 msgid "Seems a fair deal. Show usss... blast it... show us the gold and you may leave."
 msgstr ""
 
 #. [else]
-#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:308
-#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:350
+#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:345
+#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:387
 msgid "You have resssssieved $gold_amt gold piesssses."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:357
+#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:394
 msgid "My lady, we have found some gold Saurians were hiding. They probably earned it by robbing the humans living nearby."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:358
+#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:395
 msgid "Oh, so I am still 'my lady' to you? Good. We may have use for the gold in future."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:359
+#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:396
 msgid "I really don't know what 'we' you have in mind."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:365
+#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:402
 msgid "You have received $end_gold_amt gold pieces."
 msgstr ""
 
@@ -17197,7 +17279,7 @@ msgstr ""
 
 #. [objective]: condition=lose
 #: A_New_Order/scenarios/10_Siege_of_Haeltin.cfg:419
-#: A_New_Order/scenarios/09_Hired_Swords.cfg:250
+#: A_New_Order/scenarios/09_Hired_Swords.cfg:252
 msgid "Death of Majid Yahyazad"
 msgstr ""
 
@@ -17622,392 +17704,403 @@ msgstr ""
 msgid "I am a battle-tested warrior with many men at my command. Keep calling me 'underling,' and I am leaving, do you understand?"
 msgstr ""
 
+#. [objective]: condition=win
+#: A_New_Order/scenarios/09_Hired_Swords.cfg:246
+msgid "Kill all enemy leaders..."
+msgstr ""
+
+#. [objectives]
+#. continues sentence started by previous objective:
+#: A_New_Order/scenarios/09_Hired_Swords.cfg:250
+msgid "...except for maybe Reumario?"
+msgstr ""
+
 #. [event]
-#: A_New_Order/scenarios/09_Hired_Swords.cfg:267
+#: A_New_Order/scenarios/09_Hired_Swords.cfg:270
 msgid "Before you kill me, let me say just one thing: you are one damn good fighter, Lorin."
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/09_Hired_Swords.cfg:274
+#: A_New_Order/scenarios/09_Hired_Swords.cfg:277
 msgid "That's LADY Lorin to you... and you are going to tell me a lot more than just one thing. First, who are those guests you were talking about?"
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/09_Hired_Swords.cfg:275
+#: A_New_Order/scenarios/09_Hired_Swords.cfg:278
 msgid "I have no idea. It has taken a long time to stockpile the amount of supplies we were told they would need. It must be quite a large army."
 msgstr ""
 
 #. [option]
 #. spoken by Lorin
-#: A_New_Order/scenarios/09_Hired_Swords.cfg:285
+#: A_New_Order/scenarios/09_Hired_Swords.cfg:288
 msgid "You were fine warrior, Reumario. I want to honor you."
 msgstr ""
 
 #. [option]
 #. spoken by Lorin
-#: A_New_Order/scenarios/09_Hired_Swords.cfg:292
+#: A_New_Order/scenarios/09_Hired_Swords.cfg:295
 msgid "Off with your left ear! And now tell me more about these guests!"
 msgstr ""
 
 #. [command]
-#: A_New_Order/scenarios/09_Hired_Swords.cfg:294
+#: A_New_Order/scenarios/09_Hired_Swords.cfg:297
 msgid "I told you I know nothing about them! Aaargh!"
 msgstr ""
 
 #. [command]
-#: A_New_Order/scenarios/09_Hired_Swords.cfg:295
+#: A_New_Order/scenarios/09_Hired_Swords.cfg:298
 msgid "Liar! Speak!"
 msgstr ""
 
 #. [command]
-#: A_New_Order/scenarios/09_Hired_Swords.cfg:300
+#: A_New_Order/scenarios/09_Hired_Swords.cfg:303
 msgid "I do not think he will tell you anything more, my lady... he's dead. You did well to squeeze as much information as you did from him. "
 msgstr ""
 
 #. [command]
-#: A_New_Order/scenarios/09_Hired_Swords.cfg:301
+#: A_New_Order/scenarios/09_Hired_Swords.cfg:304
 msgid "Be silent, underling."
 msgstr ""
 
 #. [command]
-#: A_New_Order/scenarios/09_Hired_Swords.cfg:302
+#: A_New_Order/scenarios/09_Hired_Swords.cfg:305
 msgid "One more reference to 'underling' and I am leaving, do you understand?"
 msgstr ""
 
 #. [option]
 #. spoken by Lorin
-#: A_New_Order/scenarios/09_Hired_Swords.cfg:307
+#: A_New_Order/scenarios/09_Hired_Swords.cfg:310
 msgid "Where are those supplies? Speak, or I will cut you to pieces!"
 msgstr ""
 
 #. [then]
 #. spoken by Reumario, answering to Lorin
-#: A_New_Order/scenarios/09_Hired_Swords.cfg:320
+#: A_New_Order/scenarios/09_Hired_Swords.cfg:323
 msgid "Uh, I, I am not sure..."
 msgstr ""
 
 #. [message]: speaker=Lady Lorin
 #. spoken by Lorin to Reumario
-#: A_New_Order/scenarios/09_Hired_Swords.cfg:324
+#: A_New_Order/scenarios/09_Hired_Swords.cfg:327
 msgid "Well, what about this..."
 msgstr ""
 
 #. [option]
 #. spoken by Lorin to Reumario
-#: A_New_Order/scenarios/09_Hired_Swords.cfg:328
+#: A_New_Order/scenarios/09_Hired_Swords.cfg:331
 msgid "I would be honoured to have you in my army."
 msgstr ""
 
 #. [command]
-#: A_New_Order/scenarios/09_Hired_Swords.cfg:331
+#: A_New_Order/scenarios/09_Hired_Swords.cfg:334
 msgid "After this battle you will be able to recruit Akladian Clansmen, Warriors and Wisemen again."
 msgstr ""
 
 #. [command]
-#: A_New_Order/scenarios/09_Hired_Swords.cfg:342
+#: A_New_Order/scenarios/09_Hired_Swords.cfg:345
 msgid "Uh... yes, why not? I will join you. But let me wait until after this battle; I do not want to fight members of my own clan."
 msgstr ""
 
 #. [option]
 #. spoken by Lorin
-#: A_New_Order/scenarios/09_Hired_Swords.cfg:347
+#: A_New_Order/scenarios/09_Hired_Swords.cfg:350
 msgid "I shall let you live."
 msgstr ""
 
 #. [command]
-#: A_New_Order/scenarios/09_Hired_Swords.cfg:350
+#: A_New_Order/scenarios/09_Hired_Swords.cfg:353
 msgid "Thank you, Lorin. Frankly, I had not expected such behavior from you. As a sign of my gratitude, I will instruct members of my clan to serve you."
 msgstr ""
 
 #. [command]
-#: A_New_Order/scenarios/09_Hired_Swords.cfg:351
+#: A_New_Order/scenarios/09_Hired_Swords.cfg:354
 msgid "After this battle you will be able to recruit Akladian Clansmen again."
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/09_Hired_Swords.cfg:363
+#: A_New_Order/scenarios/09_Hired_Swords.cfg:366
 msgid "In this storeroom and..."
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/09_Hired_Swords.cfg:364
+#: A_New_Order/scenarios/09_Hired_Swords.cfg:367
 msgid "Do you think I'm stupid? This would not be enough to house an army! You must have some hidden storeroom or treasury! Speak!"
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/09_Hired_Swords.cfg:365
+#: A_New_Order/scenarios/09_Hired_Swords.cfg:368
 msgid "Aargh! Yes, we have a hidden treasury in my castle, here, I will show you."
 msgstr ""
 
 #. [message]: speaker=Majid Yahyazad
-#: A_New_Order/scenarios/09_Hired_Swords.cfg:375
+#: A_New_Order/scenarios/09_Hired_Swords.cfg:378
 msgid "Will you allow him to leave now?"
 msgstr ""
 
 #. [option]
-#: A_New_Order/scenarios/09_Hired_Swords.cfg:378
+#: A_New_Order/scenarios/09_Hired_Swords.cfg:381
 msgid "Yes, he may live."
 msgstr ""
 
 #. [option]
-#: A_New_Order/scenarios/09_Hired_Swords.cfg:384
+#: A_New_Order/scenarios/09_Hired_Swords.cfg:387
 msgid "No, he is too dangerous."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/09_Hired_Swords.cfg:405
+#: A_New_Order/scenarios/09_Hired_Swords.cfg:408
 msgid "What did I say about killing their leaders? Hm?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/09_Hired_Swords.cfg:406
+#: A_New_Order/scenarios/09_Hired_Swords.cfg:409
 msgid "But..."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/09_Hired_Swords.cfg:407
+#: A_New_Order/scenarios/09_Hired_Swords.cfg:410
 msgid "What? Are you deaf or something? I specifically instructed that you were to leave their leaders for me!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/09_Hired_Swords.cfg:418
+#: A_New_Order/scenarios/09_Hired_Swords.cfg:421
 msgid "Before I kill you, I want you to tell me few things. First, you were talking about some guests, tell me more!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/09_Hired_Swords.cfg:419
+#: A_New_Order/scenarios/09_Hired_Swords.cfg:422
 msgid "You're afraid, aren't you? They will come here in great numbers... a huge orcish army... better start running, witch."
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/09_Hired_Swords.cfg:426
+#: A_New_Order/scenarios/09_Hired_Swords.cfg:429
 msgid "Orcs? Why should I be afraid? I have fought them before. Unlike you, they are strong and worthy opponents. I look forward to meeting them in combat again."
 msgstr ""
 
 #. [else]
-#: A_New_Order/scenarios/09_Hired_Swords.cfg:429
+#: A_New_Order/scenarios/09_Hired_Swords.cfg:432
 msgid "Orcs? I've never fought orcs, though I would love to meet them. I've heard they are good soldiers, strong and fearless."
 msgstr ""
 
 #. [message]: speaker=Lady Lorin
-#: A_New_Order/scenarios/09_Hired_Swords.cfg:434
+#: A_New_Order/scenarios/09_Hired_Swords.cfg:437
 msgid "And now, tell me more..."
 msgstr ""
 
 #. [option]
 #. spoken by Lorin
-#: A_New_Order/scenarios/09_Hired_Swords.cfg:437
+#: A_New_Order/scenarios/09_Hired_Swords.cfg:440
 msgid "You were worthy opponent, Oyre Mathauri. How can I honour you?"
 msgstr ""
 
 #. [command]
-#: A_New_Order/scenarios/09_Hired_Swords.cfg:439
+#: A_New_Order/scenarios/09_Hired_Swords.cfg:442
 msgid "By hanging yourself from the nearest tree, witch!"
 msgstr ""
 
 #. [command]
-#: A_New_Order/scenarios/09_Hired_Swords.cfg:440
+#: A_New_Order/scenarios/09_Hired_Swords.cfg:443
 msgid "Seems you have wasted your last wish. Now die!"
 msgstr ""
 
 #. [option]
 #. spoken by Lorin
-#: A_New_Order/scenarios/09_Hired_Swords.cfg:445
+#: A_New_Order/scenarios/09_Hired_Swords.cfg:448
 msgid "What are orcs doing here and why are you waiting for them?"
 msgstr ""
 
 #. [option]
-#: A_New_Order/scenarios/09_Hired_Swords.cfg:451
+#: A_New_Order/scenarios/09_Hired_Swords.cfg:454
 msgid "Where have you hidden the gold?"
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/09_Hired_Swords.cfg:463
+#: A_New_Order/scenarios/09_Hired_Swords.cfg:466
 msgid "Gold? What gold? I know nothing about... AAARGH! ... it's in a safe place, I will show you!"
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/09_Hired_Swords.cfg:471
+#: A_New_Order/scenarios/09_Hired_Swords.cfg:474
 msgid "He isn't able to tell you anything more. I can't decide whether I should admire your ruthlessness or despise your cruelty."
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/09_Hired_Swords.cfg:472
+#: A_New_Order/scenarios/09_Hired_Swords.cfg:475
 msgid "His death was quick. You may admire my generosity."
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/09_Hired_Swords.cfg:481
+#: A_New_Order/scenarios/09_Hired_Swords.cfg:484
 msgid "Orcs? Bor Cryne told us to wait for them here. We will then march with them and kill every Akladian unworthy of the name! Those who violate our customs, who befriend underlings, and especially those who offend our God by marrying them! Only then God will again show us favor and reward us by ensuring we complete our conquest of Wesnoth."
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/09_Hired_Swords.cfg:483
+#: A_New_Order/scenarios/09_Hired_Swords.cfg:486
 msgid "Interesting theory. So, basically Bor Cryne wants to eliminate all of his opponents?"
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/09_Hired_Swords.cfg:489
+#: A_New_Order/scenarios/09_Hired_Swords.cfg:492
 msgid "Hey, Reumario, what do you say to that? Akladians allying with orcs to kill other Akladians? Quite a dishonorable thing, don't you think?"
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/09_Hired_Swords.cfg:490
+#: A_New_Order/scenarios/09_Hired_Swords.cfg:493
 msgid "I didn't know..."
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/09_Hired_Swords.cfg:491
+#: A_New_Order/scenarios/09_Hired_Swords.cfg:494
 msgid "So now you know. What do you intend to do about it?"
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/09_Hired_Swords.cfg:492
+#: A_New_Order/scenarios/09_Hired_Swords.cfg:495
 msgid "I don't know."
 msgstr ""
 
 #. [option]
-#: A_New_Order/scenarios/09_Hired_Swords.cfg:497
+#: A_New_Order/scenarios/09_Hired_Swords.cfg:500
 msgid "I will kill you and rip off your traitorous head!"
 msgstr ""
 
 #. [option]
-#: A_New_Order/scenarios/09_Hired_Swords.cfg:500
+#: A_New_Order/scenarios/09_Hired_Swords.cfg:503
 msgid "What about joining us against those orcs?"
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/09_Hired_Swords.cfg:512
+#: A_New_Order/scenarios/09_Hired_Swords.cfg:515
 msgid "Will you join us to fight against the orcs? Or maybe you would prefer to ally yourself with these madmen who want to slaughter their own kin?"
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/09_Hired_Swords.cfg:513
+#: A_New_Order/scenarios/09_Hired_Swords.cfg:516
 msgid "Yes... I will join you."
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/09_Hired_Swords.cfg:515
+#: A_New_Order/scenarios/09_Hired_Swords.cfg:518
 msgid "So, we won."
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/09_Hired_Swords.cfg:516
+#: A_New_Order/scenarios/09_Hired_Swords.cfg:519
 msgid "You sound disappointed... were you relishing the thought of more action?"
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/09_Hired_Swords.cfg:517
+#: A_New_Order/scenarios/09_Hired_Swords.cfg:520
 msgid "I'm sure there will be plenty of action when the orcs arrive."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/09_Hired_Swords.cfg:549
+#: A_New_Order/scenarios/09_Hired_Swords.cfg:552
 msgid "What part of the phrase 'do not kill their leaders, leave them for me' was so difficult to understand?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/09_Hired_Swords.cfg:550
+#: A_New_Order/scenarios/09_Hired_Swords.cfg:553
 msgid "But it was self-defense!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/09_Hired_Swords.cfg:551
+#: A_New_Order/scenarios/09_Hired_Swords.cfg:554
 msgid "Yeah, sure. Why do men always think I can't handle my enemies myself?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/09_Hired_Swords.cfg:555
+#: A_New_Order/scenarios/09_Hired_Swords.cfg:558
 msgid "We have taken the castle... what a pleasant surprise! What now?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/09_Hired_Swords.cfg:556
+#: A_New_Order/scenarios/09_Hired_Swords.cfg:559
 msgid "Surprise? What do you mean by that?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/09_Hired_Swords.cfg:557
+#: A_New_Order/scenarios/09_Hired_Swords.cfg:560
 msgid "I mean that I didn't think we would be able to take that castle, because..."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/09_Hired_Swords.cfg:558
+#: A_New_Order/scenarios/09_Hired_Swords.cfg:561
 msgid "Because what? You think that just because I am a weak woman I can't take a castle?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/09_Hired_Swords.cfg:559
+#: A_New_Order/scenarios/09_Hired_Swords.cfg:562
 msgid "No, I just... look, the castle provides excellent tactical position against sieges... stop glaring at me. What are you going to do now?"
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/09_Hired_Swords.cfg:566
+#: A_New_Order/scenarios/09_Hired_Swords.cfg:569
 msgid "Well, haven't you heard? An orcish army is coming here. We have to prepare the defenses immediately. And while we do so, we can ponder the next move to be made."
 msgstr ""
 
 #. [else]
-#: A_New_Order/scenarios/09_Hired_Swords.cfg:569
+#: A_New_Order/scenarios/09_Hired_Swords.cfg:572
 msgid "Well, I have my own castle, that's a start. Now I need more gold, so I guess we could 'ask' our neighbors for some. But we also need some time to rest and heal the wounded."
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/09_Hired_Swords.cfg:578
+#: A_New_Order/scenarios/09_Hired_Swords.cfg:581
 msgid "How strange... it seems that by killing so many of them, you have gained their respect."
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/09_Hired_Swords.cfg:579
+#: A_New_Order/scenarios/09_Hired_Swords.cfg:582
 msgid "What's so strange about that?"
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/09_Hired_Swords.cfg:580
+#: A_New_Order/scenarios/09_Hired_Swords.cfg:583
 msgid "The locals are placing respect for arms above respect of kin.  Some of them are even willing to fight for you now."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/09_Hired_Swords.cfg:612
+#: A_New_Order/scenarios/09_Hired_Swords.cfg:615
 msgid "We have searched the castle and we found a lot of supplies. I hope we will find a good use for them."
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/09_Hired_Swords.cfg:643
+#: A_New_Order/scenarios/09_Hired_Swords.cfg:646
 msgid "A woman! A woman killed me! Aaargh!"
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/09_Hired_Swords.cfg:644
+#: A_New_Order/scenarios/09_Hired_Swords.cfg:647
 msgid "What? Haven't I practiced the art of the blade as much as he has?"
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/09_Hired_Swords.cfg:653
+#: A_New_Order/scenarios/09_Hired_Swords.cfg:656
 msgid "I lost to a woman? Nooo..."
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/09_Hired_Swords.cfg:662
+#: A_New_Order/scenarios/09_Hired_Swords.cfg:665
 msgid "You really can fight. I salute you as I die."
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/09_Hired_Swords.cfg:663
+#: A_New_Order/scenarios/09_Hired_Swords.cfg:666
 msgid "What's wrong with these Akladians? They hate you, you start killing them, and now they like you? Are Akladians gluttons for punishment or is skill at arms paramount with your ilk?"
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/09_Hired_Swords.cfg:672
+#: A_New_Order/scenarios/09_Hired_Swords.cfg:675
 msgid "What a fighter! I would willingly fight for someone like her..."
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/09_Hired_Swords.cfg:673
+#: A_New_Order/scenarios/09_Hired_Swords.cfg:676
 msgid "I am no necromancer; I have use only for living warriors, not the dead!"
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/09_Hired_Swords.cfg:674
+#: A_New_Order/scenarios/09_Hired_Swords.cfg:677
 msgid "They seem to have come to respect you now. Strange."
 msgstr ""
 

--- a/translations/wesnoth-A_New_Order.pot
+++ b/translations/wesnoth-A_New_Order.pot
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
-"POT-Creation-Date: 2024-02-24 04:41 UTC\n"
+"POT-Creation-Date: 2024-04-02 12:18 UTC\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -2048,7 +2048,7 @@ msgstr ""
 #. [event]
 #. [option]
 #: A_New_Order/macros/ano-20macros.cfg:282
-#: A_New_Order/scenarios/08_Outlaw_Base.cfg:389
+#: A_New_Order/scenarios/08_Outlaw_Base.cfg:391
 msgid "That's all I wanted to know"
 msgstr ""
 
@@ -2640,7 +2640,7 @@ msgstr ""
 #. [scenario]: id=08_Outlaw_Base
 #: A_New_Order/macros/ano-20macros.cfg:527
 #: A_New_Order/scenarios/08_Outlaw_Base.cfg:44
-#: A_New_Order/scenarios/08_Outlaw_Base.cfg:454
+#: A_New_Order/scenarios/08_Outlaw_Base.cfg:456
 #: A_New_Order/scenarios/08_Outlaw_Base.cfg:171
 msgid "Rob Roe"
 msgstr ""
@@ -2956,7 +2956,7 @@ msgstr ""
 #: A_New_Order/scenarios/27_Orannon.cfg:754
 #: A_New_Order/scenarios/27_Orannon.cfg:1154
 #: A_New_Order/scenarios/12_Leaving_Raedwood.cfg:224
-#: A_New_Order/scenarios/08_Outlaw_Base.cfg:217
+#: A_New_Order/scenarios/08_Outlaw_Base.cfg:219
 msgid "Death of Ruvio"
 msgstr ""
 
@@ -2980,7 +2980,7 @@ msgstr ""
 #: A_New_Order/scenarios/27_Orannon.cfg:742
 #: A_New_Order/scenarios/27_Orannon.cfg:1142
 #: A_New_Order/scenarios/12_Leaving_Raedwood.cfg:216
-#: A_New_Order/scenarios/08_Outlaw_Base.cfg:213
+#: A_New_Order/scenarios/08_Outlaw_Base.cfg:215
 #: A_New_Order/scenarios/02_Fighting_for_Passage.cfg:347
 #: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:536
 msgid "Death of Gawen Hagarthen"
@@ -2992,7 +2992,7 @@ msgstr ""
 #: A_New_Order/scenarios/07_Ally_From_the_Past.cfg:364
 #: A_New_Order/scenarios/15b_Repelling_the_Orcs.cfg:104
 #: A_New_Order/scenarios/12_Leaving_Raedwood.cfg:220
-#: A_New_Order/scenarios/08_Outlaw_Base.cfg:221
+#: A_New_Order/scenarios/08_Outlaw_Base.cfg:223
 msgid "Death of Karen"
 msgstr ""
 
@@ -4800,7 +4800,7 @@ msgstr ""
 #: A_New_Order/scenarios/19a_The_Woods_of_Okladia.cfg:314
 #: A_New_Order/scenarios/19b_Entering_Okladia.cfg:304
 #: A_New_Order/scenarios/19c_The_Oracle.cfg:1813
-#: A_New_Order/scenarios/08_Outlaw_Base.cfg:588
+#: A_New_Order/scenarios/08_Outlaw_Base.cfg:590
 msgid "All is lost! Enemy reinforcements have arrived! We have no chance to win now!"
 msgstr ""
 
@@ -10626,7 +10626,7 @@ msgstr ""
 #. [event]
 #. [option]
 #: A_New_Order/scenarios/03_Coronation.cfg:258
-#: A_New_Order/scenarios/08_Outlaw_Base.cfg:347
+#: A_New_Order/scenarios/08_Outlaw_Base.cfg:349
 msgid "Uri van Roe?"
 msgstr ""
 
@@ -10639,7 +10639,7 @@ msgstr ""
 #. [event]
 #. [option]
 #: A_New_Order/scenarios/03_Coronation.cfg:267
-#: A_New_Order/scenarios/08_Outlaw_Base.cfg:353
+#: A_New_Order/scenarios/08_Outlaw_Base.cfg:355
 msgid "Bor Cryne?"
 msgstr ""
 
@@ -12989,7 +12989,7 @@ msgstr ""
 
 #. [part]
 #: A_New_Order/scenarios/08_Outlaw_Base.cfg:15
-msgid "Gawen, Ruvio and Karen didn't celebrate their victory. The bodies of the last Akladians were still warm as they hurried from the battlefield. They entered the forest of Raedwood, hoping that no one would follow them."
+msgid "Gawen, Ruvio, and Karen didn't celebrate their victory. The bodies of the last Akladians were still warm as they hurried from the battlefield. They entered the forest of Raedwood, hoping that no one would follow them."
 msgstr ""
 
 #. [unit]: id=Uorl, type=Thug
@@ -13024,293 +13024,303 @@ msgstr ""
 
 #. [event]
 #: A_New_Order/scenarios/08_Outlaw_Base.cfg:184
-msgid "You see, Gawen, when the royal family of Wesnoth started a war over succession, a golden era for bandits and thieves began. The succession wars were devastating and divided Wesnoth into many small kingdoms."
+msgid "You see, Haldric... uh, Haldric? HALDRIC!"
 msgstr ""
 
 #. [event]
 #: A_New_Order/scenarios/08_Outlaw_Base.cfg:185
-msgid "During the wars, kings became weaker and lost much of their power, so when peace came they no longer had the forces needed to drive bandits out of their hideouts. The bandits continued to flourish even in periods of peace. When the Akladians came, they didn't care about rooting the bandits out either."
+msgid "...oh right, you mean me. Sorry, I just haven't gotten used to that name yet..."
 msgstr ""
 
 #. [event]
 #: A_New_Order/scenarios/08_Outlaw_Base.cfg:186
+msgid "Right, well, as I was saying, about this place, when the royal family of Wesnoth started a war over succession, a golden era for bandits and thieves began. The succession wars were devastating and divided Wesnoth into many small kingdoms."
+msgstr ""
+
+#. [event]
+#: A_New_Order/scenarios/08_Outlaw_Base.cfg:187
+msgid "During the wars, kings became weaker and lost much of their power, so when peace came they no longer had the forces needed to drive bandits out of their hideouts. The bandits continued to flourish even in periods of peace. When the Akladians came, they didn't care about rooting the bandits out either."
+msgstr ""
+
+#. [event]
+#: A_New_Order/scenarios/08_Outlaw_Base.cfg:188
 msgid "Fortunately, the place seems to be abandoned now."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/08_Outlaw_Base.cfg:193
+#: A_New_Order/scenarios/08_Outlaw_Base.cfg:195
 msgid "Hey, people! Look who's here: such ridiculously easy targets that even though most of our forces are elsewhere, we will still have no problem taking their gold!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/08_Outlaw_Base.cfg:194
+#: A_New_Order/scenarios/08_Outlaw_Base.cfg:196
 msgid "Abandoned, huh?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/08_Outlaw_Base.cfg:195
+#: A_New_Order/scenarios/08_Outlaw_Base.cfg:197
 msgid "There are some young men living in the neighborhoods here. You may recruit a few of them."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/08_Outlaw_Base.cfg:196
+#: A_New_Order/scenarios/08_Outlaw_Base.cfg:198
 msgid "If I may, I want to personally prove to this Rob Roe that I am not a 'ridiculously easy target.' Leave him to me, if you can."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/08_Outlaw_Base.cfg:197
+#: A_New_Order/scenarios/08_Outlaw_Base.cfg:199
 msgid "What? Why are you looking at me like that?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/08_Outlaw_Base.cfg:198
+#: A_New_Order/scenarios/08_Outlaw_Base.cfg:200
 msgid "Hmm... I wonder what might lie in that northern, empty castle..."
 msgstr ""
 
 #. [objectives]
 #. no hints for NIGHTMARE difficulty:
-#: A_New_Order/scenarios/08_Outlaw_Base.cfg:203
+#: A_New_Order/scenarios/08_Outlaw_Base.cfg:205
 msgid "Your recruitment of spearmen and archers is limited in this scenario."
 msgstr ""
 
 #. [objectives]
 #. all other difficulties; we can have hints for those:
-#: A_New_Order/scenarios/08_Outlaw_Base.cfg:206
+#: A_New_Order/scenarios/08_Outlaw_Base.cfg:208
 msgid "You may recruit up to FOUR spearmen and/or archers. When you recruit a FOURTH spearman and/or archer, their recruitment will be disallowed."
 msgstr ""
 
 #. [objective]: condition=win
-#: A_New_Order/scenarios/08_Outlaw_Base.cfg:209
+#: A_New_Order/scenarios/08_Outlaw_Base.cfg:211
 #: A_New_Order/scenarios/02_Fighting_for_Passage.cfg:343
 msgid "Kill the enemy leader."
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/08_Outlaw_Base.cfg:240
+#: A_New_Order/scenarios/08_Outlaw_Base.cfg:242
 msgid "Wow! They actually know how to fight!"
 msgstr ""
 
 #. [then]
 #. Translation Note: "Marks" means easy targets/victims, usually of someone trying to rob or cheat them:
-#: A_New_Order/scenarios/08_Outlaw_Base.cfg:248
+#: A_New_Order/scenarios/08_Outlaw_Base.cfg:250
 msgid "Hmm... perhaps they are not such easy marks as I thought."
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/08_Outlaw_Base.cfg:255
+#: A_New_Order/scenarios/08_Outlaw_Base.cfg:257
 msgid "Heavens! They really know how to fight! Stop toying with them!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/08_Outlaw_Base.cfg:288
+#: A_New_Order/scenarios/08_Outlaw_Base.cfg:290
 msgid "Argh! Why would you not at least grant me the honor of death at the hand of your commander? I should have liked to learn his name..."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/08_Outlaw_Base.cfg:289
-#: A_New_Order/scenarios/08_Outlaw_Base.cfg:305
+#: A_New_Order/scenarios/08_Outlaw_Base.cfg:291
+#: A_New_Order/scenarios/08_Outlaw_Base.cfg:307
 msgid "My name is Ga... uhmm... Haldric."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/08_Outlaw_Base.cfg:290
+#: A_New_Order/scenarios/08_Outlaw_Base.cfg:292
 msgid "Gaumhaldric? Wow, every name is better than the last."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/08_Outlaw_Base.cfg:291
+#: A_New_Order/scenarios/08_Outlaw_Base.cfg:293
 msgid "It wouldn't have been so easy for you if the bulk of our army hadn't been elsewhere..."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/08_Outlaw_Base.cfg:302
+#: A_New_Order/scenarios/08_Outlaw_Base.cfg:304
 msgid "So you were worthy opponents, after all! It's a shame we didn't meet in other circumstances, or we might have been friends."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/08_Outlaw_Base.cfg:303
+#: A_New_Order/scenarios/08_Outlaw_Base.cfg:305
 msgid "You need not die, Rob Roe. I do not wish for your death. I will let you live."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/08_Outlaw_Base.cfg:304
+#: A_New_Order/scenarios/08_Outlaw_Base.cfg:306
 msgid "What's your name, noble stranger, so I can know whom to thank?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/08_Outlaw_Base.cfg:306
+#: A_New_Order/scenarios/08_Outlaw_Base.cfg:308
 msgid "So, Gaumhaldric, may I fight for you? I and my people too?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/08_Outlaw_Base.cfg:307
+#: A_New_Order/scenarios/08_Outlaw_Base.cfg:309
 msgid "Wow! Seems you have earned a new nickname, Gaumhaldric."
 msgstr ""
 
 #. [message]: speaker=Gawen Hagarthen
-#: A_New_Order/scenarios/08_Outlaw_Base.cfg:310
+#: A_New_Order/scenarios/08_Outlaw_Base.cfg:312
 msgid "After some thought..."
 msgstr ""
 
 #. [option]
-#: A_New_Order/scenarios/08_Outlaw_Base.cfg:312
+#: A_New_Order/scenarios/08_Outlaw_Base.cfg:314
 msgid "Yes, I shall accept you and any of your people who want to fight in my army."
 msgstr ""
 
 #. [option]
-#: A_New_Order/scenarios/08_Outlaw_Base.cfg:325
+#: A_New_Order/scenarios/08_Outlaw_Base.cfg:327
 msgid "No offense, but I don't trust you enough."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/08_Outlaw_Base.cfg:328
+#: A_New_Order/scenarios/08_Outlaw_Base.cfg:330
 msgid "You said most of your army is elsewhere?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/08_Outlaw_Base.cfg:329
+#: A_New_Order/scenarios/08_Outlaw_Base.cfg:331
 msgid "Yes. Our best units were hired to invade the Carrenemoe clan."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/08_Outlaw_Base.cfg:330
+#: A_New_Order/scenarios/08_Outlaw_Base.cfg:332
 msgid "The Carrenemoes? Ruvio, we have to..."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/08_Outlaw_Base.cfg:331
+#: A_New_Order/scenarios/08_Outlaw_Base.cfg:333
 msgid "We must get to Freetown as soon as possible. I'm sorry, kid."
 msgstr ""
 
 #. [then]
 #. Gawen is about to say "me" before remembering he's not supposed to reveal who he is, so instead he pretends "Gawen Hagarthen" is a different person:
-#: A_New_Order/scenarios/08_Outlaw_Base.cfg:336
+#: A_New_Order/scenarios/08_Outlaw_Base.cfg:338
 msgid "Rob Roe, there was assassin who was sent after m... Gawen Hagarthen. He was interrogated and he said he was sent from an 'Outlaw Place.' Do you know who hired him to kill king Gawen Hagarthen?"
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/08_Outlaw_Base.cfg:337
+#: A_New_Order/scenarios/08_Outlaw_Base.cfg:339
 msgid "I am not sure. Perhaps you can say a few names, and I will tell you if any of them rings a bell?"
 msgstr ""
 
 #. [message]: speaker=Gawen Hagarthen
-#: A_New_Order/scenarios/08_Outlaw_Base.cfg:345
+#: A_New_Order/scenarios/08_Outlaw_Base.cfg:347
 msgid "So, what about..."
 msgstr ""
 
 #. [command]
-#: A_New_Order/scenarios/08_Outlaw_Base.cfg:349
+#: A_New_Order/scenarios/08_Outlaw_Base.cfg:351
 msgid "No, I don't think it was him."
 msgstr ""
 
 #. [command]
 #. Konrad2 thinks the "a" before "father and son" should be removed, but maybe switching it (the "a") to "both" would make more sense? I dunno; leaving that part as-is for now:
-#: A_New_Order/scenarios/08_Outlaw_Base.cfg:356
+#: A_New_Order/scenarios/08_Outlaw_Base.cfg:358
 msgid "Yes! I remember that name now! He set a price on the head of a father and son. I think it was also he who paid us to invade the Carrenemoes' holdings."
 msgstr ""
 
 #. [option]
-#: A_New_Order/scenarios/08_Outlaw_Base.cfg:363
+#: A_New_Order/scenarios/08_Outlaw_Base.cfg:365
 msgid "Reme Carrenemoe?"
 msgstr ""
 
 #. [command]
-#: A_New_Order/scenarios/08_Outlaw_Base.cfg:365
+#: A_New_Order/scenarios/08_Outlaw_Base.cfg:367
 msgid "The noble and honorable Reme? You have got to be kidding."
 msgstr ""
 
 #. [option]
-#: A_New_Order/scenarios/08_Outlaw_Base.cfg:369
+#: A_New_Order/scenarios/08_Outlaw_Base.cfg:371
 msgid "Lady Lorin?"
 msgstr ""
 
 #. [command]
-#: A_New_Order/scenarios/08_Outlaw_Base.cfg:371
+#: A_New_Order/scenarios/08_Outlaw_Base.cfg:373
 msgid "No, it wasn't a woman. People from the Gallorae clan did contact us in the past about buying some poison, but that was years ago."
 msgstr ""
 
 #. [option]
-#: A_New_Order/scenarios/08_Outlaw_Base.cfg:377
+#: A_New_Order/scenarios/08_Outlaw_Base.cfg:379
 msgid "Graeme O Borraine?"
 msgstr ""
 
 #. [command]
-#: A_New_Order/scenarios/08_Outlaw_Base.cfg:379
+#: A_New_Order/scenarios/08_Outlaw_Base.cfg:381
 msgid "Who? Never heard of him."
 msgstr ""
 
 #. [option]
-#: A_New_Order/scenarios/08_Outlaw_Base.cfg:383
+#: A_New_Order/scenarios/08_Outlaw_Base.cfg:385
 msgid "Hoyre O Barnon?"
 msgstr ""
 
 #. [command]
-#: A_New_Order/scenarios/08_Outlaw_Base.cfg:385
+#: A_New_Order/scenarios/08_Outlaw_Base.cfg:387
 msgid "The guy from city of Barnon? No, it wasn't him, though from what I've heard about him he could do it - if he could think for himself."
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/08_Outlaw_Base.cfg:412
+#: A_New_Order/scenarios/08_Outlaw_Base.cfg:414
 msgid "There are no more trained, able-bodied young man in this small settlement to recruit as Spearman or Bowman. You may only recruit Peasants and Fencers now."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/08_Outlaw_Base.cfg:425
+#: A_New_Order/scenarios/08_Outlaw_Base.cfg:427
 msgid "Oh, there is a horse in this village. I can ride it!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/08_Outlaw_Base.cfg:437
+#: A_New_Order/scenarios/08_Outlaw_Base.cfg:439
 msgid "...see?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/08_Outlaw_Base.cfg:438
+#: A_New_Order/scenarios/08_Outlaw_Base.cfg:440
 msgid "You look different now."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/08_Outlaw_Base.cfg:439
+#: A_New_Order/scenarios/08_Outlaw_Base.cfg:441
 msgid "It's amazing the effect that getting on horseback can have on one's appearance, isn't it?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/08_Outlaw_Base.cfg:440
+#: A_New_Order/scenarios/08_Outlaw_Base.cfg:442
 msgid "Indeed."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/08_Outlaw_Base.cfg:589
+#: A_New_Order/scenarios/08_Outlaw_Base.cfg:591
 msgid "Ha! Our army has returned! You are doomed now!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/08_Outlaw_Base.cfg:602
+#: A_New_Order/scenarios/08_Outlaw_Base.cfg:604
 msgid "Hm, it seems there are some more people here, capable with spears and bows, who could be recruited."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/08_Outlaw_Base.cfg:603
+#: A_New_Order/scenarios/08_Outlaw_Base.cfg:605
 msgid "You may recruit four more archers and/or spearmen."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/08_Outlaw_Base.cfg:606
+#: A_New_Order/scenarios/08_Outlaw_Base.cfg:608
 msgid "It seems that the outlaws had a small treasury hidden here."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/08_Outlaw_Base.cfg:608
+#: A_New_Order/scenarios/08_Outlaw_Base.cfg:610
 msgid "You receive $gold_amt golden pieces."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/08_Outlaw_Base.cfg:629
+#: A_New_Order/scenarios/08_Outlaw_Base.cfg:631
 msgid "Haw haw haw, you thought we were here to fight <i><b>for</b></i> you? Think again, fools!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/08_Outlaw_Base.cfg:632
+#: A_New_Order/scenarios/08_Outlaw_Base.cfg:634
 msgid "$unit.name turned out to be an outlaw!"
 msgstr ""
 
@@ -13860,7 +13870,7 @@ msgid "Lie in peace, soldier."
 msgstr ""
 
 #. [event]
-#. this is a well-known quote from a well-known book -- translators, please find how this quote was translated into your language before trying translating it by yourself.
+#. this is the "Litany Against Fear" from the "Dune" franchise -- translators, please find how this quote was translated into your language before trying translating it by yourself.
 #: A_New_Order/scenarios/14b_Bontom.cfg:677
 msgid "I must not fear. Fear is the mind-killer. Fear is the little-death that brings total obliteration. I will face my fear. I will permit it to pass over me and through me. And when it has gone past I will turn the inner eye to see its path. Where the fear has gone there will be nothing. Only I will remain."
 msgstr ""
@@ -16442,7 +16452,7 @@ msgstr ""
 #: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:672
 #: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:695
 #: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:697
-#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:732
+#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:734
 msgid "Medic"
 msgstr ""
 
@@ -16472,78 +16482,78 @@ msgid "Hold on a moment."
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:732
+#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:734
 msgid "...and there you go."
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:733
-msgid "Thanks. (*<i>faints</i>*)"
+#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:735
+msgid "Thank you. (*<i>faints</i>*)"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:778
+#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:780
 msgid "Truly a shame we have no time to loot it or tax the inhabitants..."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:787
+#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:789
 msgid "Ah, a village..."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:788
+#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:790
 msgid "A medic! Somebody find a medic!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:789
+#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:791
 msgid "Unfortunately, it seems that there are no medics here... we will most likely have to wait until we reach the enemy encampment before we can cure Gawen's poison..."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:838
+#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:840
 msgid "I can't see... it's so cold..."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:839
+#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:841
 msgid "No! Don't you DARE die on me! Not now!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:855
+#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:857
 msgid "For freedom! Death to the Akladian beasts!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:856
+#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:858
 msgid "Umm... we are good guys, right?"
 msgstr ""
 
 #. [event]
 #. EASY difficulty, so have Reme give an additional hint:
-#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:859
+#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:861
 msgid "Do not forget to withdraw wounded units to villages, where they can rest and regain some of their health."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:872
+#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:874
 msgid "Get out of my way, filthy underling!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:884
+#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:886
 msgid "Poor fools! They have no chance, yet still they fight."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:897
+#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:899
 msgid "How dare you oppose us, heathen underling!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:905
+#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:907
 msgid "Their leader is dead, good! Now bring Gawen to their keep, men!"
 msgstr ""
 

--- a/translations/wesnoth-A_New_Order.pot
+++ b/translations/wesnoth-A_New_Order.pot
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
-"POT-Creation-Date: 2024-06-07 01:33 UTC\n"
+"POT-Creation-Date: 2024-07-25 03:36 UTC\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -469,7 +469,7 @@ msgstr ""
 
 #. [unit_type]: id=Akladian Wiseman, race=akladian
 #: A_New_Order/units/akladians/Akladian_Wiseman.cfg:32
-msgid "Akladian Wisemans are those very few from the tribes, who study herbs and ways to heal, instead of how to harm and kill people."
+msgid "Akladian Wisemen are those very few from the tribes, who study herbs and ways to heal, instead of how to harm and kill people."
 msgstr ""
 
 #. [unit_type]: id=Akladian Leader, race=akladian
@@ -499,7 +499,7 @@ msgstr ""
 
 #. [unit_type]: id=Akladian Holyman, race=akladian
 #: A_New_Order/units/akladians/Akladian_Holyman.cfg:28
-msgid "Devoting their whole life to the task of healing and curing, Akladian Holymans are respected amongst the tribes, and useful to Akladian lords."
+msgid "Devoting their whole life to the task of healing and curing, Akladian Holymen are respected amongst the tribes, and useful to Akladian lords."
 msgstr ""
 
 #. [unit_type]: id=Akladian Darknite, race=akladian
@@ -729,37 +729,38 @@ msgstr ""
 
 #. [message]: speaker=unit
 #. Kyobaine, female Elf
-#: A_New_Order/macros/elvish_macros.cfg:11
+#: A_New_Order/macros/elvish_macros.cfg:22
+#: A_New_Order/macros/elvish_macros.cfg:30
 msgid "I will never again see our beautiful forests..."
 msgstr ""
 
 #. [message]: speaker=unit
 #. Milildur, male Elf
-#: A_New_Order/macros/elvish_macros.cfg:23
+#: A_New_Order/macros/elvish_macros.cfg:44
 msgid "See how Elves die; without fear!"
 msgstr ""
 
 #. [message]: speaker=unit
 #. Elorain, female Elf
-#: A_New_Order/macros/elvish_macros.cfg:35
+#: A_New_Order/macros/elvish_macros.cfg:56
 msgid "Now, I will meet the best marksman... Death never misses."
 msgstr ""
 
 #. [message]: speaker=Elorain
 #. See scenarios/11_Council_in_Freetown for where these randomly-chosen phrases come from:
-#: A_New_Order/macros/elvish_macros.cfg:51
+#: A_New_Order/macros/elvish_macros.cfg:72
 msgid "Ha! $ano_elorain_$random "
 msgstr ""
 
 #. [message]: speaker=Milildur
 #. See scenarios/11_Council_in_Freetown for where the randomly-chosen phrases come from:
-#: A_New_Order/macros/elvish_macros.cfg:64
+#: A_New_Order/macros/elvish_macros.cfg:85
 msgid "Ha! $ano_milildur_$random "
 msgstr ""
 
 #. [event]
 #. [unit]: type=Elvish Captain, id=Milildur
-#: A_New_Order/macros/elvish_macros.cfg:78
+#: A_New_Order/macros/elvish_macros.cfg:99
 #: A_New_Order/macros/messages.cfg:147
 #: A_New_Order/scenarios/11_Council_in_Freetown.cfg:347
 #: A_New_Order/scenarios/11_Council_in_Freetown.cfg:371
@@ -768,14 +769,14 @@ msgstr ""
 
 #. [event]
 #. The message 'I fought with you for so many battles...' etc. will be spoken by both male, Milildur, and Elorain, female. Make it gender neutral.
-#: A_New_Order/macros/elvish_macros.cfg:80
-#: A_New_Order/macros/elvish_macros.cfg:97
+#: A_New_Order/macros/elvish_macros.cfg:101
+#: A_New_Order/macros/elvish_macros.cfg:118
 msgid "My lord, I fought with you for so many battles... I can accept money from you no more. Please, treat me like a friend, not like a hired soldier."
 msgstr ""
 
 #. [event]
 #. [unit]: type=Elvish Ranger, id=Elorain
-#: A_New_Order/macros/elvish_macros.cfg:97
+#: A_New_Order/macros/elvish_macros.cfg:118
 #: A_New_Order/macros/messages.cfg:144
 #: A_New_Order/scenarios/21a_Abducted_Bride.cfg:335
 #: A_New_Order/scenarios/21a_Abducted_Bride.cfg:341
@@ -787,7 +788,7 @@ msgstr ""
 
 #. [event]
 #. a more phonetic spelling of "Ahem" (noise made when clearing one's throat):
-#: A_New_Order/macros/elvish_macros.cfg:133
+#: A_New_Order/macros/elvish_macros.cfg:154
 msgid "Ekhem."
 msgstr ""
 
@@ -800,22 +801,22 @@ msgstr ""
 #. [unit]: type=Elvish Scout, id=Kyobaine
 #. [unit]: type=Elvish Fighter, id=Kyobaine
 #. [unit]: type=Elvish Archer, id=Kyobaine
-#: A_New_Order/macros/elvish_macros.cfg:134
-#: A_New_Order/macros/elvish_macros.cfg:139
-#: A_New_Order/macros/elvish_macros.cfg:142
-#: A_New_Order/macros/elvish_macros.cfg:146
-#: A_New_Order/macros/elvish_macros.cfg:177
-#: A_New_Order/macros/elvish_macros.cfg:166
-#: A_New_Order/macros/elvish_macros.cfg:207
-#: A_New_Order/macros/elvish_macros.cfg:211
-#: A_New_Order/macros/elvish_macros.cfg:216
-#: A_New_Order/macros/elvish_macros.cfg:220
-#: A_New_Order/macros/elvish_macros.cfg:197
-#: A_New_Order/macros/elvish_macros.cfg:230
-#: A_New_Order/macros/elvish_macros.cfg:314
-#: A_New_Order/macros/elvish_macros.cfg:316
-#: A_New_Order/macros/elvish_macros.cfg:319
-#: A_New_Order/macros/elvish_macros.cfg:329
+#: A_New_Order/macros/elvish_macros.cfg:155
+#: A_New_Order/macros/elvish_macros.cfg:160
+#: A_New_Order/macros/elvish_macros.cfg:163
+#: A_New_Order/macros/elvish_macros.cfg:167
+#: A_New_Order/macros/elvish_macros.cfg:198
+#: A_New_Order/macros/elvish_macros.cfg:187
+#: A_New_Order/macros/elvish_macros.cfg:228
+#: A_New_Order/macros/elvish_macros.cfg:232
+#: A_New_Order/macros/elvish_macros.cfg:237
+#: A_New_Order/macros/elvish_macros.cfg:241
+#: A_New_Order/macros/elvish_macros.cfg:218
+#: A_New_Order/macros/elvish_macros.cfg:251
+#: A_New_Order/macros/elvish_macros.cfg:335
+#: A_New_Order/macros/elvish_macros.cfg:337
+#: A_New_Order/macros/elvish_macros.cfg:340
+#: A_New_Order/macros/elvish_macros.cfg:350
 #: A_New_Order/macros/messages.cfg:161
 #: A_New_Order/macros/messages.cfg:164
 #: A_New_Order/macros/messages.cfg:174
@@ -834,8 +835,8 @@ msgstr ""
 #. [event]
 #. [event]: id=Kyobaine_recall_clothing_banter
 #. [then]
-#: A_New_Order/macros/elvish_macros.cfg:134
-#: A_New_Order/macros/elvish_macros.cfg:264
+#: A_New_Order/macros/elvish_macros.cfg:155
+#: A_New_Order/macros/elvish_macros.cfg:285
 #: A_New_Order/macros/conversations.cfg:43
 #: A_New_Order/scenarios/07_Ally_From_the_Past.cfg:676
 #: A_New_Order/scenarios/02_Fighting_for_Passage.cfg:741
@@ -844,94 +845,94 @@ msgstr ""
 
 #. [event]
 #. Gawen is speaking to Kyobaine, an elvish woman. He is repeating what Milildur and Elorain were earlier speaking; these strings should be similar. Elorain earlier said: My lord, I fought with you so many battles etc
-#: A_New_Order/macros/elvish_macros.cfg:137
+#: A_New_Order/macros/elvish_macros.cfg:158
 msgid "Well, you fought with me so many battles..."
 msgstr ""
 
 #. [event]
-#: A_New_Order/macros/elvish_macros.cfg:139
+#: A_New_Order/macros/elvish_macros.cfg:160
 msgid "...Aaand?"
 msgstr ""
 
 #. [event]
 #. again, see previously:
-#: A_New_Order/macros/elvish_macros.cfg:141
+#: A_New_Order/macros/elvish_macros.cfg:162
 msgid "Well, you know, I thought that I should no longer treat you like a hired soldier..."
 msgstr ""
 
 #. [event]
 #. "ask me out" as in, on a date:
-#: A_New_Order/macros/elvish_macros.cfg:144
+#: A_New_Order/macros/elvish_macros.cfg:165
 msgid "What?!? Are you trying to ask me out or something?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/macros/elvish_macros.cfg:145
+#: A_New_Order/macros/elvish_macros.cfg:166
 msgid "...Eee?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/macros/elvish_macros.cfg:146
+#: A_New_Order/macros/elvish_macros.cfg:167
 msgid "No offense, but... it's not like I have something against males in general. It's more like I like them less hairy. And less... human. Anything more? No? Good. Let's get back to the business. And don't forget about my 20 gold pieces."
 msgstr ""
 
 #. [event]: id=Kyobaine_post_advance_clothing_banter
 #. Kyobaine advances to Elvish Druid
-#: A_New_Order/macros/elvish_macros.cfg:168
+#: A_New_Order/macros/elvish_macros.cfg:189
 msgid "How on earth I am supposed to walk in these clothes during winter? It's frigging cold!"
 msgstr ""
 
 #. [then]
 #. Gawen speaking to Kyobaine:
-#: A_New_Order/macros/elvish_macros.cfg:176
+#: A_New_Order/macros/elvish_macros.cfg:197
 msgid "But you're wearing snowshoes though."
 msgstr ""
 
 #. [then]
 #. Kyobaine speaking to Gawen:
-#: A_New_Order/macros/elvish_macros.cfg:179
+#: A_New_Order/macros/elvish_macros.cfg:200
 msgid "Do you seriously think that helps with the fact that it's my <b><i>BARE FEET</i></b> I have strapped into them? The holes in their webbing are enormous! The snow gets right through!"
 msgstr ""
 
 #. [event]: id=Kyobaine_recall_clothing_banter
 #. The talk between Kyobaine as Elvish Druid and Gawen, during winter
-#: A_New_Order/macros/elvish_macros.cfg:199
+#: A_New_Order/macros/elvish_macros.cfg:220
 msgid "Oooh, no. I refuse to fight in these conditions, as long as I'm clad as such."
 msgstr ""
 
 #. [event]: id=Kyobaine_recall_clothing_banter
-#: A_New_Order/macros/elvish_macros.cfg:200
+#: A_New_Order/macros/elvish_macros.cfg:221
 msgid "What do you mean? Your clothes are just fine."
 msgstr ""
 
 #. [then]
 #. Kyobaine asks Gawen for different clothes when she's wearing snowshoes:
-#: A_New_Order/macros/elvish_macros.cfg:209
+#: A_New_Order/macros/elvish_macros.cfg:230
 msgid "Except for the snowshoes, these are clothes <i>for the spring</i>. The least you can do is to give me a proper cloak. You expect me to fight when I'm shivering and have goosebumps??"
 msgstr ""
 
 #. [then]
 #. [else]
-#: A_New_Order/macros/elvish_macros.cfg:210
-#: A_New_Order/macros/elvish_macros.cfg:219
+#: A_New_Order/macros/elvish_macros.cfg:231
+#: A_New_Order/macros/elvish_macros.cfg:240
 msgid "That's ridiculous."
 msgstr ""
 
 #. [then]
 #. Kyobaine asks Gawen for different clothes when she's wearing snowshoes:
-#: A_New_Order/macros/elvish_macros.cfg:213
+#: A_New_Order/macros/elvish_macros.cfg:234
 msgid "I couldn't agree more. Call me when you have a new cloak."
 msgstr ""
 
 #. [else]
 #. the old version of Kyobaine's request to Gawen:
-#: A_New_Order/macros/elvish_macros.cfg:218
+#: A_New_Order/macros/elvish_macros.cfg:239
 msgid "<i>For the spring</i>. The least you can do is to give me proper shoes. You expect me to walk in this snow <i>barefoot</i>??"
 msgstr ""
 
 #. [else]
 #. the old version of Kyobaine's request to Gawen:
-#: A_New_Order/macros/elvish_macros.cfg:222
+#: A_New_Order/macros/elvish_macros.cfg:243
 msgid "I couldn't agree more. Call me when you have new shoes."
 msgstr ""
 
@@ -941,7 +942,7 @@ msgstr ""
 #. [scenario]: id=22_Leaving_Okladia
 #. [else]
 #. [scenario]: id=14e_Saorduc_Swamps
-#: A_New_Order/macros/elvish_macros.cfg:226
+#: A_New_Order/macros/elvish_macros.cfg:247
 #: A_New_Order/macros/ano-20macros.cfg:331
 #: A_New_Order/scenarios/25_The_Awakening.cfg:23
 #: A_New_Order/scenarios/15a_The_Preparations.cfg:199
@@ -957,144 +958,144 @@ msgid "Well..."
 msgstr ""
 
 #. [event]: id=Kyobaine_recall_clothing_banter
-#: A_New_Order/macros/elvish_macros.cfg:227
+#: A_New_Order/macros/elvish_macros.cfg:248
 msgid "All right, how about I give you 25 gold pieces instead of 20?"
 msgstr ""
 
 #. [event]: id=Kyobaine_recall_clothing_banter
-#: A_New_Order/macros/elvish_macros.cfg:228
+#: A_New_Order/macros/elvish_macros.cfg:249
 msgid "All right, we will wait for the spring."
 msgstr ""
 
 #. [event]: id=Kyobaine_recall_clothing_banter
-#: A_New_Order/macros/elvish_macros.cfg:230
+#: A_New_Order/macros/elvish_macros.cfg:251
 msgid "You think you can bribe me, an elvish druid, with gold? Oh well. This will allow me to buy better winter clothes."
 msgstr ""
 
 #. [event]: id=Kyobaine_recall_clothing_banter
-#: A_New_Order/macros/elvish_macros.cfg:231
+#: A_New_Order/macros/elvish_macros.cfg:252
 msgid "Maybe I should act gentlemanly here?"
 msgstr ""
 
 #. [event]: id=Kyobaine_recall_clothing_banter
-#: A_New_Order/macros/elvish_macros.cfg:232
+#: A_New_Order/macros/elvish_macros.cfg:253
 msgid "(Offer to get the clothes for her - longer conversation)"
 msgstr ""
 
 #. [event]: id=Kyobaine_recall_clothing_banter
-#: A_New_Order/macros/elvish_macros.cfg:233
+#: A_New_Order/macros/elvish_macros.cfg:254
 msgid "(Let her get the clothes herself - end event more quickly)"
 msgstr ""
 
 #. [event]: id=Kyobaine_recall_clothing_banter
-#: A_New_Order/macros/elvish_macros.cfg:235
+#: A_New_Order/macros/elvish_macros.cfg:256
 msgid "Are you sure you wouldn't prefer it if I went and bought you better winter clothes instead? That way you could stay by a campfire while you wait."
 msgstr ""
 
 #. [event]: id=Kyobaine_recall_clothing_banter
-#: A_New_Order/macros/elvish_macros.cfg:236
+#: A_New_Order/macros/elvish_macros.cfg:257
 msgid "To be honest, I don't really trust you after you called me out here like this. Someone with judgment like that can hardly be expected to correctly purchase the clothes I require."
 msgstr ""
 
 #. [event]: id=Kyobaine_recall_clothing_banter
-#: A_New_Order/macros/elvish_macros.cfg:237
+#: A_New_Order/macros/elvish_macros.cfg:258
 msgid "What, do you require them in a particular size or something? What are your measurements?"
 msgstr ""
 
 #. [event]: id=Kyobaine_recall_clothing_banter
-#: A_New_Order/macros/elvish_macros.cfg:238
+#: A_New_Order/macros/elvish_macros.cfg:259
 msgid "My... measurements? What do you mean by that? Do you mean you humans measure yourselves before deciding what clothing to purchase?"
 msgstr ""
 
 #. [event]: id=Kyobaine_recall_clothing_banter
-#: A_New_Order/macros/elvish_macros.cfg:239
+#: A_New_Order/macros/elvish_macros.cfg:260
 msgid "I mean, yeah, we do; how do you elves make sure you get the proper fit?"
 msgstr ""
 
 #. [event]: id=Kyobaine_recall_clothing_banter
-#: A_New_Order/macros/elvish_macros.cfg:240
+#: A_New_Order/macros/elvish_macros.cfg:261
 msgid "Why, we simply wander the woods hugging trees until -"
 msgstr ""
 
 #. [event]: id=Kyobaine_recall_clothing_banter
-#: A_New_Order/macros/elvish_macros.cfg:241
+#: A_New_Order/macros/elvish_macros.cfg:262
 msgid "Wait, hold up, you literally HUG TREES?!"
 msgstr ""
 
 #. [event]: id=Kyobaine_recall_clothing_banter
-#: A_New_Order/macros/elvish_macros.cfg:242
+#: A_New_Order/macros/elvish_macros.cfg:263
 msgid "Why yes, of course, haven't you ever tried it?"
 msgstr ""
 
 #. [event]: id=Kyobaine_recall_clothing_banter
-#: A_New_Order/macros/elvish_macros.cfg:243
+#: A_New_Order/macros/elvish_macros.cfg:264
 msgid "Ha, that's hilarious! (*<i>catches breath from laughing</i>*) But, to answer your question, no, I haven't. Akladians raise their children to fear trees, and thus the only interaction we are allowed to have with trees is chopping them down."
 msgstr ""
 
 #. [event]: id=Kyobaine_recall_clothing_banter
-#: A_New_Order/macros/elvish_macros.cfg:244
+#: A_New_Order/macros/elvish_macros.cfg:265
 msgid "How horrible! You really must try hugging a tree some day, for your own well-being. But, to return to the previous topic, the way we ensure our clothes fit is to wander the woods hugging trees until one lets the vines growing around it return our embrace in a way that feels just right, and then the vines will form new clothes for us based on this experience."
 msgstr ""
 
 #. [event]: id=Kyobaine_recall_clothing_banter
-#: A_New_Order/macros/elvish_macros.cfg:245
+#: A_New_Order/macros/elvish_macros.cfg:266
 msgid "OK, well, it's winter, so I don't think any of the trees around here have vines that would really feel up to that... Could you please try the human measurement system instead just this one time?"
 msgstr ""
 
 #. [event]: id=Kyobaine_recall_clothing_banter
-#: A_New_Order/macros/elvish_macros.cfg:246
+#: A_New_Order/macros/elvish_macros.cfg:267
 msgid "All right, what measurements do you require? The length of my ears?"
 msgstr ""
 
 #. [event]: id=Kyobaine_recall_clothing_banter
-#: A_New_Order/macros/elvish_macros.cfg:250
+#: A_New_Order/macros/elvish_macros.cfg:271
 msgid "No, it's, ah, er... (*<i>blushes</i>*) ...you know what, maybe it would be better to have one of your fellow females explain this to you... look, there are Lorin and Karen over there; let's go ask one of them."
 msgstr ""
 
 #. [event]: id=Kyobaine_recall_clothing_banter
-#: A_New_Order/macros/elvish_macros.cfg:251
+#: A_New_Order/macros/elvish_macros.cfg:272
 msgid "Let's ask..."
 msgstr ""
 
 #. [event]: id=Kyobaine_recall_clothing_banter
-#: A_New_Order/macros/elvish_macros.cfg:252
+#: A_New_Order/macros/elvish_macros.cfg:273
 msgid "person_to_ask^Lorin."
 msgstr ""
 
 #. [event]: id=Kyobaine_recall_clothing_banter
-#: A_New_Order/macros/elvish_macros.cfg:253
+#: A_New_Order/macros/elvish_macros.cfg:274
 msgid "person_to_ask^Karen."
 msgstr ""
 
 #. [event]: id=Kyobaine_recall_clothing_banter
-#: A_New_Order/macros/elvish_macros.cfg:255
+#: A_New_Order/macros/elvish_macros.cfg:276
 msgid "No, it's, ah, er... (*<i>blushes</i>*) ...you know what, maybe it would be better to have someone female explain this to you... look, there's Karen over there; let's go ask her."
 msgstr ""
 
 #. [event]: id=Kyobaine_recall_clothing_banter
-#: A_New_Order/macros/elvish_macros.cfg:259
+#: A_New_Order/macros/elvish_macros.cfg:280
 msgid "Hi, mother, I was just wondering if you could help explain human measurements to Kyobaine here?"
 msgstr ""
 
 #. [event]: id=Kyobaine_recall_clothing_banter
-#: A_New_Order/macros/elvish_macros.cfg:260
+#: A_New_Order/macros/elvish_macros.cfg:281
 msgid "Measurements? You mean like how far I can drive my knife into someone's back?"
 msgstr ""
 
 #. [event]: id=Kyobaine_recall_clothing_banter
-#: A_New_Order/macros/elvish_macros.cfg:261
+#: A_New_Order/macros/elvish_macros.cfg:282
 msgid "No, of course not! I meant for clothing."
 msgstr ""
 
 #. [event]: id=Kyobaine_recall_clothing_banter
-#: A_New_Order/macros/elvish_macros.cfg:262
+#: A_New_Order/macros/elvish_macros.cfg:283
 msgid "Oh right, THOSE kinds of measurements. I don't remember them myself. I usually let an underling servant take them, and then kill him after he has returned with the clothes, so that he can't go leaking my secrets to anyone else."
 msgstr ""
 
 #. [event]: id=Kyobaine_recall_clothing_banter
 #. [event]
 #. [scenario]: id=14b_Bontom
-#: A_New_Order/macros/elvish_macros.cfg:263
+#: A_New_Order/macros/elvish_macros.cfg:284
 #: A_New_Order/scenarios/12_Leaving_Raedwood.cfg:316
 #: A_New_Order/scenarios/12_Leaving_Raedwood.cfg:358
 #: A_New_Order/scenarios/14b_Bontom.cfg:76
@@ -1103,100 +1104,100 @@ msgid "..."
 msgstr ""
 
 #. [event]: id=Kyobaine_recall_clothing_banter
-#: A_New_Order/macros/elvish_macros.cfg:265
+#: A_New_Order/macros/elvish_macros.cfg:286
 msgid "You know what, forget I asked. Kyobaine, maybe you should just go get your own clothes after all."
 msgstr ""
 
 #. [event]: id=Kyobaine_recall_clothing_banter
-#: A_New_Order/macros/elvish_macros.cfg:266
+#: A_New_Order/macros/elvish_macros.cfg:287
 msgid "Well that was a waste of time. All that talk just to get back to what my original plan was in the first place..."
 msgstr ""
 
 #. [event]: id=Kyobaine_recall_clothing_banter
-#: A_New_Order/macros/elvish_macros.cfg:269
+#: A_New_Order/macros/elvish_macros.cfg:290
 msgid "Hey Karen, I was just wondering if you could help explain human clothing measurements to Kyobaine here?"
 msgstr ""
 
 #. [event]: id=Kyobaine_recall_clothing_banter
-#: A_New_Order/macros/elvish_macros.cfg:270
+#: A_New_Order/macros/elvish_macros.cfg:291
 msgid "Oooh, clothes shopping, are we? Got a big date coming up, eh, Kyobaine?"
 msgstr ""
 
 #. [event]: id=Kyobaine_recall_clothing_banter
-#: A_New_Order/macros/elvish_macros.cfg:271
+#: A_New_Order/macros/elvish_macros.cfg:292
 msgid "What? No! I'm just cold and need a cloak."
 msgstr ""
 
 #. [event]: id=Kyobaine_recall_clothing_banter
-#: A_New_Order/macros/elvish_macros.cfg:272
+#: A_New_Order/macros/elvish_macros.cfg:293
 msgid "Oh, a cloak, that's all? You don't even need sizes for those, they're mostly one-size-fits-all. Size info would really only be necessary if you were going to replace your entire robe."
 msgstr ""
 
 #. [event]: id=Kyobaine_recall_clothing_banter
-#: A_New_Order/macros/elvish_macros.cfg:273
+#: A_New_Order/macros/elvish_macros.cfg:294
 msgid "Oh. So, what was this fuss about sizes all about again? ...Gawen?"
 msgstr ""
 
 #. [event]: id=Kyobaine_recall_clothing_banter
-#: A_New_Order/macros/elvish_macros.cfg:274
+#: A_New_Order/macros/elvish_macros.cfg:295
 msgid "What? I was just trying to be helpful."
 msgstr ""
 
 #. [event]: id=Kyobaine_recall_clothing_banter
-#: A_New_Order/macros/elvish_macros.cfg:275
+#: A_New_Order/macros/elvish_macros.cfg:296
 msgid "(*<i>snickers</i>*)"
 msgstr ""
 
 #. [event]: id=Kyobaine_recall_clothing_banter
-#: A_New_Order/macros/elvish_macros.cfg:276
+#: A_New_Order/macros/elvish_macros.cfg:297
 msgid "Well, I think I shall be fine buying my own cloak, Gawen. You just stay here while I go find a tailor."
 msgstr ""
 
 #. [event]: id=Kyobaine_recall_clothing_banter
-#: A_New_Order/macros/elvish_macros.cfg:279
+#: A_New_Order/macros/elvish_macros.cfg:300
 msgid "I think I saw a tailor just back that way that you could buy something from."
 msgstr ""
 
 #. [event]: id=Kyobaine_recall_clothing_banter
-#: A_New_Order/macros/elvish_macros.cfg:307
+#: A_New_Order/macros/elvish_macros.cfg:328
 msgid "Uh... she <i>is</i> coming back, isn't she?"
 msgstr ""
 
 #. [event]: id=Kyobaine_recall_clothing_banter
 #. [then]
-#: A_New_Order/macros/elvish_macros.cfg:314
+#: A_New_Order/macros/elvish_macros.cfg:335
 #: A_New_Order/scenarios/16_Choosing_the_Best.cfg:314
 msgid "...yes?"
 msgstr ""
 
 #. [event]: id=Kyobaine_recall_clothing_banter
-#: A_New_Order/macros/elvish_macros.cfg:315
+#: A_New_Order/macros/elvish_macros.cfg:336
 msgid "...!"
 msgstr ""
 
 #. [event]: id=Kyobaine_recall_clothing_banter
-#: A_New_Order/macros/elvish_macros.cfg:316
+#: A_New_Order/macros/elvish_macros.cfg:337
 msgid "...why do you look so surprised? I <i>did</i> say I was going to buy better winter clothes, didn't I? I think this cloak shall do just fine."
 msgstr ""
 
 #. [event]: id=Kyobaine_recall_clothing_banter
 #. Gawen is tongue-tied by Kyobaine's reappearance:
-#: A_New_Order/macros/elvish_macros.cfg:318
+#: A_New_Order/macros/elvish_macros.cfg:339
 msgid "...yes, well, indeed! Carry on, then!"
 msgstr ""
 
 #. [event]: id=Kyobaine_recall_clothing_banter
-#: A_New_Order/macros/elvish_macros.cfg:319
+#: A_New_Order/macros/elvish_macros.cfg:340
 msgid "Humans... their reactions can be so strange sometimes..."
 msgstr ""
 
 #. [event]: id=Kyobaine_recall_clothing_banter
-#: A_New_Order/macros/elvish_macros.cfg:325
+#: A_New_Order/macros/elvish_macros.cfg:346
 msgid "Hey, give back my gold!"
 msgstr ""
 
 #. [event]: id=Kyobaine_recall_clothing_banter
-#: A_New_Order/macros/elvish_macros.cfg:329
+#: A_New_Order/macros/elvish_macros.cfg:350
 msgid "Stingy bastard."
 msgstr ""
 
@@ -1682,7 +1683,7 @@ msgstr ""
 #: A_New_Order/scenarios/27_Orannon.cfg:1147
 #: A_New_Order/scenarios/02_Fighting_for_Passage.cfg:352
 #: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:540
-#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:298
+#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:299
 #: A_New_Order/scenarios/10_Siege_of_Haeltin.cfg:423
 #: A_New_Order/scenarios/09_Hired_Swords.cfg:256
 msgid "Death of Lady Lorin"
@@ -1695,7 +1696,7 @@ msgstr ""
 #: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:504
 #: A_New_Order/scenarios/02_Fighting_for_Passage.cfg:356
 #: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:544
-#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:302
+#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:303
 msgid "Death of Reme Carrenemoe"
 msgstr ""
 
@@ -2347,10 +2348,10 @@ msgstr ""
 #: A_New_Order/scenarios/21a_Abducted_Bride.cfg:26
 #: A_New_Order/scenarios/21a_Abducted_Bride.cfg:56
 #: A_New_Order/scenarios/12_Leaving_Raedwood.cfg:13
-#: A_New_Order/scenarios/14b_Bontom.cfg:558
-#: A_New_Order/scenarios/14b_Bontom.cfg:565
-#: A_New_Order/scenarios/14b_Bontom.cfg:608
-#: A_New_Order/scenarios/14b_Bontom.cfg:615
+#: A_New_Order/scenarios/14b_Bontom.cfg:559
+#: A_New_Order/scenarios/14b_Bontom.cfg:566
+#: A_New_Order/scenarios/14b_Bontom.cfg:611
+#: A_New_Order/scenarios/14b_Bontom.cfg:618
 #: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:227
 #: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:318
 #: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:379
@@ -3209,7 +3210,7 @@ msgstr ""
 #. [event]
 #: A_New_Order/macros/ano-14macros.cfg:185
 #: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:138
-#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:380
+#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:381
 msgid "Rassum"
 msgstr ""
 
@@ -3218,7 +3219,7 @@ msgstr ""
 #. [scenario]: id=14e_Saorduc_Swamps
 #: A_New_Order/macros/ano-14macros.cfg:193
 #: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:161
-#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:266
+#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:267
 msgid "Bussur"
 msgstr ""
 
@@ -3228,7 +3229,7 @@ msgstr ""
 #: A_New_Order/macros/ano-14macros.cfg:201
 #: A_New_Order/macros/messages.cfg:135
 #: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:92
-#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:58
+#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:59
 msgid "Burass"
 msgstr ""
 
@@ -3237,9 +3238,9 @@ msgstr ""
 #. [event]
 #: A_New_Order/macros/ano-14macros.cfg:204
 #: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:115
-#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:432
-#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:439
-#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:441
+#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:433
+#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:440
+#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:442
 msgid "Ussuh"
 msgstr ""
 
@@ -3297,7 +3298,7 @@ msgstr ""
 #. [side]: id=Hoyre O Barnone, type=Akladian Lord
 #: A_New_Order/macros/messages.cfg:54
 #: A_New_Order/scenarios/25_The_Awakening.cfg:466
-#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:98
+#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:99
 #: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:83
 msgid "Hoyre O Barnone"
 msgstr ""
@@ -3797,7 +3798,7 @@ msgstr ""
 #: A_New_Order/scenarios/13_Scouting.cfg:330
 #: A_New_Order/scenarios/15a_The_Preparations.cfg:32
 #: A_New_Order/scenarios/15c_Raedwood_East.cfg:35
-#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:46
+#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:47
 #: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:160
 #: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:759
 #: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:782
@@ -3921,7 +3922,7 @@ msgstr ""
 #: A_New_Order/scenarios/13_Scouting.cfg:884
 #: A_New_Order/scenarios/13_Scouting.cfg:916
 #: A_New_Order/scenarios/13_Scouting.cfg:947
-#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:463
+#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:464
 #: A_New_Order/scenarios/21a_Abducted_Bride.cfg:481
 #: A_New_Order/scenarios/14d_Avenging_Ruen.cfg:183
 #: A_New_Order/scenarios/14d_Avenging_Ruen.cfg:247
@@ -3930,8 +3931,8 @@ msgstr ""
 #: A_New_Order/scenarios/19b_Entering_Okladia.cfg:191
 #: A_New_Order/scenarios/21b_Haunted_Place.cfg:233
 #: A_New_Order/scenarios/21b_Haunted_Place.cfg:441
-#: A_New_Order/scenarios/14b_Bontom.cfg:471
-#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:486
+#: A_New_Order/scenarios/14b_Bontom.cfg:472
+#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:487
 #: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:151
 #: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:175
 #: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:199
@@ -3955,15 +3956,15 @@ msgstr ""
 #: A_New_Order/scenarios/13_Scouting.cfg:885
 #: A_New_Order/scenarios/13_Scouting.cfg:917
 #: A_New_Order/scenarios/13_Scouting.cfg:948
-#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:464
+#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:465
 #: A_New_Order/scenarios/21a_Abducted_Bride.cfg:482
 #: A_New_Order/scenarios/14d_Avenging_Ruen.cfg:184
 #: A_New_Order/scenarios/19a_The_Woods_of_Okladia.cfg:201
 #: A_New_Order/scenarios/19b_Entering_Okladia.cfg:192
 #: A_New_Order/scenarios/21b_Haunted_Place.cfg:234
 #: A_New_Order/scenarios/21b_Haunted_Place.cfg:442
-#: A_New_Order/scenarios/14b_Bontom.cfg:472
-#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:487
+#: A_New_Order/scenarios/14b_Bontom.cfg:473
+#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:488
 #: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:152
 #: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:176
 #: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:200
@@ -4160,10 +4161,10 @@ msgstr ""
 #: A_New_Order/scenarios/13_Scouting.cfg:661
 #: A_New_Order/scenarios/13_Scouting.cfg:681
 #: A_New_Order/scenarios/13_Scouting.cfg:694
-#: A_New_Order/scenarios/14b_Bontom.cfg:553
-#: A_New_Order/scenarios/14b_Bontom.cfg:561
-#: A_New_Order/scenarios/14b_Bontom.cfg:603
-#: A_New_Order/scenarios/14b_Bontom.cfg:611
+#: A_New_Order/scenarios/14b_Bontom.cfg:554
+#: A_New_Order/scenarios/14b_Bontom.cfg:562
+#: A_New_Order/scenarios/14b_Bontom.cfg:606
+#: A_New_Order/scenarios/14b_Bontom.cfg:614
 #: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:222
 #: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:313
 #: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:374
@@ -4785,9 +4786,7 @@ msgstr ""
 #: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:492
 #: A_New_Order/scenarios/27_Orannon.cfg:738
 #: A_New_Order/scenarios/27_Orannon.cfg:1139
-#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:243
-#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:255
-#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:294
+#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:295
 msgid "Kill all enemy leaders"
 msgstr ""
 
@@ -5491,8 +5490,8 @@ msgstr ""
 #: A_New_Order/scenarios/13_Scouting.cfg:438
 #: A_New_Order/scenarios/15a_The_Preparations.cfg:287
 #: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:466
-#: A_New_Order/scenarios/14b_Bontom.cfg:656
-#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:421
+#: A_New_Order/scenarios/14b_Bontom.cfg:659
+#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:422
 #: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:347
 #: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:458
 msgid "Why?"
@@ -6522,205 +6521,215 @@ msgid "Be careful! Our forest is almost gone!"
 msgstr ""
 
 #. [objective]: condition=win
-#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:6
-#: A_New_Order/scenarios/14b_Bontom.cfg:398
-#: A_New_Order/scenarios/14b_Bontom.cfg:414
-#: A_New_Order/scenarios/10_Siege_of_Haeltin.cfg:411
-msgid "HEROIC: Kill all enemy leaders OR"
+#. trailing space is intentional, to pad the footnote a bit:
+#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:7
+#: A_New_Order/scenarios/14b_Bontom.cfg:399
+#: A_New_Order/scenarios/14b_Bontom.cfg:415
+msgid "HEROIC: Kill all enemy leaders "
 msgstr ""
 
 #. [objective]: condition=win
-#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:10
+#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:7
+#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:583
+#: A_New_Order/scenarios/12_Leaving_Raedwood.cfg:209
+#: A_New_Order/scenarios/14b_Bontom.cfg:399
+#: A_New_Order/scenarios/14b_Bontom.cfg:415
+#: A_New_Order/scenarios/02_Fighting_for_Passage.cfg:340
+msgid " OR"
+msgstr ""
+
+#. [objective]: condition=win
+#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:11
 msgid "NORMAL: Interrogate Orcish leader with Ruvio or Gawen and withdraw to northern signpost"
 msgstr ""
 
 #. [scenario]: id=14a_Scouting_Near_Barnon
-#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:15
+#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:16
 msgid "Scouting Near Barnon"
 msgstr ""
 
 #. [part]
 #. spoken by Gawen
-#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:29
+#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:30
 msgid "Entering the forests surrounding Barnon from the north, I could not stop myself from thinking about the battle a few months ago, when I was betrayed and left for dead on the battlefield. But then, if not for that betrayal and that battle, I would probably never met Ruvio and Karen..."
 msgstr ""
 
 #. [side]: id=Kariv Rebarnon, type=Akladian Lord
 #. [scenario]: id=14a_Scouting_Near_Barnon
-#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:60
-#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:216
+#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:61
+#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:217
 msgid "Kariv Rebarnon"
 msgstr ""
 
 #. [side]: id=Baruk Bar, type=Orcish Warrior
 #. [scenario]: id=14a_Scouting_Near_Barnon
-#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:139
-#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:274
+#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:140
+#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:275
 msgid "Baruk Bar"
 msgstr ""
 
 #. [label]
-#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:172
+#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:173
 #: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:362
 msgid "Castle of Barnon"
 msgstr ""
 
 #. [label]
-#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:176
+#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:177
 #: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:366
 msgid "City of Barnon"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:221
+#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:222
 msgid "It seems like only yesterday when I was betrayed on these fields..."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:223
+#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:224
 msgid "My lord... I..."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:224
+#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:225
 msgid "Reme, don't blame yourself. I know you would have prefered to stay with me that day and fight to the end, but I gave you other orders, and your duty was to follow them. I know it wasn't easy for you."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:226
+#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:227
 msgid "On the other hand, leaving me was quite easy for him. It seems he just needed some practice."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:229
+#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:230
 msgid "Let's be careful. Scouts reported orcs garrisoned east from here. Now, we just have to capture their leader and..."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:230
+#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:231
 msgid "...and we will see our great future king Gaumhaldric defeat his enemies in an epic battle, which will be described by bards forevermore!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:231
+#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:232
 msgid "Anyway, what I wanted to say before my offspring so rudely interrupted me, is that we don't have to defeat all of the enemies. We can withdraw after interrogating the Orcish leader."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:232
+#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:233
 msgid "My lord, an army is approaching!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:233
+#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:234
 msgid "Oh, do not worry. Those are probably our people returning from making a deal with the outlaw underlings."
 msgstr ""
 
 #. [objectives]
-#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:238
+#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:239
 msgid ""
 "Lady Lorin can also interrogate enemy leaders.\n"
 "You will receive no bonus if withdrawing with Gawen."
 msgstr ""
 
 #. [objectives]
-#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:265
+#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:266
 msgid "You will receive no bonus if withdrawing with Gawen."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:284
+#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:285
 msgid "That's impossible! They are breaking into the city! How, how, how this could happened? Where are my soldiers? My allies? Help me!!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:285
+#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:286
 msgid "Humans... cowards... good only for meat..."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:294
-#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:310
+#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:295
+#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:311
 msgid "Dear God! Everything is lost! Run for your life!"
-msgstr ""
-
-#. [event]
-#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:300
-#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:316
-msgid "Hey, wait, what about our fight?! Coward!"
 msgstr ""
 
 #. [event]
 #: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:301
 #: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:317
+msgid "Hey, wait, what about our fight?! Coward!"
+msgstr ""
+
+#. [event]
+#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:302
+#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:318
 msgid "He ran away! But I will meet him again one day, and next time I will make sure he has no chance to flee..."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:331
+#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:332
 msgid "Wait a minute, I know you! You were one of those young chieftains who visited Vattin back in the day..."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:332
+#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:333
 msgid "Yes! Yes! That could be! I was at Vattin once!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:333
+#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:334
 msgid "God be praised!  I'm glad! I'm really, really glad to meet you again! What is your name, man?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:334
+#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:335
 msgid "Kariv, my lady, yes, Kariv."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:335
+#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:336
 msgid "Do you remember that bawdy ballad you were singing outside my windows while you were drunk?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:336
+#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:337
 msgid "That was you? Oh no!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:337
+#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:338
 msgid "I promised myself that I would take revenge one day. And indeed, God has favored me, because he has let me find you and kill you! Or... maybe you know something about the orcs - why they are here and all?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:338
-#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:359
-#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:380
+#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:339
+#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:360
+#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:381
 msgid "Orcs? Yes, yes, orcs! They are helping us! They are, uhm, our allies or something!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:339
-#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:365
+#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:340
+#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:366
 msgid "He doesn't know anything. Let him go."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:340
+#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:341
 msgid "Put down that knife!  You can't - Aaargh!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:341
+#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:342
 msgid "Mother!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:342
+#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:343
 msgid "What? You should have heard what he sang he wanted to do to me..."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:343
+#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:344
 msgid "But I had some questions of my own that I wanted to ask him..."
 msgstr ""
 
@@ -6728,150 +6737,150 @@ msgstr ""
 #. Konrad2 says "Understand?" should be "Understood?" but I think it is fine as is. Likewise with the question: "what do you know" applies
 #. to both halves of the sentence, i.e. "what do you know about the orcs?" and "what do you know about why they are here?" so there is
 #. no need to rewrite the second part of it into its own separate question as "why are they here?" in this line:
-#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:358
+#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:359
 msgid "Listen, if you'll answer me a few questions I'll let you go. Understand? Now, what do you know about the orcs and why they are here?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:361
+#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:362
 msgid "One last question. What about Reme Carrenemoe, do you know anything about his fate?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:362
-#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:384
+#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:363
+#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:385
 msgid "Yes! His clan settlements were attacked by outlaws. They captured him and they are keeping him in some place called Bontom. They will sell him to Bor Cryne, I think."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:379
+#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:380
 msgid "Listen, if you will answer my questions I will let you go. Understand? Now, what do you know about orcs and why they are here?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:381
+#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:382
 msgid "He knows nothing. Let him go."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:383
+#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:384
 msgid "Wait, one last question. What about Reme Carrenemoe, do you know anything about his fate?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:387
+#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:388
 msgid "Oh well..."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:409
+#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:410
 msgid "Wait! I wanted to interrogate him..."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:417
+#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:418
 msgid "Hey orc! Can you still hear me? Are you okay?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:418
+#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:419
 msgid "Mother earth, a human woman is trying to save me? Such care for a fallen enemy is so rarely found!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:419
+#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:420
 msgid "Trying to save you? Well, not exactly. I want to... wait, I must think of the correct term... terrorize you, yes, that's more what I have on my mind. Let's start with the basics. This is a knife. When a knife is put into human - or, in this case, orcish - flesh, it hurts."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:420
+#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:421
 msgid "Mother! Stop it! This is disgusting and I will not allow it!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:421
+#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:422
 msgid "Hmm... You know what, orc? Let's make a deal... If you will tell me why are you here, allied with Akladians, then I will let you die peacefully. If not, despite my son's cries I will demonstrate to you other fascinating aspects on the topic of what suffering can be induced by a simple knife in hands of an able woman."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:422
-msgid "No, I won't let you! Orc, tell us everything you know and I will let you live."
-msgstr ""
-
-#. [event]
 #: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:423
-#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:434
-#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:446
-#: A_New_Order/scenarios/14d_Avenging_Ruen.cfg:263
-#: A_New_Order/scenarios/14d_Avenging_Ruen.cfg:298
-#: A_New_Order/scenarios/14b_Bontom.cfg:703
-#: A_New_Order/scenarios/14b_Bontom.cfg:719
-msgid "I don't know much - only that this was the wish of our guide, Grekulak. He wished Akladians to be allied with us."
+msgid "No, I won't let you! Orc, tell us everything you know and I will let you live."
 msgstr ""
 
 #. [event]
 #: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:424
 #: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:435
 #: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:447
-#: A_New_Order/scenarios/14d_Avenging_Ruen.cfg:228
-#: A_New_Order/scenarios/14d_Avenging_Ruen.cfg:264
-#: A_New_Order/scenarios/14d_Avenging_Ruen.cfg:299
-#: A_New_Order/scenarios/14b_Bontom.cfg:683
-#: A_New_Order/scenarios/14b_Bontom.cfg:709
-#: A_New_Order/scenarios/14b_Bontom.cfg:725
-msgid "Grekulak! I know that name. We should go back to Freetown and report that, that's all we need to know!"
+#: A_New_Order/scenarios/14d_Avenging_Ruen.cfg:263
+#: A_New_Order/scenarios/14d_Avenging_Ruen.cfg:298
+#: A_New_Order/scenarios/14b_Bontom.cfg:706
+#: A_New_Order/scenarios/14b_Bontom.cfg:722
+msgid "I don't know much - only that this was the wish of our guide, Grekulak. He wished Akladians to be allied with us."
 msgstr ""
 
 #. [event]
 #: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:425
 #: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:436
 #: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:448
-#: A_New_Order/scenarios/14d_Avenging_Ruen.cfg:265
-#: A_New_Order/scenarios/14d_Avenging_Ruen.cfg:300
-#: A_New_Order/scenarios/14b_Bontom.cfg:684
-#: A_New_Order/scenarios/14b_Bontom.cfg:710
-#: A_New_Order/scenarios/14b_Bontom.cfg:726
-msgid "Grekulak? That's something to report. We should go back to Freetown then."
+#: A_New_Order/scenarios/14d_Avenging_Ruen.cfg:228
+#: A_New_Order/scenarios/14d_Avenging_Ruen.cfg:264
+#: A_New_Order/scenarios/14d_Avenging_Ruen.cfg:299
+#: A_New_Order/scenarios/14b_Bontom.cfg:686
+#: A_New_Order/scenarios/14b_Bontom.cfg:712
+#: A_New_Order/scenarios/14b_Bontom.cfg:728
+msgid "Grekulak! I know that name. We should go back to Freetown and report that, that's all we need to know!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:432
-#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:444
-msgid "Orc, do not die, yet! Can you still hear me? I will ask you a few questions, and if you will answer them, I will order someone to bind your wounds and I will let you live."
+#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:426
+#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:437
+#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:449
+#: A_New_Order/scenarios/14d_Avenging_Ruen.cfg:265
+#: A_New_Order/scenarios/14d_Avenging_Ruen.cfg:300
+#: A_New_Order/scenarios/14b_Bontom.cfg:687
+#: A_New_Order/scenarios/14b_Bontom.cfg:713
+#: A_New_Order/scenarios/14b_Bontom.cfg:729
+msgid "Grekulak? That's something to report. We should go back to Freetown then."
 msgstr ""
 
 #. [event]
 #: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:433
 #: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:445
+msgid "Orc, do not die, yet! Can you still hear me? I will ask you a few questions, and if you will answer them, I will order someone to bind your wounds and I will let you live."
+msgstr ""
+
+#. [event]
+#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:434
+#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:446
 msgid "Listen, that won't work! I am well-acquainted with the job of interrogating prisoners. What you're doing isn't even a decent amateur job... this is..."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:437
-#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:449
+#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:438
+#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:450
 msgid "Amazing. Simply, amazing."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:462
+#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:463
 #: A_New_Order/scenarios/14d_Avenging_Ruen.cfg:182
 #: A_New_Order/scenarios/21b_Haunted_Place.cfg:232
-#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:485
+#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:486
 msgid "My lord, are you sure you want to retreat?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:577
+#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:578
 msgid "Oh no! New reinforcements have arrived to help our enemies, now we cannot win!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:591
+#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:592
 msgid "Ha! The orcs were hiding some gold here!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:592
+#: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:593
 msgid "You have received $orc_gold_amt gold pieces."
 msgstr ""
 
@@ -7324,13 +7333,6 @@ msgstr ""
 #. trailing space is intentional, to pad the footnote a bit:
 #: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:583
 msgid "Move Gawen to south-eastern signpost "
-msgstr ""
-
-#. [objective]: condition=win
-#: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:583
-#: A_New_Order/scenarios/12_Leaving_Raedwood.cfg:209
-#: A_New_Order/scenarios/02_Fighting_for_Passage.cfg:340
-msgid " OR"
 msgstr ""
 
 #. [objective]: condition=win
@@ -8110,7 +8112,7 @@ msgstr ""
 #. [unit]: id=Reme Carrenemoe, type=Akladian Chieftain
 #: A_New_Order/scenarios/05_Unexpected_Guests.cfg:101
 #: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:155
-#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:142
+#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:143
 msgid "Reme Carrenemoe"
 msgstr ""
 
@@ -8122,7 +8124,7 @@ msgstr ""
 #: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:1326
 #: A_New_Order/scenarios/06_Separation.cfg:59
 #: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:138
-#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:32
+#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:33
 #: A_New_Order/scenarios/10_Siege_of_Haeltin.cfg:59
 #: A_New_Order/scenarios/09_Hired_Swords.cfg:118
 msgid "Lady Lorin"
@@ -9340,26 +9342,26 @@ msgstr ""
 #. [event]
 #: A_New_Order/scenarios/14d_Avenging_Ruen.cfg:260
 #: A_New_Order/scenarios/14d_Avenging_Ruen.cfg:295
-#: A_New_Order/scenarios/14b_Bontom.cfg:700
-#: A_New_Order/scenarios/14b_Bontom.cfg:716
+#: A_New_Order/scenarios/14b_Bontom.cfg:703
+#: A_New_Order/scenarios/14b_Bontom.cfg:719
 msgid "I will allow you to live, if you will tell me few things."
 msgstr ""
 
 #. [event]
 #: A_New_Order/scenarios/14d_Avenging_Ruen.cfg:261
 #: A_New_Order/scenarios/14d_Avenging_Ruen.cfg:296
-#: A_New_Order/scenarios/14b_Bontom.cfg:701
-#: A_New_Order/scenarios/14b_Bontom.cfg:717
+#: A_New_Order/scenarios/14b_Bontom.cfg:704
+#: A_New_Order/scenarios/14b_Bontom.cfg:720
 msgid "Ask then, human."
 msgstr ""
 
 #. [event]
 #: A_New_Order/scenarios/14d_Avenging_Ruen.cfg:262
 #: A_New_Order/scenarios/14d_Avenging_Ruen.cfg:297
-#: A_New_Order/scenarios/14b_Bontom.cfg:577
-#: A_New_Order/scenarios/14b_Bontom.cfg:627
-#: A_New_Order/scenarios/14b_Bontom.cfg:702
-#: A_New_Order/scenarios/14b_Bontom.cfg:718
+#: A_New_Order/scenarios/14b_Bontom.cfg:578
+#: A_New_Order/scenarios/14b_Bontom.cfg:630
+#: A_New_Order/scenarios/14b_Bontom.cfg:705
+#: A_New_Order/scenarios/14b_Bontom.cfg:721
 msgid "Why are you allied with Akladians?"
 msgstr ""
 
@@ -9410,7 +9412,7 @@ msgstr ""
 
 #. [event]
 #: A_New_Order/scenarios/14d_Avenging_Ruen.cfg:485
-#: A_New_Order/scenarios/14b_Bontom.cfg:902
+#: A_New_Order/scenarios/14b_Bontom.cfg:905
 msgid "Oh no! New reinforcements have arrived to help our enemies, now we have no chances to defeat them!"
 msgstr ""
 
@@ -10947,8 +10949,8 @@ msgstr ""
 
 #. [objectives]
 #: A_New_Order/scenarios/21b_Haunted_Place.cfg:207
-#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:246
-#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:258
+#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:247
+#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:259
 msgid "You may withdraw by moving Gawen to signpost."
 msgstr ""
 
@@ -11113,7 +11115,7 @@ msgstr ""
 #. [object]: id=healing_skill
 #: A_New_Order/scenarios/19c_The_Oracle.cfg:86
 #: A_New_Order/scenarios/14b_Bontom.cfg:25
-#: A_New_Order/scenarios/14b_Bontom.cfg:995
+#: A_New_Order/scenarios/14b_Bontom.cfg:1027
 msgid "Healing skill"
 msgstr ""
 
@@ -12348,8 +12350,8 @@ msgstr ""
 #. [then]
 #. [event]
 #: A_New_Order/scenarios/14c_She_Wolf_of_Haeltin.cfg:194
-#: A_New_Order/scenarios/14b_Bontom.cfg:575
-#: A_New_Order/scenarios/14b_Bontom.cfg:625
+#: A_New_Order/scenarios/14b_Bontom.cfg:576
+#: A_New_Order/scenarios/14b_Bontom.cfg:628
 msgid "I have no idea."
 msgstr ""
 
@@ -13446,19 +13448,19 @@ msgstr ""
 
 #. [object]: id=healing_skill
 #: A_New_Order/scenarios/14b_Bontom.cfg:27
-#: A_New_Order/scenarios/14b_Bontom.cfg:997
+#: A_New_Order/scenarios/14b_Bontom.cfg:1029
 msgid "This unit has learned basic healing skills: it can cure poison and up to 2 HP of wounded friendly units."
 msgstr ""
 
 #. [heals]: id=basic_healing
 #: A_New_Order/scenarios/14b_Bontom.cfg:39
-#: A_New_Order/scenarios/14b_Bontom.cfg:1009
+#: A_New_Order/scenarios/14b_Bontom.cfg:1041
 msgid "basic healing"
 msgstr ""
 
 #. [heals]: id=basic_healing
 #: A_New_Order/scenarios/14b_Bontom.cfg:40
-#: A_New_Order/scenarios/14b_Bontom.cfg:1010
+#: A_New_Order/scenarios/14b_Bontom.cfg:1042
 msgid "heals +2, cures poison"
 msgstr ""
 
@@ -13494,8 +13496,8 @@ msgstr ""
 
 #. [unit]: id=Old Woman, type=Old Peasant Woman
 #: A_New_Order/scenarios/14b_Bontom.cfg:63
-#: A_New_Order/scenarios/14b_Bontom.cfg:931
-#: A_New_Order/scenarios/14b_Bontom.cfg:970
+#: A_New_Order/scenarios/14b_Bontom.cfg:963
+#: A_New_Order/scenarios/14b_Bontom.cfg:1002
 msgid "Old woman"
 msgstr ""
 
@@ -13569,14 +13571,14 @@ msgstr ""
 #. [side]: id=Hans the Ripper, type=Fugitive
 #. [event]
 #: A_New_Order/scenarios/14b_Bontom.cfg:156
-#: A_New_Order/scenarios/14b_Bontom.cfg:596
-#: A_New_Order/scenarios/14b_Bontom.cfg:598
-#: A_New_Order/scenarios/14b_Bontom.cfg:623
-#: A_New_Order/scenarios/14b_Bontom.cfg:625
+#: A_New_Order/scenarios/14b_Bontom.cfg:599
+#: A_New_Order/scenarios/14b_Bontom.cfg:601
+#: A_New_Order/scenarios/14b_Bontom.cfg:626
 #: A_New_Order/scenarios/14b_Bontom.cfg:628
 #: A_New_Order/scenarios/14b_Bontom.cfg:631
 #: A_New_Order/scenarios/14b_Bontom.cfg:634
 #: A_New_Order/scenarios/14b_Bontom.cfg:637
+#: A_New_Order/scenarios/14b_Bontom.cfg:640
 msgid "Hans the Ripper"
 msgstr ""
 
@@ -13680,402 +13682,419 @@ msgstr ""
 
 #. [event]
 #: A_New_Order/scenarios/14b_Bontom.cfg:378
-#: A_New_Order/scenarios/14b_Bontom.cfg:488
+#: A_New_Order/scenarios/14b_Bontom.cfg:489
 msgid "Free! Free, at last!"
 msgstr ""
 
 #. [event]
 #: A_New_Order/scenarios/14b_Bontom.cfg:379
-#: A_New_Order/scenarios/14b_Bontom.cfg:489
+#: A_New_Order/scenarios/14b_Bontom.cfg:490
 msgid "My lord, the outlaw army decimated my clan. But still, some of my people survived, and they will be glad to help you."
 msgstr ""
 
 #. [event]
 #: A_New_Order/scenarios/14b_Bontom.cfg:380
-#: A_New_Order/scenarios/14b_Bontom.cfg:490
+#: A_New_Order/scenarios/14b_Bontom.cfg:491
 msgid "You may recruit Akladian Clansmen again."
 msgstr ""
 
 #. [objective]: condition=win
-#: A_New_Order/scenarios/14b_Bontom.cfg:402
-#: A_New_Order/scenarios/14b_Bontom.cfg:418
+#: A_New_Order/scenarios/14b_Bontom.cfg:403
+#: A_New_Order/scenarios/14b_Bontom.cfg:419
 msgid "NORMAL: Rescue Reme Carrenemoe and move him to the north-eastern signpost"
 msgstr ""
 
 #. [objectives]
-#: A_New_Order/scenarios/14b_Bontom.cfg:405
-msgid "You may interrogate the Orcish leader with either Gawen, Ruvio, or Lorin. Other leaders may be interrogated by Gawen only."
+#: A_New_Order/scenarios/14b_Bontom.cfg:406
+msgid "You may interrogate the Orcish leader with either Gawen, Ruvio, or Lorin. Other leaders may be interrogated by Gawen only. The Outlaw leader interrogations are largely identical."
 msgstr ""
 
 #. [objectives]
-#: A_New_Order/scenarios/14b_Bontom.cfg:422
-msgid "You may interrogate the Orcish leader with either Gawen or Ruvio. Other leaders may be interrogated by Gawen only."
+#: A_New_Order/scenarios/14b_Bontom.cfg:423
+msgid "You may interrogate the Orcish leader with either Gawen or Ruvio. Other leaders may be interrogated by Gawen only. The Outlaw leader interrogations are largely identical."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14b_Bontom.cfg:467
+#: A_New_Order/scenarios/14b_Bontom.cfg:468
 msgid "To win, you should move Reme Carrenemore here!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14b_Bontom.cfg:470
+#: A_New_Order/scenarios/14b_Bontom.cfg:471
 msgid "My lord, are you sure you want to retreat? We should move Reme Carrenemoe here first!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14b_Bontom.cfg:475
+#: A_New_Order/scenarios/14b_Bontom.cfg:476
 msgid "I'm sorry Reme, but we simply couldn't succeed."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14b_Bontom.cfg:476
+#: A_New_Order/scenarios/14b_Bontom.cfg:477
 msgid "Good. Reme left me, we left him, so balance in the universe is preserved."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14b_Bontom.cfg:508
+#: A_New_Order/scenarios/14b_Bontom.cfg:509
 msgid "So, Reme. We meet again. Hm... I would say something to the effect of 'I'm happy to see you again', but to be honest, I am not."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14b_Bontom.cfg:510
+#: A_New_Order/scenarios/14b_Bontom.cfg:511
 msgid "Lorin... and... Gawen? Is that really you?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14b_Bontom.cfg:516
+#: A_New_Order/scenarios/14b_Bontom.cfg:517
 msgid "Reme, are you ok?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14b_Bontom.cfg:518
-#: A_New_Order/scenarios/14b_Bontom.cfg:538
+#: A_New_Order/scenarios/14b_Bontom.cfg:519
+#: A_New_Order/scenarios/14b_Bontom.cfg:539
 msgid "Yes... yes... Gawen? Is that really you?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14b_Bontom.cfg:535
+#: A_New_Order/scenarios/14b_Bontom.cfg:536
 msgid "They are keeping some Akladian in cage in here. Should I kill him?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14b_Bontom.cfg:536
+#: A_New_Order/scenarios/14b_Bontom.cfg:537
 msgid "No! This is my friend, Reme! Reme, are you ok?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14b_Bontom.cfg:546
-#: A_New_Order/scenarios/14b_Bontom.cfg:596
-msgid "Such a young man... And yet, one darn good fighter.."
-msgstr ""
-
-#. [event]
 #: A_New_Order/scenarios/14b_Bontom.cfg:547
-#: A_New_Order/scenarios/14b_Bontom.cfg:597
-msgid "You were worthy opponent too."
+#: A_New_Order/scenarios/14b_Bontom.cfg:599
+msgid "Such a young man... And yet, one darn good fighter..."
 msgstr ""
 
 #. [event]
 #: A_New_Order/scenarios/14b_Bontom.cfg:548
-#: A_New_Order/scenarios/14b_Bontom.cfg:598
-msgid "Yes... it was a good fight, wasn't it?"
+#: A_New_Order/scenarios/14b_Bontom.cfg:600
+msgid "You were a worthy opponent, too."
 msgstr ""
 
 #. [event]
 #: A_New_Order/scenarios/14b_Bontom.cfg:549
-#: A_New_Order/scenarios/14b_Bontom.cfg:599
+#: A_New_Order/scenarios/14b_Bontom.cfg:601
+msgid "Yes... it was a good fight, wasn't it?"
+msgstr ""
+
+#. [event]
+#: A_New_Order/scenarios/14b_Bontom.cfg:550
+#: A_New_Order/scenarios/14b_Bontom.cfg:602
 msgid "Yes... Before you pass on, please answer me few questions."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14b_Bontom.cfg:554
-#: A_New_Order/scenarios/14b_Bontom.cfg:562
-#: A_New_Order/scenarios/14b_Bontom.cfg:604
-#: A_New_Order/scenarios/14b_Bontom.cfg:612
+#: A_New_Order/scenarios/14b_Bontom.cfg:555
+#: A_New_Order/scenarios/14b_Bontom.cfg:563
+#: A_New_Order/scenarios/14b_Bontom.cfg:607
+#: A_New_Order/scenarios/14b_Bontom.cfg:615
 msgid "Why are orcs here, allied with Akladians?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14b_Bontom.cfg:555
-#: A_New_Order/scenarios/14b_Bontom.cfg:605
-msgid "Who hired the assassin that was trying to kill Gawen Hagarthen?"
-msgstr ""
-
-#. [event]
 #: A_New_Order/scenarios/14b_Bontom.cfg:556
-#: A_New_Order/scenarios/14b_Bontom.cfg:563
-#: A_New_Order/scenarios/14b_Bontom.cfg:606
-#: A_New_Order/scenarios/14b_Bontom.cfg:613
-msgid "Why do you fight alongside Akladians?"
+#: A_New_Order/scenarios/14b_Bontom.cfg:608
+msgid "Who hired the assassin that was trying to kill Gawen Hagarthen?"
 msgstr ""
 
 #. [event]
 #: A_New_Order/scenarios/14b_Bontom.cfg:557
 #: A_New_Order/scenarios/14b_Bontom.cfg:564
-#: A_New_Order/scenarios/14b_Bontom.cfg:607
-#: A_New_Order/scenarios/14b_Bontom.cfg:614
+#: A_New_Order/scenarios/14b_Bontom.cfg:609
+#: A_New_Order/scenarios/14b_Bontom.cfg:616
+msgid "Why do you fight alongside Akladians?"
+msgstr ""
+
+#. [event]
+#: A_New_Order/scenarios/14b_Bontom.cfg:558
+#: A_New_Order/scenarios/14b_Bontom.cfg:565
+#: A_New_Order/scenarios/14b_Bontom.cfg:610
+#: A_New_Order/scenarios/14b_Bontom.cfg:617
 msgid "Do you know who poisoned Gawen Hagarthen's mother?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14b_Bontom.cfg:572
-#: A_New_Order/scenarios/14b_Bontom.cfg:622
+#: A_New_Order/scenarios/14b_Bontom.cfg:573
+#: A_New_Order/scenarios/14b_Bontom.cfg:625
 msgid "Do you know why orcs are here?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14b_Bontom.cfg:573
+#: A_New_Order/scenarios/14b_Bontom.cfg:574
 msgid "They are allied with Akladians."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14b_Bontom.cfg:574
-#: A_New_Order/scenarios/14b_Bontom.cfg:624
-#: A_New_Order/scenarios/14b_Bontom.cfg:654
+#: A_New_Order/scenarios/14b_Bontom.cfg:575
+#: A_New_Order/scenarios/14b_Bontom.cfg:627
+#: A_New_Order/scenarios/14b_Bontom.cfg:657
 msgid "But why?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14b_Bontom.cfg:578
-#: A_New_Order/scenarios/14b_Bontom.cfg:628
+#: A_New_Order/scenarios/14b_Bontom.cfg:579
+#: A_New_Order/scenarios/14b_Bontom.cfg:631
 msgid "Allied? We are allied with none. They have simply paid for our services. That's all."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14b_Bontom.cfg:580
-#: A_New_Order/scenarios/14b_Bontom.cfg:630
+#. "whence" is a contraction for "from where"; it has nothing to do with the word "when":
+#: A_New_Order/scenarios/14b_Bontom.cfg:582
+#: A_New_Order/scenarios/14b_Bontom.cfg:633
 msgid "You are from the Outlaw Base, right? The place whence assassins come... maybe you know who poisoned the mother of Gawen Hagarthen?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14b_Bontom.cfg:581
+#: A_New_Order/scenarios/14b_Bontom.cfg:583
 msgid "I don't know that."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14b_Bontom.cfg:583
-#: A_New_Order/scenarios/14b_Bontom.cfg:633
+#: A_New_Order/scenarios/14b_Bontom.cfg:585
+#: A_New_Order/scenarios/14b_Bontom.cfg:636
 msgid "Someone hired an assassin to kill Gawen Hagarthen, immediately after his father's death. I know he came from the Outlaw Base. Who hired him?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14b_Bontom.cfg:584
-#: A_New_Order/scenarios/14b_Bontom.cfg:634
-msgid "I think it was one of Akladian lords... yes... his name was Cryne, Bor Cryne..."
+#. lowercase "l" in "lords" because we're talking about the rank generically, not the name of the unit type:
+#: A_New_Order/scenarios/14b_Bontom.cfg:587
+#: A_New_Order/scenarios/14b_Bontom.cfg:637
+msgid "I think it was one of the Akladian lords... yes... his name was Cryne, Bor Cryne..."
 msgstr ""
 
 #. [event]
 #. probably unreachable, but just here to ensure all our bases our covered:
-#: A_New_Order/scenarios/14b_Bontom.cfg:589
+#: A_New_Order/scenarios/14b_Bontom.cfg:592
 msgid "I didn't quite catch that, but, oh well..."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14b_Bontom.cfg:623
+#: A_New_Order/scenarios/14b_Bontom.cfg:626
 msgid "They are allied with the Akladians."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14b_Bontom.cfg:631
+#: A_New_Order/scenarios/14b_Bontom.cfg:634
 msgid "I don't know that. A lot of Akladians buy poison from us."
 msgstr ""
 
 #. [event]
 #. probably unreachable, but just here to ensure all our bases our covered:
-#: A_New_Order/scenarios/14b_Bontom.cfg:639
+#: A_New_Order/scenarios/14b_Bontom.cfg:642
 msgid "Uh... what was that?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14b_Bontom.cfg:647
+#: A_New_Order/scenarios/14b_Bontom.cfg:650
 msgid "It's you! Witch!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14b_Bontom.cfg:648
+#: A_New_Order/scenarios/14b_Bontom.cfg:651
 msgid "Really? Are you sure it's really me?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14b_Bontom.cfg:649
+#: A_New_Order/scenarios/14b_Bontom.cfg:652
 msgid "Uhm... what?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14b_Bontom.cfg:650
+#: A_New_Order/scenarios/14b_Bontom.cfg:653
 msgid "I mean, you are dying. Your whole life probably is passing before your eyes. Maybe you are hallucinating? There is only one way to find out."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14b_Bontom.cfg:651
+#: A_New_Order/scenarios/14b_Bontom.cfg:654
 msgid "What... What way?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14b_Bontom.cfg:652
+#: A_New_Order/scenarios/14b_Bontom.cfg:655
 msgid "If I am just a  hallucination, this won't hurt."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14b_Bontom.cfg:653
+#: A_New_Order/scenarios/14b_Bontom.cfg:656
 msgid "No! Mother, I won't let you! Leave him to die peacefully!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14b_Bontom.cfg:655
+#: A_New_Order/scenarios/14b_Bontom.cfg:658
 msgid "Because it is a bad thing to torture people."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14b_Bontom.cfg:657
+#: A_New_Order/scenarios/14b_Bontom.cfg:660
 msgid "Because... uh..."
 msgstr ""
 
 #. [event]
 #. "teach an old dog new tricks" is a common idiom in English; feel free to word your translation with a similar
 #. idiom from your own language, as long as it allows Lorin to react to the "old" part in her response:
-#: A_New_Order/scenarios/14b_Bontom.cfg:660
+#: A_New_Order/scenarios/14b_Bontom.cfg:663
 msgid "Gawen, she is Akladian. You can't teach an old dog new tricks."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14b_Bontom.cfg:661
+#: A_New_Order/scenarios/14b_Bontom.cfg:664
 msgid "Who are you calling OLD?!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14b_Bontom.cfg:666
+#: A_New_Order/scenarios/14b_Bontom.cfg:669
 msgid "You were a good opponent. What is your name? Please tell me, so I can tell the spirits of my ancestors who defeated me!"
 msgstr ""
 
 #. [event]
 #. Gawen was about to give him his fake "Gaumhaldric" name before changing his mind and deciding to use his real one:
-#: A_New_Order/scenarios/14b_Bontom.cfg:668
+#: A_New_Order/scenarios/14b_Bontom.cfg:671
 msgid "Gau... Gawen. Gawen Hagarthen."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14b_Bontom.cfg:669
+#: A_New_Order/scenarios/14b_Bontom.cfg:672
 msgid "My king! Now I know why I was defeated. This is my punishment for betrayal. I should never have listened to the orders of our clan leaders. My king, will you forgive me?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14b_Bontom.cfg:670
+#: A_New_Order/scenarios/14b_Bontom.cfg:673
 msgid "Lie in peace, soldier."
 msgstr ""
 
 #. [event]
 #. this is the "Litany Against Fear" from the "Dune" franchise -- translators, please find how this quote was translated into your language before trying translating it by yourself.
-#: A_New_Order/scenarios/14b_Bontom.cfg:677
+#: A_New_Order/scenarios/14b_Bontom.cfg:680
 msgid "I must not fear. Fear is the mind-killer. Fear is the little-death that brings total obliteration. I will face my fear. I will permit it to pass over me and through me. And when it has gone past I will turn the inner eye to see its path. Where the fear has gone there will be nothing. Only I will remain."
 msgstr ""
 
 #. [event]
 #. this is a play on what the orc just said; try to use similar wording when translating:
-#: A_New_Order/scenarios/14b_Bontom.cfg:679
+#: A_New_Order/scenarios/14b_Bontom.cfg:682
 msgid "Oh that was cute. Now, if you are quite finished, I have here this little knife-thing. This knife is what brings total obliteration, not to mention suffering."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14b_Bontom.cfg:680
+#: A_New_Order/scenarios/14b_Bontom.cfg:683
 msgid "I must not... ARGH!... I must not..."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14b_Bontom.cfg:681
+#: A_New_Order/scenarios/14b_Bontom.cfg:684
 msgid "Why are you here, allied with traitors from the Akladian race?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14b_Bontom.cfg:682
+#: A_New_Order/scenarios/14b_Bontom.cfg:685
 msgid "I know nothing! I know nothing! Our guide Grekulak ordered us to ally with Akladians, I know nothing more!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14b_Bontom.cfg:685
+#: A_New_Order/scenarios/14b_Bontom.cfg:688
 msgid "Mother, you may let him go now."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14b_Bontom.cfg:686
+#: A_New_Order/scenarios/14b_Bontom.cfg:689
 msgid "Argh!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14b_Bontom.cfg:692
+#: A_New_Order/scenarios/14b_Bontom.cfg:695
 msgid "Excuse me, my son, this orc screamed so loud in agony that I couldn't hear what you were saying. What was that?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14b_Bontom.cfg:693
+#: A_New_Order/scenarios/14b_Bontom.cfg:696
 msgid "Never mind. My step-mother is obsessed with death and pain. Sigh."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14b_Bontom.cfg:694
+#: A_New_Order/scenarios/14b_Bontom.cfg:697
 msgid "And she looks beautiful in armour, too."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14b_Bontom.cfg:738
+#: A_New_Order/scenarios/14b_Bontom.cfg:741
 msgid "Ha! The outlaws were hiding some gold here!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14b_Bontom.cfg:739
+#: A_New_Order/scenarios/14b_Bontom.cfg:742
 msgid "You have received $outlaw_gold_amt gold pieces."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14b_Bontom.cfg:755
+#: A_New_Order/scenarios/14b_Bontom.cfg:758
 msgid "Ha! The Akladians were hiding some gold here!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14b_Bontom.cfg:756
+#: A_New_Order/scenarios/14b_Bontom.cfg:759
 msgid "You have received $akl_gold_amt gold pieces."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14b_Bontom.cfg:761
+#: A_New_Order/scenarios/14b_Bontom.cfg:764
 msgid "I guess this was gold prepared to pay for Reme Carrenemoe."
 msgstr ""
 
+#. [then]
+#: A_New_Order/scenarios/14b_Bontom.cfg:928
+msgid "I am saved!"
+msgstr ""
+
+#. [else]
+#: A_New_Order/scenarios/14b_Bontom.cfg:932
+msgid "It's a hollow victory, defeating Reme's captors without him among our ranks..."
+msgstr ""
+
 #. [event]
-#: A_New_Order/scenarios/14b_Bontom.cfg:913
+#: A_New_Order/scenarios/14b_Bontom.cfg:942
 msgid "The outlaws are defeated!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14b_Bontom.cfg:939
+#: A_New_Order/scenarios/14b_Bontom.cfg:944
+msgid "We saved Reme, but do not have him here with us for our victory? What happened?"
+msgstr ""
+
+#. [event]
+#: A_New_Order/scenarios/14b_Bontom.cfg:971
 msgid "Akladian? Go away. Since the death of my old man I do not talk to Akladians."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14b_Bontom.cfg:944
-#: A_New_Order/scenarios/14b_Bontom.cfg:979
+#: A_New_Order/scenarios/14b_Bontom.cfg:976
+#: A_New_Order/scenarios/14b_Bontom.cfg:1011
 msgid "What do you want? I have already taught one of your people how to cure. That should be enough."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14b_Bontom.cfg:946
+#: A_New_Order/scenarios/14b_Bontom.cfg:978
 msgid "What do you want? I have already told you I speak to no Akladians since my husband, poor old soul, have died."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14b_Bontom.cfg:981
+#: A_New_Order/scenarios/14b_Bontom.cfg:1013
 msgid "Ooo, who's there? The avengers from Freetown on a mission, huh?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14b_Bontom.cfg:983
-#: A_New_Order/scenarios/14b_Bontom.cfg:986
-#: A_New_Order/scenarios/14b_Bontom.cfg:988
+#: A_New_Order/scenarios/14b_Bontom.cfg:1015
+#: A_New_Order/scenarios/14b_Bontom.cfg:1018
+#: A_New_Order/scenarios/14b_Bontom.cfg:1020
 msgid "Yes, old woman, we are from Freetown. You can go back to your village, you are safe now."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14b_Bontom.cfg:990
+#: A_New_Order/scenarios/14b_Bontom.cfg:1022
 msgid "Ha, ha, ha. Indeed I am, since it seems to me you are taking care of orcs and Akladians. You know what, young fellow: in exchange for what you did for this poor village, I will teach you few tricks about herbs."
 msgstr ""
 
@@ -14525,288 +14544,295 @@ msgstr ""
 msgid "Ruvio complained that nothing good could be found in the Saorduc Swamps, but that didn't stop Gawen. He reasoned that in the winter the swamps would be frozen and the lizards would be much easier to defeat."
 msgstr ""
 
-#. [event]
-#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:273
-msgid "...bitterly I fought, yessss, and I was heavily wounded. A woman wassss amongsst thossse humansss, a crazy one."
+#. [objective]: condition=win
+#. trailing space is intentional, to pad the footnote a bit:
+#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:244
+#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:256
+msgid "Kill all enemy leaders. "
 msgstr ""
 
 #. [event]
 #: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:274
+msgid "...bitterly I fought, yessss, and I was heavily wounded. A woman wassss amongsst thossse humansss, a crazy one."
+msgstr ""
+
+#. [event]
+#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:275
 msgid "Be calm, you are amongsst friendss, no humanss here..."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:276
+#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:277
 msgid "Lizards!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:277
+#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:278
 msgid "Oh no!!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:278
+#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:279
 msgid "Prepare to be exterminated!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:279
+#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:280
 msgid "Oh, that was cute. Where did she learn to talk like that?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:281
+#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:282
 msgid "Oh, I hate lizards."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:282
+#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:283
 msgid "They will be good practice for our soldiers. And maybe they know something."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:285
+#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:286
 msgid "So, what now?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:286
+#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:287
 msgid "Well, the plan is simple: ask their leaders about orcs, kill them all."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:287
+#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:288
 msgid "Wow, it couldn't get any simpler. Gawen, you are military genius. The simplicity of your brilliant plan is breathtaking."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:289
+#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:290
 msgid "Much of the swamp is frozen over; that increases our chances considerably."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:290
+#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:291
 msgid "We can withdraw at any moment, remember that."
 msgstr ""
 
 #. [event]
 #. EASY difficulty; reference to event that only exists at this difficulty:
-#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:293
+#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:294
 msgid "I doubt we'll need to do so; since lizards are cold-blooded, they should be weaker this time of year."
 msgstr ""
 
 #. [event]
 #. EASY difficulty:
-#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:295
+#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:296
 msgid "All right, Gawen, if you're sure about this, let's go ahead... I was only reminding you of the option to withdraw just in case..."
 msgstr ""
 
 #. [then]
 #. EASY difficulty:
-#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:359
+#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:360
 msgid "See! The lizards have become sluggish from the cold!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:379
+#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:380
 msgid "Lizard thing... Uh... So... What do you know about orcs?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:380
+#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:381
 msgid "Orcsss? They are big and bad and they are going around sssslaughtering humansss, which isss a good thing."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:381
+#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:382
 msgid "Ugh, you smell awful... do you not wash yourself on purpose, to scare away enemies? I can't think of any more questions in such a stench... so die, lizard thing..."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:388
+#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:389
 msgid "You could simply have chosen not to kill him and allow us to ask him few questions instead; did such a revolutionary idea enter your mind?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:389
+#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:390
 msgid "I think the ideas are too affraid of Lorin's mind to enter it."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:395
+#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:396
 msgid "Lizard, do you like your tail? If so, tell me everything you know about why orcs are in Vakladia, and do it fast."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:396
+#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:397
 msgid "Orcss creaturesss? They were invited here, by ssssome Akladian lordsss, that's all I know!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:397
+#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:398
 msgid "Think faster about something more, if you want to go to your lizard heaven in one piece!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:398
+#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:399
 msgid "Lizard heaven? We do not have sssuch thing."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:399
+#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:400
 msgid "Of course you don't, I know you are going straight to hell; that was a metaphor."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:400
+#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:401
 msgid "No, no, I mean that our philosssophical sysstem doesn't employ such vague ideas as 'heaven' or 'hell'. Our thinking about the world, sssomething you call religion, isss much more ssssophissssticated. For example..."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:406
+#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:407
 msgid "Off with your head! Surely he looks much less sophisticated without his head, doesn't he?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:407
+#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:408
 msgid "Ah, I like tough girls. Tell me, Lorin, do you sleep with your sword, too?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:413
+#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:414
 msgid "Do we know each other?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:414
+#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:415
 msgid "We met before, lady thing... I wass wounded but I sssurvived. It wasss a hope I had I wouldn't see your feissssse again..."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:415
+#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:416
 msgid "My what? Anyway, whatever, you will tell me everything you know about orcs."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:417
+#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:418
 msgid "You will tell me everything you know about orcs."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:420
+#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:421
 msgid "And I thought this day sssstarted ssssuch beautifully... What orcs? They have two legssss, two handsss, what'sss more do you want to know? Being Akladian you ssshould know them better..."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:422
+#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:423
 msgid "Aren't you allied now? Which issss quite natural for you, isssn't it?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:423
+#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:424
 msgid "We? No, not really. I guess you don't know nothing really important. Go to your ancestors, lizard!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:424
+#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:425
 msgid "Thank you! Ssso you will sssave my life?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:425
+#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:426
 msgid "Uh, what?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:426
+#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:427
 msgid "You are allowing me to leave, so I could go to my ancestors... some of them live quite near thisss place..."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:427
+#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:428
 msgid "I think you are confused... But all of a sudden I have lost my natural urge to cut your head off. Maybe I am confused, but go away now before I change my mind."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:432
+#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:433
 msgid "You will allow me to live! And you will be sspared!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:433
+#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:434
 msgid "Uh, what? I think your command of human language is quite limited. How on earth do you think you will sssspare me?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:435
+#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:436
 msgid "Maybe he was thinking about about some other word. Uhmmm, for example..."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:436
+#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:437
 msgid "Majid, do you really want to explore the depths of my patience?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:437
+#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:438
 msgid "Majid! So you are familiar enough with me now to remember my first name!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:439
+#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:440
 msgid "Iff you will kill me, other lizardss will find you and sssslain you and..."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:440
+#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:441
 msgid "Then again, again, maybe he was thinking about another word, for example..."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:441
+#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:442
 msgid "Aaaaaargh!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:447
+#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:448
 msgid "I hate empty threats."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:455
+#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:456
 msgid "Ha! We're off to an easy start! See, I told you that lizards are much less dangerous in the winter. This will be a nice occasion to train our troops."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:490
+#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:491
 msgid "Fighting with lizards here is waste of time. Retreat!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:510
+#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:511
 msgid "Ha! The lizards were hiding some gold here!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:511
+#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:512
 msgid "You have received $gold_amt_s14e gold pieces."
 msgstr ""
 
 #. [event]
 #. EASY difficulty:
-#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:533
+#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:534
 msgid "There appears to be a path through the snow here!"
 msgstr ""
 
 #. [event]
 #. NORMAL difficulty; condition to trigger is a bit harder than the one from EASY:
-#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:552
+#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:553
 msgid "My fight with that lizard revealed a path through the snow here!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:708
+#: A_New_Order/scenarios/14e_Saorduc_Swamps.cfg:709
 msgid "Oh no! New reinforcements have arrived to help our enemies, now we have no chance to defeat them!"
 msgstr ""
 
@@ -16693,7 +16719,7 @@ msgstr ""
 
 #. [part]
 #: A_New_Order/scenarios/21c_Ruins_of_the_Past.cfg:27
-msgid "After Mal-Ravanal's defeat, Grekulak was trapped in the swamps, spending his days roving in the morass and quagmire. Finally he came up with an idea. The undead had been storming the world of Wesnoth for millenia. They never succeeded, and often a very small group of brave living creatures - be they elves, humans or dwarves - were able to defeat large hordes of undead. "
+msgid "After Mal-Ravanal's defeat, Grekulak was trapped in the swamps, spending his days roving in the morass and quagmire. Finally he came up with an idea. The undead had been storming the world of Wesnoth for millennia. They never succeeded, and often a very small group of brave living creatures - be they elves, humans or dwarves - were able to defeat large hordes of undead. "
 msgstr ""
 
 #. [part]
@@ -16973,143 +16999,143 @@ msgid "The Swamp Things"
 msgstr ""
 
 #. [part]
-#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:17
+#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:18
 msgid "The party entered the swamps and woods of Saoren Duc with heavy hearts."
 msgstr ""
 
 #. [side]: type=Saurian Ambusher, id=Ssumar
 #. [scenario]: id=05_The_Swamp_Things
-#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:83
-#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:261
+#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:84
+#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:262
 msgid "Ssumar"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:268
+#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:269
 msgid "I have the strangest feeling, as though someone was watching us from the bushes..."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:269
+#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:270
 msgid "Humanssss! Leave thessse foressts!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:270
+#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:271
 msgid "We can't! Our enemies are hot on our heels. We only wish to cross your swamp and then you will hear no more from us."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:271
+#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:272
 msgid "Ssswampss you leave now! Hear about you no more!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:272
+#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:273
 msgid "Reme, leave negotiations to me, I am far more experienced. Lizards! You are about to be exterminated! Prepare to meet your destiny!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:273
+#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:274
 msgid "(<i>To himself</i>) No wonder no one really liked her..."
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:288
+#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:289
 msgid "I am not sure whether we have enough gold for this endeavor. I wish we'd gotten more in previous battles, at least 200."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:316
-#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:358
+#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:317
+#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:359
 msgid "Wait! Ssspare my life, for I know sssomething..."
-msgstr ""
-
-#. [then]
-#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:323
-#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:365
-msgid "Interesting. Speak, and maybe I will spare your worthless head, inhuman ungodly beast."
 msgstr ""
 
 #. [then]
 #: A_New_Order/scenarios/05_The_Swamp_Things.cfg:324
 #: A_New_Order/scenarios/05_The_Swamp_Things.cfg:366
-msgid "The orcss are coming in great numbersss... They are numerousss, they are hiding in the hillss waiting for the right moment to come..."
+msgid "Interesting. Speak, and maybe I will spare your worthless head, inhuman ungodly beast."
 msgstr ""
 
 #. [then]
 #: A_New_Order/scenarios/05_The_Swamp_Things.cfg:325
 #: A_New_Order/scenarios/05_The_Swamp_Things.cfg:367
-msgid "What moment?"
+msgid "The orcss are coming in great numbersss... They are numerousss, they are hiding in the hillss waiting for the right moment to come..."
 msgstr ""
 
 #. [then]
 #: A_New_Order/scenarios/05_The_Swamp_Things.cfg:326
 #: A_New_Order/scenarios/05_The_Swamp_Things.cfg:368
-msgid "What moment I do not know, but I know that they are expecting a human envoy."
+msgid "What moment?"
 msgstr ""
 
 #. [then]
 #: A_New_Order/scenarios/05_The_Swamp_Things.cfg:327
 #: A_New_Order/scenarios/05_The_Swamp_Things.cfg:369
-msgid "Human envoy? That's impossible."
+msgid "What moment I do not know, but I know that they are expecting a human envoy."
 msgstr ""
 
 #. [then]
 #: A_New_Order/scenarios/05_The_Swamp_Things.cfg:328
 #: A_New_Order/scenarios/05_The_Swamp_Things.cfg:370
-msgid "If it isss impossssible, then they will wait a long time... will you let me live now?"
+msgid "Human envoy? That's impossible."
 msgstr ""
 
 #. [then]
 #: A_New_Order/scenarios/05_The_Swamp_Things.cfg:329
 #: A_New_Order/scenarios/05_The_Swamp_Things.cfg:371
-msgid "Hide in your quagmire, lizard thing."
+msgid "If it isss impossssible, then they will wait a long time... will you let me live now?"
 msgstr ""
 
-#. [else]
-#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:336
-#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:378
-msgid "We already know everything we need to know. Your friend had told us about a great army of orcs, what else you could possibly know?"
+#. [then]
+#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:330
+#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:372
+msgid "Hide in your quagmire, lizard thing."
 msgstr ""
 
 #. [else]
 #: A_New_Order/scenarios/05_The_Swamp_Things.cfg:337
 #: A_New_Order/scenarios/05_The_Swamp_Things.cfg:379
+msgid "We already know everything we need to know. Your friend had told us about a great army of orcs, what else you could possibly know?"
+msgstr ""
+
+#. [else]
+#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:338
+#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:380
 msgid "I know where we hide the gold. Humanss, you love gold, will you ssave my life if I show you?"
 msgstr ""
 
 #. [else]
 #. Lorin is mad that she is starting to pick up saurian speech patterns:
 #. Lorin is mad that she is starting to pick up saurian speech patterns:
-#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:339
-#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:381
+#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:340
+#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:382
 msgid "Seems a fair deal. Show usss... blast it... show us the gold and you may leave."
 msgstr ""
 
 #. [else]
-#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:345
-#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:387
+#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:346
+#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:388
 msgid "You have resssssieved $gold_amt gold piesssses."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:394
+#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:395
 msgid "My lady, we have found some gold Saurians were hiding. They probably earned it by robbing the humans living nearby."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:395
+#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:396
 msgid "Oh, so I am still 'my lady' to you? Good. We may have use for the gold in future."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:396
+#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:397
 msgid "I really don't know what 'we' you have in mind."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:402
+#: A_New_Order/scenarios/05_The_Swamp_Things.cfg:403
 msgid "You have received $end_gold_amt gold pieces."
 msgstr ""
 
@@ -17280,6 +17306,11 @@ msgstr ""
 #. [then]
 #: A_New_Order/scenarios/10_Siege_of_Haeltin.cfg:365
 msgid "They look well-prepared. Call in the reserves!"
+msgstr ""
+
+#. [objective]: condition=win
+#: A_New_Order/scenarios/10_Siege_of_Haeltin.cfg:411
+msgid "HEROIC: Kill all enemy leaders OR"
 msgstr ""
 
 #. [objective]: condition=win

--- a/translations/wesnoth-A_New_Order.pot
+++ b/translations/wesnoth-A_New_Order.pot
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
-"POT-Creation-Date: 2024-07-25 03:36 UTC\n"
+"POT-Creation-Date: 2024-08-19 01:38 UTC\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -66,7 +66,7 @@ msgstr ""
 #. [unit_type]: id=Oracle, race=human
 #. [unit]: type=Oracle, id=Oracle
 #: A_New_Order/units/others/Oracle.cfg:6
-#: A_New_Order/scenarios/19c_The_Oracle.cfg:1836
+#: A_New_Order/scenarios/19c_The_Oracle.cfg:1869
 msgid "Oracle"
 msgstr ""
 
@@ -92,10 +92,10 @@ msgstr ""
 #: A_New_Order/units/others/Ruvios_Daughter.cfg:4
 #: A_New_Order/macros/messages.cfg:70
 #: A_New_Order/macros/messages.cfg:74
-#: A_New_Order/scenarios/13_Scouting.cfg:716
-#: A_New_Order/scenarios/13_Scouting.cfg:726
-#: A_New_Order/scenarios/13_Scouting.cfg:737
-#: A_New_Order/scenarios/13_Scouting.cfg:745
+#: A_New_Order/scenarios/13_Scouting.cfg:731
+#: A_New_Order/scenarios/13_Scouting.cfg:741
+#: A_New_Order/scenarios/13_Scouting.cfg:752
+#: A_New_Order/scenarios/13_Scouting.cfg:760
 #: A_New_Order/scenarios/07_Ally_From_the_Past.cfg:94
 msgid "Karen"
 msgstr ""
@@ -130,19 +130,19 @@ msgstr ""
 #: A_New_Order/macros/messages.cfg:102
 #: A_New_Order/macros/messages.cfg:106
 #: A_New_Order/macros/messages.cfg:113
-#: A_New_Order/scenarios/20_Okladia.cfg:437
-#: A_New_Order/scenarios/20_Okladia.cfg:446
-#: A_New_Order/scenarios/20_Okladia.cfg:456
-#: A_New_Order/scenarios/20_Okladia.cfg:464
-#: A_New_Order/scenarios/13_Scouting.cfg:715
-#: A_New_Order/scenarios/13_Scouting.cfg:725
-#: A_New_Order/scenarios/13_Scouting.cfg:736
-#: A_New_Order/scenarios/13_Scouting.cfg:744
+#: A_New_Order/scenarios/20_Okladia.cfg:438
+#: A_New_Order/scenarios/20_Okladia.cfg:447
+#: A_New_Order/scenarios/20_Okladia.cfg:457
+#: A_New_Order/scenarios/20_Okladia.cfg:465
+#: A_New_Order/scenarios/13_Scouting.cfg:730
+#: A_New_Order/scenarios/13_Scouting.cfg:740
+#: A_New_Order/scenarios/13_Scouting.cfg:751
+#: A_New_Order/scenarios/13_Scouting.cfg:759
 #: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:650
 #: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:690
 #: A_New_Order/scenarios/07_Ally_From_the_Past.cfg:78
-#: A_New_Order/scenarios/21a_Abducted_Bride.cfg:622
-#: A_New_Order/scenarios/21a_Abducted_Bride.cfg:637
+#: A_New_Order/scenarios/21a_Abducted_Bride.cfg:624
+#: A_New_Order/scenarios/21a_Abducted_Bride.cfg:639
 #: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:562
 #: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:570
 msgid "Ruvio"
@@ -355,7 +355,7 @@ msgstr ""
 #. [unit_type]: id=Akladian Protector, race=akladian
 #. [campaign]: id=A_New_Order
 #: A_New_Order/units/akladians/Akladian_Protector.cfg:4
-#: A_New_Order/_main.cfg:60
+#: A_New_Order/_main.cfg:63
 msgid "Akladian Protector"
 msgstr ""
 
@@ -414,7 +414,7 @@ msgstr ""
 #. [campaign]: id=A_New_Order
 #: A_New_Order/units/akladians/Akladian_Clansman.cfg:4
 #: A_New_Order/scenarios/02_Fighting_for_Passage.cfg:960
-#: A_New_Order/_main.cfg:57
+#: A_New_Order/_main.cfg:60
 msgid "Akladian Clansman"
 msgstr ""
 
@@ -453,7 +453,7 @@ msgstr ""
 #. [unit_type]: id=Akladian Warrior, race=akladian
 #. [campaign]: id=A_New_Order
 #: A_New_Order/units/akladians/Akladian_Warrior.cfg:4
-#: A_New_Order/_main.cfg:58
+#: A_New_Order/_main.cfg:61
 msgid "Akladian Warrior"
 msgstr ""
 
@@ -570,7 +570,7 @@ msgstr ""
 #. [unit_type]: id=Akladian Shieldguard, race=akladian
 #. [campaign]: id=A_New_Order
 #: A_New_Order/units/akladians/Akladian_Shieldguard.cfg:4
-#: A_New_Order/_main.cfg:59
+#: A_New_Order/_main.cfg:62
 msgid "Akladian Shieldguard"
 msgstr ""
 
@@ -627,8 +627,9 @@ msgid ""
 "main={long_firstn}|{short_firstn} {lastn}\n"
 "short_firstn={prefix}{suffix}|{prefix_v}{suffix_c}\n"
 "long_firstn={prefix}{midfix}{suffix}|{prefix}{midfix}{midfix}{suffix}|{prefix}{midfix_v}{suffix_c}\n"
-"lastn=O {uplace}|Ohavenort|Areon|Rothe|Crynenoj|Cruveno|Mathauri|Ramenari|Rebarnon|Khan|Harnen|Barien|Barrae|Scud|Skagrrae|Riddon|Travil|Hurionen|Urien|Brien|Dark|Wonder|Moric|Putin\n"
+"lastn=O {uplace}|Ohavenort|Areon|Rothe|Crynenoj|Cruveno|Mathauri|Ramenari|Rebarnon|Khan|Harnen|Barien|Barrae|Scud|Skagrrae|Riddon|Travil|Hurionen|Urien|Brien|Dark|Wonder|Moric|Putin|{uplace}{demonymsuffix}|Netanyahu\n"
 "uplace=Gaeltin|Borraine|Barnone|Vattin|Haeltin|Raedbor|Raednon|Barron|Warhol|Skagrrak|Travil|Trimmen\n"
+"demonymsuffix=an|ite|ish|ard|iot|na\n"
 "prefix={prefix_v}|{prefix_c}\n"
 "prefix_v=Re|Ao|Te|Ro|Eo|Lee|La|Ru|Theo|Ae|Rao|Ne|I|Ia|Ioe|Kro|Kre|Yeo|Que|Thu|Mari|Bo|Uri|Ri|Nai|Rau|Gra|Ree|Stro|Reo|Oy|Au|Oe|Mo|No|Rou|Moe|Mi|U|Li|Reu|Ra|Ee|E|Be|Bu|Wu|Dau|Co|Ai|Gau|Al|Odo|Gae|Gei|Eu|Oda|To|Beo|Ku|Tre|Ha|Lu\n"
 "prefix_c=Or|Kar|Sav|Raul|Ur|Bar|Er|Mar|Mir|Um|Quiv|Bur|Tel|As|Lar|Rav|Rum|Cim|At|Eur|Tot|Hun|Hil|Hild|En|Enk|Tam|Sky|Ar|Arg|Gen|Kub|Trev|B|Zan\n"
@@ -641,7 +642,7 @@ msgid ""
 msgstr ""
 
 #. Generator for female Akladian names; see <https://wiki.wesnoth.org/Context-free_grammar> for syntax:
-#: A_New_Order/units/_main.cfg:25
+#: A_New_Order/units/_main.cfg:26
 msgid ""
 "\n"
 "main={prefix}{suffix}|{prefix}{midfix}{suffix}\n"
@@ -652,7 +653,7 @@ msgid ""
 msgstr ""
 
 #. [race]: id=akladian
-#: A_New_Order/units/_main.cfg:35
+#: A_New_Order/units/_main.cfg:36
 msgid ""
 " The Akladians are wild barbarians. Hailing from the harsh east, they are born fighters. Stronger, more agile and quicker than normal people, they are a civilisation based entirely on war.\n"
 "\n"
@@ -664,29 +665,29 @@ msgid ""
 msgstr ""
 
 #. [race]: id=akladian
-#: A_New_Order/units/_main.cfg:42
+#: A_New_Order/units/_main.cfg:43
 msgid "race^Akladian"
 msgstr ""
 
 #. [race]: id=akladian
-#: A_New_Order/units/_main.cfg:43
+#: A_New_Order/units/_main.cfg:44
 msgid "race+female^Akladian"
 msgstr ""
 
 #. [race]: id=akladian
-#: A_New_Order/units/_main.cfg:44
+#: A_New_Order/units/_main.cfg:45
 msgid "race^Akladians"
 msgstr ""
 
 #. [race]: id=akladian
 #. Most of the new additions to this male_names list are just taken from names that were hardcoded elsewhere in the campaign:
-#: A_New_Order/units/_main.cfg:48
+#: A_New_Order/units/_main.cfg:49
 msgid "Reuke,Aorenor,Reme,Terao,Aoeree,Reeoe,Larao,Borien,Rouenoe,Eoleree,Leenore,Oreoke,Lauroe,Rumethe,Theorien,Rukeen,Aeorei,Raori,Neiae,Ien,Ian,Iain,Ioeneree,Karnee,Kromoe,Kreneo,Savireo,Raulien,Urenaye,Yeorgh,Yeorimo,Quenerien,Thurimarien,Mariaele,Orieo,Boraeo,Uriliaen,Eoremar,Rioulien,Naiyen,Barukee,Rauoli,Graeme,Graukin,Ruke,Urke,Erke,Reeanoo,Mareele,Eolan,Eolorien,Iree,Stromeoeo,Reonee,Raoke,Oyre,Auree,Aueree,Oeme,Moro,Moreo,Nome,Oeame,Roule,Moerro,Urheare,Mirro,Umeari,Rioto,Lioato,Moerre,Reuluigi,Raole,Quivre,Kariv,Rouke,Raban,Marlin,Burke,Barien,Eesterregge,Barbarbar,Burien,Telen,Dulen,Beren,Buren,Boren,Rebarnon,Wutan,Askarial,Bark,Rurk,Rauke,Dauri,Conan,Larkin,Aire,Raven,Rumpel,Cimper,Camper,Gauri,Attila,Alaric,Odoacer,Theodoric,Gaeseric,Geiseric,Genseeriec,Euriac,Odaovacer,Totila,Huneric,Hilderic,Beowuelfe,Atreides,Enkidu,Tamerlan,Timuree,Turanee,Kimeree,Skythike,Touman,Arglebargle,Aeioeeu,Aieoiu,Genghis,Kublai,Eeoeeu,Barburien,Trevoree,Burbarurkian,Har,Bors,Lucs"
 msgstr ""
 
 #. [race]: id=akladian
 #. I don't think this female_names list actually gets used anywhere (unless you're using debug mode); feel free to skip:
-#: A_New_Order/units/_main.cfg:50
+#: A_New_Order/units/_main.cfg:51
 msgid "Lorin,Laorin,Aoerin,Uyenaya,Rianna,Yeorienna,Thurienna,Marioellin,Eena,Nemaara,Xena,Ayla"
 msgstr ""
 
@@ -948,7 +949,7 @@ msgstr ""
 #: A_New_Order/scenarios/15a_The_Preparations.cfg:199
 #: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:422
 #: A_New_Order/scenarios/23_Trapped.cfg:28
-#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:603
+#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:604
 #: A_New_Order/scenarios/22_Leaving_Okladia.cfg:150
 #: A_New_Order/scenarios/22_Leaving_Okladia.cfg:158
 #: A_New_Order/scenarios/22_Leaving_Okladia.cfg:173
@@ -1316,43 +1317,51 @@ msgstr ""
 msgid "No, nothing. It doesn't matter. I... I'm sorry, but I can't... I will join you later."
 msgstr ""
 
-#: A_New_Order/macros/conversations.cfg:56
+#: A_New_Order/macros/conversations.cfg:55
 msgid "Gawen, I've never seen your step-mother like this before. I think she is sick. Very sick. I saw her vomiting yesterday."
 msgstr ""
 
 #. Gawen is reacting to Ruvio informing him that he saw Lorin vomiting yesterday; the way he intended
 #. to complete the "Is she..." sentence at the end is left intentionally ambiguous so that Ruvio can complete
 #. it with his own assumption that Gawen meant "...poisoned?" to complete it.
-#: A_New_Order/macros/conversations.cfg:60
+#: A_New_Order/macros/conversations.cfg:59
 msgid "But... What happened? Why? Is she..."
 msgstr ""
 
-#: A_New_Order/macros/conversations.cfg:61
+#: A_New_Order/macros/conversations.cfg:60
 msgid "Poisoned? It's not impossible. We have Akladians in our army, don't we?"
 msgstr ""
 
-#: A_New_Order/macros/conversations.cfg:62
+#: A_New_Order/macros/conversations.cfg:61
 msgid "My lord, I do not wish to disturb you, but our scouts have reported about the enemy forces."
 msgstr ""
 
-#: A_New_Order/macros/conversations.cfg:63
+#: A_New_Order/macros/conversations.cfg:62
 msgid "Hmm... It seems we will have to fight this army to continue our journey. It should be easy."
 msgstr ""
 
-#: A_New_Order/macros/conversations.cfg:65
-#: A_New_Order/macros/conversations.cfg:67
+#: A_New_Order/macros/conversations.cfg:64
+#: A_New_Order/macros/conversations.cfg:66
 msgid "My lord, our scouts also told us that we are being followed by a very large army of Akladians. Someone has noticed us. Maybe our successes have been too much. We have to win quickly, or we will be crushed by another foe."
 msgstr ""
 
-#: A_New_Order/macros/conversations.cfg:69
+#: A_New_Order/macros/conversations.cfg:68
 msgid "It will be have to be a quick and decisive victory, then."
 msgstr ""
 
-#: A_New_Order/macros/conversations.cfg:73
-msgid "Now that we have quit Raedwood forest, we should find Deorien. We know he is somewhere in Okladia, another kingdom that was founded by Akladians, and is ruled by your cousins from the Hagarthen line. But where Deorien is exactly... well, we have no idea."
+#: A_New_Order/macros/conversations.cfg:72
+msgid "I am ready to take Lorin's place in your battle formation, my lord."
 msgstr ""
 
 #: A_New_Order/macros/conversations.cfg:74
+msgid "If only we had someone to take Lorin's place..."
+msgstr ""
+
+#: A_New_Order/macros/conversations.cfg:80
+msgid "Now that we have quit Raedwood forest, we should find Deorien. We know he is somewhere in Okladia, another kingdom that was founded by Akladians, and is ruled by your cousins from the Hagarthen line. But where Deorien is exactly... well, we have no idea."
+msgstr ""
+
+#: A_New_Order/macros/conversations.cfg:81
 msgid "That's why I suggest we visit the Oracle, who, being a mage herself, may know where Deorien is."
 msgstr ""
 
@@ -1671,18 +1680,18 @@ msgstr ""
 #: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:599
 #: A_New_Order/scenarios/05_Unexpected_Guests.cfg:283
 #: A_New_Order/scenarios/05_Unexpected_Guests.cfg:387
-#: A_New_Order/scenarios/21a_Abducted_Bride.cfg:399
-#: A_New_Order/scenarios/21a_Abducted_Bride.cfg:428
+#: A_New_Order/scenarios/21a_Abducted_Bride.cfg:400
+#: A_New_Order/scenarios/21a_Abducted_Bride.cfg:430
 #: A_New_Order/scenarios/23_Trapped.cfg:913
-#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:480
+#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:481
 #: A_New_Order/scenarios/21b_Haunted_Place.cfg:196
 #: A_New_Order/scenarios/21b_Haunted_Place.cfg:221
-#: A_New_Order/scenarios/19c_The_Oracle.cfg:1574
+#: A_New_Order/scenarios/19c_The_Oracle.cfg:1604
 #: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:500
 #: A_New_Order/scenarios/27_Orannon.cfg:746
 #: A_New_Order/scenarios/27_Orannon.cfg:1147
 #: A_New_Order/scenarios/02_Fighting_for_Passage.cfg:352
-#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:540
+#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:541
 #: A_New_Order/scenarios/05_The_Swamp_Things.cfg:299
 #: A_New_Order/scenarios/10_Siege_of_Haeltin.cfg:423
 #: A_New_Order/scenarios/09_Hired_Swords.cfg:256
@@ -1695,7 +1704,7 @@ msgstr ""
 #: A_New_Order/scenarios/05_Unexpected_Guests.cfg:391
 #: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:504
 #: A_New_Order/scenarios/02_Fighting_for_Passage.cfg:356
-#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:544
+#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:545
 #: A_New_Order/scenarios/05_The_Swamp_Things.cfg:303
 msgid "Death of Reme Carrenemoe"
 msgstr ""
@@ -1768,7 +1777,7 @@ msgstr ""
 #. [message]
 #. [event]
 #: A_New_Order/macros/debug.cfg:51
-#: A_New_Order/scenarios/13_Scouting.cfg:449
+#: A_New_Order/scenarios/13_Scouting.cfg:464
 msgid "Hello."
 msgstr ""
 
@@ -1815,14 +1824,14 @@ msgstr ""
 #. [command]
 #. [event]
 #: A_New_Order/macros/debug.cfg:66
-#: A_New_Order/scenarios/20_Okladia.cfg:441
-#: A_New_Order/scenarios/20_Okladia.cfg:449
-#: A_New_Order/scenarios/20_Okladia.cfg:459
-#: A_New_Order/scenarios/20_Okladia.cfg:466
-#: A_New_Order/scenarios/13_Scouting.cfg:720
-#: A_New_Order/scenarios/13_Scouting.cfg:729
-#: A_New_Order/scenarios/13_Scouting.cfg:739
-#: A_New_Order/scenarios/13_Scouting.cfg:746
+#: A_New_Order/scenarios/20_Okladia.cfg:442
+#: A_New_Order/scenarios/20_Okladia.cfg:450
+#: A_New_Order/scenarios/20_Okladia.cfg:460
+#: A_New_Order/scenarios/20_Okladia.cfg:467
+#: A_New_Order/scenarios/13_Scouting.cfg:735
+#: A_New_Order/scenarios/13_Scouting.cfg:744
+#: A_New_Order/scenarios/13_Scouting.cfg:754
+#: A_New_Order/scenarios/13_Scouting.cfg:761
 #: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:565
 #: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:572
 msgid "I changed my mind"
@@ -1866,8 +1875,8 @@ msgstr ""
 #. [event]
 #. [unit]: id=Alarice, type=White Mage
 #: A_New_Order/macros/ano-20macros.cfg:20
-#: A_New_Order/scenarios/21d_Ruins_of_Weldyn.cfg:139
-#: A_New_Order/scenarios/21d_Ruins_of_Weldyn.cfg:154
+#: A_New_Order/scenarios/21d_Ruins_of_Weldyn.cfg:140
+#: A_New_Order/scenarios/21d_Ruins_of_Weldyn.cfg:155
 #: A_New_Order/scenarios/21c_Ruins_of_the_Past.cfg:182
 msgid "Alarice"
 msgstr ""
@@ -1880,8 +1889,8 @@ msgstr ""
 #. [event]
 #. [unit]: id=Maurice, type=Red Mage
 #: A_New_Order/macros/ano-20macros.cfg:29
-#: A_New_Order/scenarios/21d_Ruins_of_Weldyn.cfg:123
-#: A_New_Order/scenarios/21d_Ruins_of_Weldyn.cfg:157
+#: A_New_Order/scenarios/21d_Ruins_of_Weldyn.cfg:124
+#: A_New_Order/scenarios/21d_Ruins_of_Weldyn.cfg:158
 #: A_New_Order/scenarios/21c_Ruins_of_the_Past.cfg:165
 msgid "Maurice"
 msgstr ""
@@ -1897,8 +1906,8 @@ msgstr ""
 #: A_New_Order/macros/ano-20macros.cfg:37
 #: A_New_Order/macros/messages.cfg:126
 #: A_New_Order/scenarios/20_Okladia.cfg:97
-#: A_New_Order/scenarios/20_Okladia.cfg:440
-#: A_New_Order/scenarios/20_Okladia.cfg:457
+#: A_New_Order/scenarios/20_Okladia.cfg:441
+#: A_New_Order/scenarios/20_Okladia.cfg:458
 #: A_New_Order/scenarios/21d_Ruins_of_Weldyn.cfg:70
 #: A_New_Order/scenarios/21c_Ruins_of_the_Past.cfg:111
 msgid "Deorien"
@@ -2004,7 +2013,7 @@ msgstr ""
 #: A_New_Order/scenarios/23_Trapped.cfg:635
 #: A_New_Order/scenarios/23_Trapped.cfg:651
 #: A_New_Order/scenarios/23_Trapped.cfg:667
-#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:679
+#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:680
 #: A_New_Order/scenarios/21b_Haunted_Place.cfg:346
 #: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:2261
 #: A_New_Order/scenarios/09_Hired_Swords.cfg:370
@@ -2277,7 +2286,7 @@ msgstr ""
 #. [event]
 #. [scenario]: id=13_Scouting
 #: A_New_Order/macros/ano-20macros.cfg:352
-#: A_New_Order/scenarios/13_Scouting.cfg:166
+#: A_New_Order/scenarios/13_Scouting.cfg:181
 #: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:233
 #: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:384
 #: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:493
@@ -2337,14 +2346,14 @@ msgstr ""
 #: A_New_Order/macros/ano-20macros.cfg:395
 #: A_New_Order/macros/ano-20macros.cfg:401
 #: A_New_Order/macros/ano-20macros.cfg:408
-#: A_New_Order/scenarios/20_Okladia.cfg:312
-#: A_New_Order/scenarios/20_Okladia.cfg:362
-#: A_New_Order/scenarios/20_Okladia.cfg:409
+#: A_New_Order/scenarios/20_Okladia.cfg:313
+#: A_New_Order/scenarios/20_Okladia.cfg:363
+#: A_New_Order/scenarios/20_Okladia.cfg:410
 #: A_New_Order/scenarios/25_The_Awakening.cfg:1190
 #: A_New_Order/scenarios/25_The_Awakening.cfg:1218
 #: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:58
 #: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:93
-#: A_New_Order/scenarios/21a_Abducted_Bride.cfg:581
+#: A_New_Order/scenarios/21a_Abducted_Bride.cfg:583
 #: A_New_Order/scenarios/21a_Abducted_Bride.cfg:26
 #: A_New_Order/scenarios/21a_Abducted_Bride.cfg:56
 #: A_New_Order/scenarios/12_Leaving_Raedwood.cfg:13
@@ -2972,14 +2981,14 @@ msgstr ""
 #: A_New_Order/scenarios/15c_Raedwood_East.cfg:220
 #: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:595
 #: A_New_Order/scenarios/07_Ally_From_the_Past.cfg:361
-#: A_New_Order/scenarios/21a_Abducted_Bride.cfg:395
-#: A_New_Order/scenarios/21a_Abducted_Bride.cfg:424
+#: A_New_Order/scenarios/21a_Abducted_Bride.cfg:396
+#: A_New_Order/scenarios/21a_Abducted_Bride.cfg:426
 #: A_New_Order/scenarios/19a_The_Woods_of_Okladia.cfg:189
 #: A_New_Order/scenarios/15b_Repelling_the_Orcs.cfg:96
 #: A_New_Order/scenarios/19b_Entering_Okladia.cfg:180
 #: A_New_Order/scenarios/21b_Haunted_Place.cfg:192
 #: A_New_Order/scenarios/21b_Haunted_Place.cfg:217
-#: A_New_Order/scenarios/19c_The_Oracle.cfg:1570
+#: A_New_Order/scenarios/19c_The_Oracle.cfg:1600
 #: A_New_Order/scenarios/27_Orannon.cfg:754
 #: A_New_Order/scenarios/27_Orannon.cfg:1155
 #: A_New_Order/scenarios/12_Leaving_Raedwood.cfg:225
@@ -2993,23 +3002,23 @@ msgstr ""
 #: A_New_Order/scenarios/15c_Raedwood_East.cfg:224
 #: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:591
 #: A_New_Order/scenarios/07_Ally_From_the_Past.cfg:357
-#: A_New_Order/scenarios/21a_Abducted_Bride.cfg:391
-#: A_New_Order/scenarios/21a_Abducted_Bride.cfg:420
+#: A_New_Order/scenarios/21a_Abducted_Bride.cfg:392
+#: A_New_Order/scenarios/21a_Abducted_Bride.cfg:422
 #: A_New_Order/scenarios/23_Trapped.cfg:905
-#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:472
+#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:473
 #: A_New_Order/scenarios/19a_The_Woods_of_Okladia.cfg:185
 #: A_New_Order/scenarios/15b_Repelling_the_Orcs.cfg:100
 #: A_New_Order/scenarios/19b_Entering_Okladia.cfg:176
 #: A_New_Order/scenarios/21b_Haunted_Place.cfg:188
 #: A_New_Order/scenarios/21b_Haunted_Place.cfg:213
-#: A_New_Order/scenarios/19c_The_Oracle.cfg:1566
+#: A_New_Order/scenarios/19c_The_Oracle.cfg:1596
 #: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:496
 #: A_New_Order/scenarios/27_Orannon.cfg:742
 #: A_New_Order/scenarios/27_Orannon.cfg:1143
 #: A_New_Order/scenarios/12_Leaving_Raedwood.cfg:217
 #: A_New_Order/scenarios/08_Outlaw_Base.cfg:215
 #: A_New_Order/scenarios/02_Fighting_for_Passage.cfg:348
-#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:536
+#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:537
 msgid "Death of Gawen Hagarthen"
 msgstr ""
 
@@ -3258,8 +3267,8 @@ msgstr ""
 #: A_New_Order/scenarios/15c_Raedwood_East.cfg:294
 #: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:654
 #: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:697
-#: A_New_Order/scenarios/21a_Abducted_Bride.cfg:617
-#: A_New_Order/scenarios/21a_Abducted_Bride.cfg:632
+#: A_New_Order/scenarios/21a_Abducted_Bride.cfg:619
+#: A_New_Order/scenarios/21a_Abducted_Bride.cfg:634
 msgid "Gawen"
 msgstr ""
 
@@ -3339,14 +3348,14 @@ msgstr ""
 #: A_New_Order/macros/messages.cfg:82
 #: A_New_Order/macros/messages.cfg:86
 #: A_New_Order/macros/messages.cfg:90
-#: A_New_Order/scenarios/20_Okladia.cfg:439
-#: A_New_Order/scenarios/20_Okladia.cfg:448
-#: A_New_Order/scenarios/20_Okladia.cfg:458
-#: A_New_Order/scenarios/20_Okladia.cfg:465
-#: A_New_Order/scenarios/13_Scouting.cfg:718
-#: A_New_Order/scenarios/13_Scouting.cfg:727
+#: A_New_Order/scenarios/20_Okladia.cfg:440
+#: A_New_Order/scenarios/20_Okladia.cfg:449
+#: A_New_Order/scenarios/20_Okladia.cfg:459
+#: A_New_Order/scenarios/20_Okladia.cfg:466
+#: A_New_Order/scenarios/13_Scouting.cfg:733
+#: A_New_Order/scenarios/13_Scouting.cfg:742
 #: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:706
-#: A_New_Order/scenarios/21a_Abducted_Bride.cfg:607
+#: A_New_Order/scenarios/21a_Abducted_Bride.cfg:609
 #: A_New_Order/scenarios/28_Lorin.cfg:3
 #: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:564
 #: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:571
@@ -3356,14 +3365,14 @@ msgstr ""
 #. [event]
 #: A_New_Order/macros/messages.cfg:94
 #: A_New_Order/macros/messages.cfg:98
-#: A_New_Order/scenarios/20_Okladia.cfg:438
-#: A_New_Order/scenarios/20_Okladia.cfg:447
-#: A_New_Order/scenarios/13_Scouting.cfg:717
-#: A_New_Order/scenarios/13_Scouting.cfg:738
+#: A_New_Order/scenarios/20_Okladia.cfg:439
+#: A_New_Order/scenarios/20_Okladia.cfg:448
+#: A_New_Order/scenarios/13_Scouting.cfg:732
+#: A_New_Order/scenarios/13_Scouting.cfg:753
 #: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:646
 #: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:683
-#: A_New_Order/scenarios/21a_Abducted_Bride.cfg:612
-#: A_New_Order/scenarios/21a_Abducted_Bride.cfg:627
+#: A_New_Order/scenarios/21a_Abducted_Bride.cfg:614
+#: A_New_Order/scenarios/21a_Abducted_Bride.cfg:629
 #: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:563
 msgid "Reme"
 msgstr ""
@@ -3371,8 +3380,8 @@ msgstr ""
 #. [event]
 #: A_New_Order/macros/messages.cfg:117
 #: A_New_Order/macros/messages.cfg:122
-#: A_New_Order/scenarios/13_Scouting.cfg:719
-#: A_New_Order/scenarios/13_Scouting.cfg:728
+#: A_New_Order/scenarios/13_Scouting.cfg:734
+#: A_New_Order/scenarios/13_Scouting.cfg:743
 msgid "Yahyazad"
 msgstr ""
 
@@ -3392,7 +3401,7 @@ msgstr ""
 
 #. [unit]: type=Peasant, id=Matthew Eagles-Eye
 #: A_New_Order/macros/messages.cfg:178
-#: A_New_Order/scenarios/13_Scouting.cfg:895
+#: A_New_Order/scenarios/13_Scouting.cfg:910
 msgid "Matthew Eagle's-Eye"
 msgstr ""
 
@@ -3408,8 +3417,8 @@ msgstr ""
 #. [unit]: id=Assassin
 #: A_New_Order/macros/messages.cfg:186
 #: A_New_Order/scenarios/02_Fighting_for_Passage.cfg:659
-#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:431
-#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:575
+#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:432
+#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:576
 msgid "Assassin"
 msgstr ""
 
@@ -3795,7 +3804,7 @@ msgstr ""
 #. [side]: id=Gawen Hagarthen, type=Akladian Lady
 #: A_New_Order/scenarios/20_Okladia.cfg:67
 #: A_New_Order/scenarios/25_The_Awakening.cfg:327
-#: A_New_Order/scenarios/13_Scouting.cfg:330
+#: A_New_Order/scenarios/13_Scouting.cfg:345
 #: A_New_Order/scenarios/15a_The_Preparations.cfg:32
 #: A_New_Order/scenarios/15c_Raedwood_East.cfg:35
 #: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:47
@@ -3831,7 +3840,7 @@ msgstr ""
 #: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:300
 #: A_New_Order/scenarios/24_Fall_of_Freetown.cfg:62
 #: A_New_Order/scenarios/02_Fighting_for_Passage.cfg:63
-#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:126
+#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:127
 #: A_New_Order/scenarios/21c_Ruins_of_the_Past.cfg:100
 #: A_New_Order/scenarios/26_Return_of_the_King.cfg:45
 msgid "Gawen Hagarthen"
@@ -3905,25 +3914,25 @@ msgid "This is a large-scale map, where you will choose a way to go. You should 
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/20_Okladia.cfg:169
+#: A_New_Order/scenarios/20_Okladia.cfg:170
 msgid "So, shall we go to the ruins of Weldyn?"
 msgstr ""
 
 #. [event]
 #. [else]
-#: A_New_Order/scenarios/20_Okladia.cfg:170
-#: A_New_Order/scenarios/20_Okladia.cfg:190
-#: A_New_Order/scenarios/20_Okladia.cfg:208
-#: A_New_Order/scenarios/20_Okladia.cfg:228
-#: A_New_Order/scenarios/20_Okladia.cfg:253
-#: A_New_Order/scenarios/13_Scouting.cfg:527
-#: A_New_Order/scenarios/13_Scouting.cfg:551
-#: A_New_Order/scenarios/13_Scouting.cfg:587
-#: A_New_Order/scenarios/13_Scouting.cfg:884
-#: A_New_Order/scenarios/13_Scouting.cfg:916
-#: A_New_Order/scenarios/13_Scouting.cfg:947
+#: A_New_Order/scenarios/20_Okladia.cfg:171
+#: A_New_Order/scenarios/20_Okladia.cfg:191
+#: A_New_Order/scenarios/20_Okladia.cfg:209
+#: A_New_Order/scenarios/20_Okladia.cfg:229
+#: A_New_Order/scenarios/20_Okladia.cfg:254
+#: A_New_Order/scenarios/13_Scouting.cfg:542
+#: A_New_Order/scenarios/13_Scouting.cfg:566
+#: A_New_Order/scenarios/13_Scouting.cfg:602
+#: A_New_Order/scenarios/13_Scouting.cfg:899
+#: A_New_Order/scenarios/13_Scouting.cfg:931
+#: A_New_Order/scenarios/13_Scouting.cfg:962
 #: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:464
-#: A_New_Order/scenarios/21a_Abducted_Bride.cfg:481
+#: A_New_Order/scenarios/21a_Abducted_Bride.cfg:483
 #: A_New_Order/scenarios/14d_Avenging_Ruen.cfg:183
 #: A_New_Order/scenarios/14d_Avenging_Ruen.cfg:247
 #: A_New_Order/scenarios/14d_Avenging_Ruen.cfg:282
@@ -3945,19 +3954,19 @@ msgstr ""
 
 #. [event]
 #. [else]
-#: A_New_Order/scenarios/20_Okladia.cfg:171
-#: A_New_Order/scenarios/20_Okladia.cfg:191
-#: A_New_Order/scenarios/20_Okladia.cfg:209
-#: A_New_Order/scenarios/20_Okladia.cfg:229
-#: A_New_Order/scenarios/20_Okladia.cfg:254
-#: A_New_Order/scenarios/13_Scouting.cfg:528
-#: A_New_Order/scenarios/13_Scouting.cfg:552
-#: A_New_Order/scenarios/13_Scouting.cfg:588
-#: A_New_Order/scenarios/13_Scouting.cfg:885
-#: A_New_Order/scenarios/13_Scouting.cfg:917
-#: A_New_Order/scenarios/13_Scouting.cfg:948
+#: A_New_Order/scenarios/20_Okladia.cfg:172
+#: A_New_Order/scenarios/20_Okladia.cfg:192
+#: A_New_Order/scenarios/20_Okladia.cfg:210
+#: A_New_Order/scenarios/20_Okladia.cfg:230
+#: A_New_Order/scenarios/20_Okladia.cfg:255
+#: A_New_Order/scenarios/13_Scouting.cfg:543
+#: A_New_Order/scenarios/13_Scouting.cfg:567
+#: A_New_Order/scenarios/13_Scouting.cfg:603
+#: A_New_Order/scenarios/13_Scouting.cfg:900
+#: A_New_Order/scenarios/13_Scouting.cfg:932
+#: A_New_Order/scenarios/13_Scouting.cfg:963
 #: A_New_Order/scenarios/14a_Scouting_Near_Barnon.cfg:465
-#: A_New_Order/scenarios/21a_Abducted_Bride.cfg:482
+#: A_New_Order/scenarios/21a_Abducted_Bride.cfg:484
 #: A_New_Order/scenarios/14d_Avenging_Ruen.cfg:184
 #: A_New_Order/scenarios/19a_The_Woods_of_Okladia.cfg:201
 #: A_New_Order/scenarios/19b_Entering_Okladia.cfg:192
@@ -3976,35 +3985,35 @@ msgid "Well, maybe not."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/20_Okladia.cfg:179
+#: A_New_Order/scenarios/20_Okladia.cfg:180
 msgid "My lord, we already visited that place, and we found Deorien there."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/20_Okladia.cfg:189
+#: A_New_Order/scenarios/20_Okladia.cfg:190
 msgid "So, shall we go to these haunted ruins?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/20_Okladia.cfg:199
-#: A_New_Order/scenarios/20_Okladia.cfg:217
+#: A_New_Order/scenarios/20_Okladia.cfg:200
+#: A_New_Order/scenarios/20_Okladia.cfg:218
 msgid "My lord, we already visited that place."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/20_Okladia.cfg:207
+#: A_New_Order/scenarios/20_Okladia.cfg:208
 msgid "So, should we go that way?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/20_Okladia.cfg:227
-#: A_New_Order/scenarios/20_Okladia.cfg:252
+#: A_New_Order/scenarios/20_Okladia.cfg:228
+#: A_New_Order/scenarios/20_Okladia.cfg:253
 msgid "So, should we go back to Vakladia?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/20_Okladia.cfg:243
-#: A_New_Order/scenarios/20_Okladia.cfg:268
+#: A_New_Order/scenarios/20_Okladia.cfg:244
+#: A_New_Order/scenarios/20_Okladia.cfg:269
 msgid "My lord, we have not found Deorien yet."
 msgstr ""
 
@@ -4013,32 +4022,32 @@ msgstr ""
 #. FIXME: her signpost is actually west from here, but maybe this villager is just stupid/lying?
 #. FIXME: her signpost is actually west from here, but maybe this villager is just stupid/lying?
 #. he is wrong about where Deorien lives, but as he says, he doesn't know, so preserve his mistake on translation:
-#: A_New_Order/scenarios/20_Okladia.cfg:277
-#: A_New_Order/scenarios/20_Okladia.cfg:281
-#: A_New_Order/scenarios/20_Okladia.cfg:293
-#: A_New_Order/scenarios/20_Okladia.cfg:299
+#: A_New_Order/scenarios/20_Okladia.cfg:278
+#: A_New_Order/scenarios/20_Okladia.cfg:282
+#: A_New_Order/scenarios/20_Okladia.cfg:294
 #: A_New_Order/scenarios/20_Okladia.cfg:300
-#: A_New_Order/scenarios/20_Okladia.cfg:315
-#: A_New_Order/scenarios/20_Okladia.cfg:317
-#: A_New_Order/scenarios/20_Okladia.cfg:319
-#: A_New_Order/scenarios/20_Okladia.cfg:321
-#: A_New_Order/scenarios/20_Okladia.cfg:323
-#: A_New_Order/scenarios/20_Okladia.cfg:326
-#: A_New_Order/scenarios/20_Okladia.cfg:328
-#: A_New_Order/scenarios/20_Okladia.cfg:343
-#: A_New_Order/scenarios/20_Okladia.cfg:345
-#: A_New_Order/scenarios/20_Okladia.cfg:366
-#: A_New_Order/scenarios/20_Okladia.cfg:368
-#: A_New_Order/scenarios/20_Okladia.cfg:384
-#: A_New_Order/scenarios/20_Okladia.cfg:386
-#: A_New_Order/scenarios/20_Okladia.cfg:389
-#: A_New_Order/scenarios/20_Okladia.cfg:391
-#: A_New_Order/scenarios/20_Okladia.cfg:399
-#: A_New_Order/scenarios/20_Okladia.cfg:401
-#: A_New_Order/scenarios/20_Okladia.cfg:412
-#: A_New_Order/scenarios/20_Okladia.cfg:414
-#: A_New_Order/scenarios/20_Okladia.cfg:416
-#: A_New_Order/scenarios/20_Okladia.cfg:418
+#: A_New_Order/scenarios/20_Okladia.cfg:301
+#: A_New_Order/scenarios/20_Okladia.cfg:316
+#: A_New_Order/scenarios/20_Okladia.cfg:318
+#: A_New_Order/scenarios/20_Okladia.cfg:320
+#: A_New_Order/scenarios/20_Okladia.cfg:322
+#: A_New_Order/scenarios/20_Okladia.cfg:324
+#: A_New_Order/scenarios/20_Okladia.cfg:327
+#: A_New_Order/scenarios/20_Okladia.cfg:329
+#: A_New_Order/scenarios/20_Okladia.cfg:344
+#: A_New_Order/scenarios/20_Okladia.cfg:346
+#: A_New_Order/scenarios/20_Okladia.cfg:367
+#: A_New_Order/scenarios/20_Okladia.cfg:369
+#: A_New_Order/scenarios/20_Okladia.cfg:385
+#: A_New_Order/scenarios/20_Okladia.cfg:387
+#: A_New_Order/scenarios/20_Okladia.cfg:390
+#: A_New_Order/scenarios/20_Okladia.cfg:392
+#: A_New_Order/scenarios/20_Okladia.cfg:400
+#: A_New_Order/scenarios/20_Okladia.cfg:402
+#: A_New_Order/scenarios/20_Okladia.cfg:413
+#: A_New_Order/scenarios/20_Okladia.cfg:415
+#: A_New_Order/scenarios/20_Okladia.cfg:417
+#: A_New_Order/scenarios/20_Okladia.cfg:419
 #: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:217
 #: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:219
 #: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:231
@@ -4101,66 +4110,66 @@ msgid "Village leader"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/20_Okladia.cfg:277
+#: A_New_Order/scenarios/20_Okladia.cfg:278
 msgid "Thank you once again, noble Gaumhaldric! I've sent my daughter to safety. If not for you, she would still be imprisoned."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/20_Okladia.cfg:281
+#: A_New_Order/scenarios/20_Okladia.cfg:282
 msgid "Please accept this as modest sign of our gratitude."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/20_Okladia.cfg:284
+#: A_New_Order/scenarios/20_Okladia.cfg:285
 msgid "You have received $bride_gold_amt gold pieces."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/20_Okladia.cfg:293
+#: A_New_Order/scenarios/20_Okladia.cfg:294
 msgid "We are saved! Look who has come - it's Gaumhaldric the legendary!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/20_Okladia.cfg:295
+#: A_New_Order/scenarios/20_Okladia.cfg:296
 msgid "It's Gaumhaldric, this is true, but he is also Gawen Hagarthen, king of Vakladia, and as Haldric he is king of Wesnoth. Wait, did you say - `saved`?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/20_Okladia.cfg:297
+#: A_New_Order/scenarios/20_Okladia.cfg:298
 msgid "Well, yes, it's me, but why do you need to be saved?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/20_Okladia.cfg:299
+#: A_New_Order/scenarios/20_Okladia.cfg:300
 msgid "My lord, my daughter is the most beautiful girl in these parts. I knew this would bring woe upon us. An Akladian lord wanted her hand in marriage, and she foolishly refused."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/20_Okladia.cfg:300
+#: A_New_Order/scenarios/20_Okladia.cfg:301
 msgid "This Akladian lord, from Skagrrae clan, abducted her and swore to keep her imprisoned until she changed her mind. Please, free her!"
 msgstr ""
 
 #. [event]
 #. Lorin is about to say "underling" but catches herself:
-#: A_New_Order/scenarios/20_Okladia.cfg:302
+#: A_New_Order/scenarios/20_Okladia.cfg:303
 msgid "From your description she seems to be a girl with character, even for an under... anyway, we will release her, won't we, Gawen?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/20_Okladia.cfg:303
+#: A_New_Order/scenarios/20_Okladia.cfg:304
 msgid "Yes, of course, but first I want to ask few questions."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/20_Okladia.cfg:308
-#: A_New_Order/scenarios/20_Okladia.cfg:358
-#: A_New_Order/scenarios/20_Okladia.cfg:405
-#: A_New_Order/scenarios/13_Scouting.cfg:610
-#: A_New_Order/scenarios/13_Scouting.cfg:623
-#: A_New_Order/scenarios/13_Scouting.cfg:648
-#: A_New_Order/scenarios/13_Scouting.cfg:661
-#: A_New_Order/scenarios/13_Scouting.cfg:681
-#: A_New_Order/scenarios/13_Scouting.cfg:694
+#: A_New_Order/scenarios/20_Okladia.cfg:309
+#: A_New_Order/scenarios/20_Okladia.cfg:359
+#: A_New_Order/scenarios/20_Okladia.cfg:406
+#: A_New_Order/scenarios/13_Scouting.cfg:625
+#: A_New_Order/scenarios/13_Scouting.cfg:638
+#: A_New_Order/scenarios/13_Scouting.cfg:663
+#: A_New_Order/scenarios/13_Scouting.cfg:676
+#: A_New_Order/scenarios/13_Scouting.cfg:696
+#: A_New_Order/scenarios/13_Scouting.cfg:709
 #: A_New_Order/scenarios/14b_Bontom.cfg:554
 #: A_New_Order/scenarios/14b_Bontom.cfg:562
 #: A_New_Order/scenarios/14b_Bontom.cfg:606
@@ -4173,8 +4182,8 @@ msgid "Please, tell me..."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/20_Okladia.cfg:309
-#: A_New_Order/scenarios/20_Okladia.cfg:406
+#: A_New_Order/scenarios/20_Okladia.cfg:310
+#: A_New_Order/scenarios/20_Okladia.cfg:407
 #: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:223
 #: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:314
 #: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:375
@@ -4183,18 +4192,18 @@ msgid "Would you fight for me?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/20_Okladia.cfg:310
-#: A_New_Order/scenarios/20_Okladia.cfg:407
-#: A_New_Order/scenarios/21a_Abducted_Bride.cfg:580
+#: A_New_Order/scenarios/20_Okladia.cfg:311
+#: A_New_Order/scenarios/20_Okladia.cfg:408
+#: A_New_Order/scenarios/21a_Abducted_Bride.cfg:582
 #: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:376
 #: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:485
 msgid "Do you know something about the mage Deorien?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/20_Okladia.cfg:311
-#: A_New_Order/scenarios/20_Okladia.cfg:361
-#: A_New_Order/scenarios/20_Okladia.cfg:408
+#: A_New_Order/scenarios/20_Okladia.cfg:312
+#: A_New_Order/scenarios/20_Okladia.cfg:362
+#: A_New_Order/scenarios/20_Okladia.cfg:409
 #: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:226
 #: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:317
 #: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:378
@@ -4203,85 +4212,85 @@ msgid "Have you heard any interesting news recently?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/20_Okladia.cfg:315
+#: A_New_Order/scenarios/20_Okladia.cfg:316
 msgid "Hard and grueling times are ahead, I can't release anyone to join your army."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/20_Okladia.cfg:317
-#: A_New_Order/scenarios/20_Okladia.cfg:384
-#: A_New_Order/scenarios/20_Okladia.cfg:414
+#: A_New_Order/scenarios/20_Okladia.cfg:318
+#: A_New_Order/scenarios/20_Okladia.cfg:385
+#: A_New_Order/scenarios/20_Okladia.cfg:415
 msgid "Who?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/20_Okladia.cfg:318
+#: A_New_Order/scenarios/20_Okladia.cfg:319
 msgid "Deorien, the great mage."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/20_Okladia.cfg:319
+#: A_New_Order/scenarios/20_Okladia.cfg:320
 msgid "I don't know. Mages were all slaughtered by Akladians long time ago."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/20_Okladia.cfg:321
+#: A_New_Order/scenarios/20_Okladia.cfg:322
 msgid "Our king, Buffin, is gathering an army to invade the neighbouring kingdom of Vakladia."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/20_Okladia.cfg:322
+#: A_New_Order/scenarios/20_Okladia.cfg:323
 msgid "Take over Vakladia? How?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/20_Okladia.cfg:323
+#: A_New_Order/scenarios/20_Okladia.cfg:324
 msgid "The previous king of Vakladia is dead. Usually Akladian lords would elect a new Hagarthen for the throne, but their king left no heir. So they should pick a regent and then send for a Hagarthen from another country, but instead they're just fighting amongst themselves."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/20_Okladia.cfg:325
+#: A_New_Order/scenarios/20_Okladia.cfg:326
 msgid "Gawen Hagarthen is not dead, You see him now with your own eyes."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/20_Okladia.cfg:326
+#: A_New_Order/scenarios/20_Okladia.cfg:327
 msgid "No offense, but I don't care. You wanted news, so I repeated what I've heard."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/20_Okladia.cfg:328
+#: A_New_Order/scenarios/20_Okladia.cfg:329
 msgid "I've heard that Perien, king of Easkladia is besieged in his own capital by Wesnothians. Two brothers in Guilcorta, Luc and Gauri, are quarreling amongst themselves. Our king, Buffin, decided he would invite himself to Vakladia. He thinks none can oppose him."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/20_Okladia.cfg:329
+#: A_New_Order/scenarios/20_Okladia.cfg:330
 msgid "Interesting. Very, very interesting."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/20_Okladia.cfg:343
+#: A_New_Order/scenarios/20_Okladia.cfg:344
 msgid "It's you who defeated the ghosts, aren't you? We will always keep you in our memory."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/20_Okladia.cfg:345
+#: A_New_Order/scenarios/20_Okladia.cfg:346
 msgid "You've defeated the ghosts, then? We don't have much, but please accept this token of our gratitude."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/20_Okladia.cfg:348
+#: A_New_Order/scenarios/20_Okladia.cfg:349
 msgid "You have received $haunted_gold_amt gold pieces."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/20_Okladia.cfg:359
+#: A_New_Order/scenarios/20_Okladia.cfg:360
 msgid "Will you fight for me?"
 msgstr ""
 
 #. [event]
 #. [scenario]: id=21a_Abducted_Bride
-#: A_New_Order/scenarios/20_Okladia.cfg:360
+#: A_New_Order/scenarios/20_Okladia.cfg:361
 #: A_New_Order/scenarios/21a_Abducted_Bride.cfg:25
 #: A_New_Order/scenarios/21a_Abducted_Bride.cfg:55
 #: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:224
@@ -4290,284 +4299,284 @@ msgid "Do you know anything about the mage Deorien?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/20_Okladia.cfg:366
+#: A_New_Order/scenarios/20_Okladia.cfg:367
 msgid "There are no more people left here who can go with you."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/20_Okladia.cfg:368
+#: A_New_Order/scenarios/20_Okladia.cfg:369
 msgid "I can't, but there is one young man who would love to fight for you!"
 msgstr ""
 
 #. [unit]: type=Spearman, id=Gusto
-#: A_New_Order/scenarios/20_Okladia.cfg:373
+#: A_New_Order/scenarios/20_Okladia.cfg:374
 msgid "Gusto"
-msgstr ""
-
-#. [event]
-#: A_New_Order/scenarios/20_Okladia.cfg:385
-#: A_New_Order/scenarios/20_Okladia.cfg:415
-msgid "Deorien, a great mage."
 msgstr ""
 
 #. [event]
 #: A_New_Order/scenarios/20_Okladia.cfg:386
 #: A_New_Order/scenarios/20_Okladia.cfg:416
+msgid "Deorien, a great mage."
+msgstr ""
+
+#. [event]
+#: A_New_Order/scenarios/20_Okladia.cfg:387
+#: A_New_Order/scenarios/20_Okladia.cfg:417
 msgid "I don't know. Mages were all killed by Akladians long time ago."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/20_Okladia.cfg:389
+#: A_New_Order/scenarios/20_Okladia.cfg:390
 msgid "The greatest news is that you have defeated the ghosts which plagued the neighbourhood."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/20_Okladia.cfg:391
+#: A_New_Order/scenarios/20_Okladia.cfg:392
 msgid "There is a haunted place east from here. People who go there never come back. We don't know what happens to them."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/20_Okladia.cfg:399
+#: A_New_Order/scenarios/20_Okladia.cfg:400
 msgid "Our village is poor, we have no food, we have no gold, we..."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/20_Okladia.cfg:400
+#: A_New_Order/scenarios/20_Okladia.cfg:401
 msgid "I don't want your food or gold. I just want to ask you few questions."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/20_Okladia.cfg:401
+#: A_New_Order/scenarios/20_Okladia.cfg:402
 msgid "We live in terror. Terrible things have taken up residence in the ruins east from here. We are waiting for someone who can free us from fear."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/20_Okladia.cfg:412
+#: A_New_Order/scenarios/20_Okladia.cfg:413
 msgid "No, not really."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/20_Okladia.cfg:418
+#: A_New_Order/scenarios/20_Okladia.cfg:419
 msgid "There is a haunted place to the east. People who go there disappear. We don't know what happens to them."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/20_Okladia.cfg:436
-#: A_New_Order/scenarios/20_Okladia.cfg:445
-#: A_New_Order/scenarios/20_Okladia.cfg:455
-#: A_New_Order/scenarios/20_Okladia.cfg:463
-#: A_New_Order/scenarios/13_Scouting.cfg:714
-#: A_New_Order/scenarios/13_Scouting.cfg:724
-#: A_New_Order/scenarios/13_Scouting.cfg:735
-#: A_New_Order/scenarios/13_Scouting.cfg:743
+#: A_New_Order/scenarios/20_Okladia.cfg:437
+#: A_New_Order/scenarios/20_Okladia.cfg:446
+#: A_New_Order/scenarios/20_Okladia.cfg:456
+#: A_New_Order/scenarios/20_Okladia.cfg:464
+#: A_New_Order/scenarios/13_Scouting.cfg:729
+#: A_New_Order/scenarios/13_Scouting.cfg:739
+#: A_New_Order/scenarios/13_Scouting.cfg:750
+#: A_New_Order/scenarios/13_Scouting.cfg:758
 #: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:561
 #: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:569
 msgid "I would love to talk to..."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/20_Okladia.cfg:473
-#: A_New_Order/scenarios/13_Scouting.cfg:754
+#: A_New_Order/scenarios/20_Okladia.cfg:474
+#: A_New_Order/scenarios/13_Scouting.cfg:769
 msgid "Ruvio, please tell me.."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/20_Okladia.cfg:474
+#: A_New_Order/scenarios/20_Okladia.cfg:475
 #: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:579
 msgid "Why do you dislike Lorin?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/20_Okladia.cfg:475
+#: A_New_Order/scenarios/20_Okladia.cfg:476
 msgid "Tell me more about you and my mother."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/20_Okladia.cfg:476
+#: A_New_Order/scenarios/20_Okladia.cfg:477
 #: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:581
 msgid "Tell me about Karen"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/20_Okladia.cfg:479
+#: A_New_Order/scenarios/20_Okladia.cfg:480
 msgid "You must be kidding. That woman is so grating and harsh, I cannot understand why Yahyazad seems to have a crush on her."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/20_Okladia.cfg:481
+#: A_New_Order/scenarios/20_Okladia.cfg:482
 msgid "There's not much to talk about. I told you she was my fiancée. But a few days before our wedding... Gawen, please, don't ask me. It's too painful."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/20_Okladia.cfg:482
+#: A_New_Order/scenarios/20_Okladia.cfg:483
 msgid "But you have a wife now, and you love her, don't you?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/20_Okladia.cfg:483
+#: A_New_Order/scenarios/20_Okladia.cfg:484
 msgid "Yes. I love my wife, and my daughters. But sometimes, just sometimes... I feel like I've betrayed my first love."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/20_Okladia.cfg:485
+#: A_New_Order/scenarios/20_Okladia.cfg:486
 #: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:592
 msgid "Well, she is my oldest daughter. From her youth she always wanted to be a great fighter, and she always tried to be the best."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/20_Okladia.cfg:486
+#: A_New_Order/scenarios/20_Okladia.cfg:487
 #: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:593
 msgid "I'm kind of surprised that she is not here with us."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/20_Okladia.cfg:487
+#: A_New_Order/scenarios/20_Okladia.cfg:488
 #: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:594
 msgid "I ordered Karl to tie her up and lock her room. I think that gave us enough time to escape. This journey is really too dangerous for her. I hope she will remain safe in Freetown."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/20_Okladia.cfg:492
-#: A_New_Order/scenarios/20_Okladia.cfg:496
+#: A_New_Order/scenarios/20_Okladia.cfg:493
+#: A_New_Order/scenarios/20_Okladia.cfg:497
 #: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:598
 msgid "Hey Reme, what's going on?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/20_Okladia.cfg:493
+#: A_New_Order/scenarios/20_Okladia.cfg:494
 msgid "An alliance with a mage is a disturbing concept, my lord. But I shall try to adjust."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/20_Okladia.cfg:494
+#: A_New_Order/scenarios/20_Okladia.cfg:495
 #: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:601
 msgid "Nice to hear that."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/20_Okladia.cfg:497
+#: A_New_Order/scenarios/20_Okladia.cfg:498
 msgid "I'm not quite sure. Many people, are starting to hail you as the messiah. You could become king of all Wesnoth and the religious leader of our people."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/20_Okladia.cfg:498
+#: A_New_Order/scenarios/20_Okladia.cfg:499
 msgid "Don't worry about that. You will always be my friend."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/20_Okladia.cfg:501
+#: A_New_Order/scenarios/20_Okladia.cfg:502
 #: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:604
 msgid "Mother, what's going on?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/20_Okladia.cfg:504
+#: A_New_Order/scenarios/20_Okladia.cfg:505
 #: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:606
 msgid "Mother? I thought you said I was not your real mother?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/20_Okladia.cfg:505
+#: A_New_Order/scenarios/20_Okladia.cfg:506
 #: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:607
 msgid "I'm sorry. I was really angry."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/20_Okladia.cfg:510
-#: A_New_Order/scenarios/13_Scouting.cfg:829
+#: A_New_Order/scenarios/20_Okladia.cfg:511
+#: A_New_Order/scenarios/13_Scouting.cfg:844
 #: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:613
 #: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:621
 msgid "Mother, can I have a word with you?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/20_Okladia.cfg:511
+#: A_New_Order/scenarios/20_Okladia.cfg:512
 msgid "Why do you want to kill Deorien?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/20_Okladia.cfg:512
+#: A_New_Order/scenarios/20_Okladia.cfg:513
 msgid "Why have you been so upset recently?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/20_Okladia.cfg:513
-#: A_New_Order/scenarios/20_Okladia.cfg:530
-#: A_New_Order/scenarios/13_Scouting.cfg:825
-#: A_New_Order/scenarios/13_Scouting.cfg:833
+#: A_New_Order/scenarios/20_Okladia.cfg:514
+#: A_New_Order/scenarios/20_Okladia.cfg:531
+#: A_New_Order/scenarios/13_Scouting.cfg:840
+#: A_New_Order/scenarios/13_Scouting.cfg:848
 #: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:617
 #: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:624
 msgid "Never mind"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/20_Okladia.cfg:517
+#: A_New_Order/scenarios/20_Okladia.cfg:518
 msgid "Deorien is a mage. Mages deserve to be killed. It is that simple."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/20_Okladia.cfg:519
+#: A_New_Order/scenarios/20_Okladia.cfg:520
 msgid "Please, do not ask. I am starting to regret something I have done. Sometimes I am so happy about it... and yet I know I should have no hope, but still, sometimes..."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/20_Okladia.cfg:520
+#: A_New_Order/scenarios/20_Okladia.cfg:521
 #: A_New_Order/scenarios/15_Back_in_Freetown.cfg:187
 msgid "I don't understand."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/20_Okladia.cfg:521
+#: A_New_Order/scenarios/20_Okladia.cfg:522
 msgid "Neither do I, Gawen. Neither do I."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/20_Okladia.cfg:526
+#: A_New_Order/scenarios/20_Okladia.cfg:527
 msgid "Deorien, can I have a word with you?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/20_Okladia.cfg:527
+#: A_New_Order/scenarios/20_Okladia.cfg:528
 msgid "Why did you wait until I came to you?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/20_Okladia.cfg:528
+#: A_New_Order/scenarios/20_Okladia.cfg:529
 msgid "What are your plans for the future?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/20_Okladia.cfg:529
+#: A_New_Order/scenarios/20_Okladia.cfg:530
 msgid "If Oracle is so respected by Akladians, why does not she simply declare Akladians should love Wesnothians?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/20_Okladia.cfg:533
+#: A_New_Order/scenarios/20_Okladia.cfg:534
 msgid "Why did you and the Oracle wait until I came to Weldyn? Why didn't you declare me messiah before?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/20_Okladia.cfg:534
+#: A_New_Order/scenarios/20_Okladia.cfg:535
 msgid "Because I wasn't sure whether you were the right person. I had to see you in person to decide. Besides, you had to make a name for yourself on your own. You had to become well-known amongst both Akladians and Wesnothians. A year ago you were a boy without a name; now that name has been earned with your own sword."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/20_Okladia.cfg:536
+#: A_New_Order/scenarios/20_Okladia.cfg:537
 msgid "We will declare you king of Wesnoth and Vakladia, and messiah. As the messiah you will become ruler of all Akladians. I hope both Akladians and Wesnothians will back you. Then we will defeat the orcs and any Akladians who still oppose you. Finally, we will stop Grekulak's invasion."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/20_Okladia.cfg:538
+#: A_New_Order/scenarios/20_Okladia.cfg:539
 msgid "Because some things may be spoken only when listener is prepared to listen. You see, young king, I don't know why Akladians respect and listen to Oracle. But I think it may be because what she says does not openly contradict their beliefs. I believe they would quickly declare her a tool of false God once they would stop to like what she tells them."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/20_Okladia.cfg:539
+#: A_New_Order/scenarios/20_Okladia.cfg:540
 msgid "Then why do you think they won't ignore what she tells them now?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/20_Okladia.cfg:540
+#: A_New_Order/scenarios/20_Okladia.cfg:541
 msgid "Because Akladians are in a desperate position. I think most of them, deep in their hearts, want changes --- but at the same time, they seem to be unable to admit that. Mind you, I may be wrong; but I think they simply need someone to tell them they must change."
 msgstr ""
 
@@ -4782,7 +4791,7 @@ msgstr ""
 #: A_New_Order/scenarios/15b_Repelling_the_Orcs.cfg:92
 #: A_New_Order/scenarios/21b_Haunted_Place.cfg:184
 #: A_New_Order/scenarios/21b_Haunted_Place.cfg:209
-#: A_New_Order/scenarios/19c_The_Oracle.cfg:1558
+#: A_New_Order/scenarios/19c_The_Oracle.cfg:1588
 #: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:492
 #: A_New_Order/scenarios/27_Orannon.cfg:738
 #: A_New_Order/scenarios/27_Orannon.cfg:1139
@@ -4792,9 +4801,9 @@ msgstr ""
 
 #. [objective]: condition=lose
 #: A_New_Order/scenarios/25_The_Awakening.cfg:752
-#: A_New_Order/scenarios/21a_Abducted_Bride.cfg:403
+#: A_New_Order/scenarios/21a_Abducted_Bride.cfg:404
 #: A_New_Order/scenarios/23_Trapped.cfg:909
-#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:476
+#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:477
 #: A_New_Order/scenarios/21b_Haunted_Place.cfg:200
 #: A_New_Order/scenarios/27_Orannon.cfg:750
 #: A_New_Order/scenarios/27_Orannon.cfg:1151
@@ -4817,12 +4826,12 @@ msgstr ""
 #. this string is both the usual "time over" message, and a fakeout here in S22:
 #: A_New_Order/scenarios/25_The_Awakening.cfg:869
 #: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:964
-#: A_New_Order/scenarios/21a_Abducted_Bride.cfg:547
-#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:856
-#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:929
+#: A_New_Order/scenarios/21a_Abducted_Bride.cfg:549
+#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:857
+#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:930
 #: A_New_Order/scenarios/19a_The_Woods_of_Okladia.cfg:314
 #: A_New_Order/scenarios/19b_Entering_Okladia.cfg:304
-#: A_New_Order/scenarios/19c_The_Oracle.cfg:1813
+#: A_New_Order/scenarios/19c_The_Oracle.cfg:1846
 #: A_New_Order/scenarios/08_Outlaw_Base.cfg:591
 msgid "All is lost! Enemy reinforcements have arrived! We have no chance to win now!"
 msgstr ""
@@ -5121,373 +5130,373 @@ msgid "Scouting"
 msgstr ""
 
 #. [part]
-#: A_New_Order/scenarios/13_Scouting.cfg:21
+#: A_New_Order/scenarios/13_Scouting.cfg:36
 msgid "After leaving the Forest of Raedwood, Gawen and his companions found themselves faced with a problem: what to do next and how to fulfill the request of Mithrandil. Gawen wasn't sure what it meant to 'find the real reason behind the Akladian-Orcish alliance' and definitely had no idea how to accomplish that."
 msgstr ""
 
 #. [part]
 #. Spoken by Lorin
-#: A_New_Order/scenarios/13_Scouting.cfg:26
+#: A_New_Order/scenarios/13_Scouting.cfg:41
 msgid "I am still confused. When I saw Gawen, at first I did not recognize him. He had changed from the last time I saw him. He was just a kid then, but now he looks more like a young man... an amazing change in just a few months."
 msgstr ""
 
 #. [part]
-#: A_New_Order/scenarios/13_Scouting.cfg:30
+#: A_New_Order/scenarios/13_Scouting.cfg:45
 msgid "...and now he keeps the company of underlings... an underling child who tries to behave like a woman, an underling man who looks like a veteran of many battles, underling soldiers, and even worse: elves. The green devils. But since I have been amongst underlings for months myself, this moves me much less than I would have thought."
 msgstr ""
 
 #. [part]
-#: A_New_Order/scenarios/13_Scouting.cfg:34
+#: A_New_Order/scenarios/13_Scouting.cfg:49
 msgid "Looking at him, I keep on thinking about what the oracle once told me; I am starting to dread those thoughts. When his father died, I thought that everything - well, almost everything - the Oracle had told me were lies, but now... now I am scared and I try not to think about it. But it keeps coming back."
 msgstr ""
 
 #. [part]
-#: A_New_Order/scenarios/13_Scouting.cfg:39
+#: A_New_Order/scenarios/13_Scouting.cfg:54
 msgid "Gawen ordered his soldiers to march quickly to the temporary base that had been established in the plains north of Barnon. He was afraid that more enemy forces would arrive, and wanted to tend to his wounded."
 msgstr ""
 
 #. [part]
-#: A_New_Order/scenarios/13_Scouting.cfg:43
+#: A_New_Order/scenarios/13_Scouting.cfg:58
 msgid "Fighting in the swamps of Saorduc had not made anyone happy and Gawen's soldiers were delighted to leave the frozen fens. They were all mired in a strange mix of mud and snow, and this was not improving their mood."
 msgstr ""
 
 #. [part]
-#: A_New_Order/scenarios/13_Scouting.cfg:47
+#: A_New_Order/scenarios/13_Scouting.cfg:62
 msgid "After seeing the atrocities committed by the orcs, Gawen's soldiers were unusually silent. None joked nor sang, as had been the norm after their last few battles. Each seemed to be thinking about their own families, their wives and children."
 msgstr ""
 
 #. [part]
 #. Spoken by Reme Carrenemoe
-#: A_New_Order/scenarios/13_Scouting.cfg:53
+#: A_New_Order/scenarios/13_Scouting.cfg:68
 msgid "I am finally free! I still can hardly believe it. Not only am I free, but also Gawen, my king, is alive. It is a very real relief for me; the thought that I had abandoned him during the Battle of Barnon has haunted me for weeks now."
 msgstr ""
 
 #. [part]
-#: A_New_Order/scenarios/13_Scouting.cfg:58
+#: A_New_Order/scenarios/13_Scouting.cfg:73
 msgid "I am surprised that he is surrounded by Underlings. But then, Gawen has demanded that I should never use that word again, that I should start to think of them as 'Wesnothians'. I think the girl with red hair has a crush on Gawen, and despite Lorin calling her 'a mite of a child' she is a woman already, and quite pretty."
 msgstr ""
 
 #. [part]
-#: A_New_Order/scenarios/13_Scouting.cfg:62
+#: A_New_Order/scenarios/13_Scouting.cfg:77
 msgid "I am surprised that he is surrounded by Underlings. But then, Gawen has demanded that I should never use that word again, that I should start to think of them as 'Wesnothians'. I think the girl with red hair has a crush on Gawen, and despite her youth, she is a woman already, and quite pretty."
 msgstr ""
 
 #. [part]
-#: A_New_Order/scenarios/13_Scouting.cfg:67
+#: A_New_Order/scenarios/13_Scouting.cfg:82
 msgid "Failing to save Reme left Gawen feeling devastated. The news about Reme's death reached Gawen's temporary base soon after, throwing all into a somber melancholy."
 msgstr ""
 
 #. [part]
-#: A_New_Order/scenarios/13_Scouting.cfg:82
-#: A_New_Order/scenarios/13_Scouting.cfg:88
+#: A_New_Order/scenarios/13_Scouting.cfg:97
+#: A_New_Order/scenarios/13_Scouting.cfg:103
 msgid "Bitter and depressed, having failed to interrogate a single orc leader who knew anything of substance, Gawen and his troops headed home toward Freetown. Along the way, they found a near-frozen orc, dying in the snow. 'Grekulak', it said, and then expired."
 msgstr ""
 
 #. [part]
-#: A_New_Order/scenarios/13_Scouting.cfg:102
+#: A_New_Order/scenarios/13_Scouting.cfg:117
 msgid "Rob Roe was not amongst Gawen's soldiers. He disappeared one night and no one, not even the outlaws in Gawen's army, knew the reasons of Roe's sudden disappearance. Outlaws were startled by the event and many of them refused to follow Gawen's orders any more."
 msgstr ""
 
 #. [scenario]: id=13_Scouting
-#: A_New_Order/scenarios/13_Scouting.cfg:112
+#: A_New_Order/scenarios/13_Scouting.cfg:127
 msgid "I've seen a lot of orcs lately. They are going here and there, and have been surprisingly disciplined and well-behaved considering what I've heard about orcs. Well, yes, they killed and ate three of our cows and took our only horse, but that's what one can expect from any soldiers. Some orcish unit is garrisoned near Barnon, south from here."
 msgstr ""
 
 #. [scenario]: id=13_Scouting
-#: A_New_Order/scenarios/13_Scouting.cfg:114
-#: A_New_Order/scenarios/13_Scouting.cfg:211
+#: A_New_Order/scenarios/13_Scouting.cfg:129
+#: A_New_Order/scenarios/13_Scouting.cfg:226
 msgid "Reme? No, I have not heard about him."
 msgstr ""
 
 #. [scenario]: id=13_Scouting
-#: A_New_Order/scenarios/13_Scouting.cfg:117
+#: A_New_Order/scenarios/13_Scouting.cfg:132
 msgid "Bontom? Of course I know about it. It is a nice place a little bit west from here! My wife is from that area."
 msgstr ""
 
 #. [event]
 #. [scenario]: id=13_Scouting
 #. [scenario]: id=14b_Bontom
-#: A_New_Order/scenarios/13_Scouting.cfg:370
-#: A_New_Order/scenarios/13_Scouting.cfg:142
+#: A_New_Order/scenarios/13_Scouting.cfg:385
+#: A_New_Order/scenarios/13_Scouting.cfg:157
 #: A_New_Order/scenarios/14b_Bontom.cfg:3
 msgid "Bontom"
 msgstr ""
 
 #. [scenario]: id=13_Scouting
-#: A_New_Order/scenarios/13_Scouting.cfg:150
+#: A_New_Order/scenarios/13_Scouting.cfg:165
 msgid "No offense, but you've already asked me that question."
 msgstr ""
 
 #. [scenario]: id=13_Scouting
-#: A_New_Order/scenarios/13_Scouting.cfg:153
+#: A_New_Order/scenarios/13_Scouting.cfg:168
 msgid "Well, and what do you propose in exchange?"
 msgstr ""
 
 #. [scenario]: id=13_Scouting
 #. [message]: speaker=Lady Lorin
-#: A_New_Order/scenarios/13_Scouting.cfg:154
+#: A_New_Order/scenarios/13_Scouting.cfg:169
 #: A_New_Order/scenarios/09_Hired_Swords.cfg:498
 msgid "What about this:"
 msgstr ""
 
 #. [scenario]: id=13_Scouting
-#: A_New_Order/scenarios/13_Scouting.cfg:155
+#: A_New_Order/scenarios/13_Scouting.cfg:170
 msgid "If not, I will burn down this village."
 msgstr ""
 
 #. [scenario]: id=13_Scouting
-#: A_New_Order/scenarios/13_Scouting.cfg:156
+#: A_New_Order/scenarios/13_Scouting.cfg:171
 msgid "I will pay you in gold."
 msgstr ""
 
 #. [scenario]: id=13_Scouting
-#: A_New_Order/scenarios/13_Scouting.cfg:157
+#: A_New_Order/scenarios/13_Scouting.cfg:172
 msgid "A chance to fight against orcs and Akladians."
 msgstr ""
 
 #. [scenario]: id=13_Scouting
-#: A_New_Order/scenarios/13_Scouting.cfg:160
+#: A_New_Order/scenarios/13_Scouting.cfg:175
 msgid "No offense, but I value my life more than gold."
 msgstr ""
 
 #. [scenario]: id=13_Scouting
-#: A_New_Order/scenarios/13_Scouting.cfg:162
+#: A_New_Order/scenarios/13_Scouting.cfg:177
 msgid "That is supposed to convince me?!? Go away, little butcher. I will talk to you no more!"
 msgstr ""
 
 #. [scenario]: id=13_Scouting
-#: A_New_Order/scenarios/13_Scouting.cfg:165
+#: A_New_Order/scenarios/13_Scouting.cfg:180
 msgid "And this is a good reason, because...?"
 msgstr ""
 
 #. [scenario]: id=13_Scouting
-#: A_New_Order/scenarios/13_Scouting.cfg:167
+#: A_New_Order/scenarios/13_Scouting.cfg:182
 msgid "You may have some fun!"
 msgstr ""
 
 #. [scenario]: id=13_Scouting
-#: A_New_Order/scenarios/13_Scouting.cfg:168
+#: A_New_Order/scenarios/13_Scouting.cfg:183
 msgid "You will earn some gold in process!"
 msgstr ""
 
 #. [scenario]: id=13_Scouting
-#: A_New_Order/scenarios/13_Scouting.cfg:169
+#: A_New_Order/scenarios/13_Scouting.cfg:184
 msgid "People unwilling to fight for freedom aren't worthy of it. Are you?"
 msgstr ""
 
 #. [scenario]: id=13_Scouting
-#: A_New_Order/scenarios/13_Scouting.cfg:170
+#: A_New_Order/scenarios/13_Scouting.cfg:185
 msgid "What, are you a coward? Afraid of a few orcs?"
 msgstr ""
 
 #. [scenario]: id=13_Scouting
-#: A_New_Order/scenarios/13_Scouting.cfg:174
+#: A_New_Order/scenarios/13_Scouting.cfg:189
 msgid "Well... yes, why not? One of our boys can really handle a bow. You might have some use for him."
 msgstr ""
 
 #. [unit]: type=Bowman, id=Ringo
 #. I guess because the default Bowman portrait looks kinda like Ringo Starr of the Beatles?
-#: A_New_Order/scenarios/13_Scouting.cfg:179
+#: A_New_Order/scenarios/13_Scouting.cfg:194
 msgid "Ringo"
 msgstr ""
 
 #. [scenario]: id=13_Scouting
-#: A_New_Order/scenarios/13_Scouting.cfg:189
+#: A_New_Order/scenarios/13_Scouting.cfg:204
 msgid "Ha, ha, and I thought you were serious."
 msgstr ""
 
 #. [scenario]: id=13_Scouting
-#: A_New_Order/scenarios/13_Scouting.cfg:204
+#: A_New_Order/scenarios/13_Scouting.cfg:219
 msgid "Orcs? They were here, but they left in hurry. They were pillaging villages to the east of us. They were headed for a place called Haeltin, and I've heard they were defeated there by some woman."
 msgstr ""
 
 #. [scenario]: id=13_Scouting
-#: A_New_Order/scenarios/13_Scouting.cfg:206
+#: A_New_Order/scenarios/13_Scouting.cfg:221
 msgid "Some woman? SOME WOMAN? That freckled kid might be SOME woman when she grows up, but not me. I am a Lady, LADY Lorin!"
 msgstr ""
 
 #. [scenario]: id=13_Scouting
-#: A_New_Order/scenarios/13_Scouting.cfg:208
+#: A_New_Order/scenarios/13_Scouting.cfg:223
 msgid "Ah, that must be that 'She-wolf of Haeltin' you mentioned, Ruvio. Will have to meet her."
 msgstr ""
 
 #. [scenario]: id=13_Scouting
-#: A_New_Order/scenarios/13_Scouting.cfg:213
+#: A_New_Order/scenarios/13_Scouting.cfg:228
 msgid "Bontom? It is somewhere in the south-west. I think. In one of the villages south of here people might know more about its exact location."
 msgstr ""
 
 #. [scenario]: id=13_Scouting
-#: A_New_Order/scenarios/13_Scouting.cfg:215
+#: A_New_Order/scenarios/13_Scouting.cfg:230
 msgid "If I were younger, then I might have said yes, why not, but I am really too old for adventure seeking now."
 msgstr ""
 
 #. [scenario]: id=13_Scouting
-#: A_New_Order/scenarios/13_Scouting.cfg:227
+#: A_New_Order/scenarios/13_Scouting.cfg:242
 msgid "Orcs? Da orcs were in plains pillagin' and burnin'. They are big and bad and you should avoid them, boy."
 msgstr ""
 
 #. [scenario]: id=13_Scouting
-#: A_New_Order/scenarios/13_Scouting.cfg:229
+#: A_New_Order/scenarios/13_Scouting.cfg:244
 msgid "Reme? What is Reme? Some kind of food?"
 msgstr ""
 
 #. [scenario]: id=13_Scouting
-#: A_New_Order/scenarios/13_Scouting.cfg:230
+#: A_New_Order/scenarios/13_Scouting.cfg:245
 msgid "No, no, it's one of the Akladian lords, who..."
 msgstr ""
 
 #. [scenario]: id=13_Scouting
-#: A_New_Order/scenarios/13_Scouting.cfg:231
+#: A_New_Order/scenarios/13_Scouting.cfg:246
 msgid "Oh, Akladian lords, yeah, I've heard about them. They are big and bad and you should avoid them, boy."
 msgstr ""
 
 #. [scenario]: id=13_Scouting
-#: A_New_Order/scenarios/13_Scouting.cfg:233
+#: A_New_Order/scenarios/13_Scouting.cfg:248
 msgid "A place called Bontom? Yeah, I've heard about that. It's somewhere in the south; maybe people living in villages more to the south would know more about it."
 msgstr ""
 
 #. [scenario]: id=13_Scouting
-#: A_New_Order/scenarios/13_Scouting.cfg:236
+#: A_New_Order/scenarios/13_Scouting.cfg:251
 msgid "I'm too old ta be leavin' my village, and the one boy who wanted to search for adventures already joined you."
 msgstr ""
 
 #. [scenario]: id=13_Scouting
-#: A_New_Order/scenarios/13_Scouting.cfg:238
+#: A_New_Order/scenarios/13_Scouting.cfg:253
 msgid "I'm too old ta be leavin my village, but there is one boy who could fight for you, why not."
 msgstr ""
 
 #. [scenario]: id=13_Scouting
-#: A_New_Order/scenarios/13_Scouting.cfg:240
+#: A_New_Order/scenarios/13_Scouting.cfg:255
 msgid "One of local peasants joins your army. It's an untrained but LOYAL, STRONG, and RESILIENT unit."
 msgstr ""
 
 #. [unit]: type=Peasant, id=John the Baldhead
-#: A_New_Order/scenarios/13_Scouting.cfg:247
+#: A_New_Order/scenarios/13_Scouting.cfg:262
 msgid "John the Baldhead"
 msgstr ""
 
 #. [scenario]: id=13_Scouting
-#: A_New_Order/scenarios/13_Scouting.cfg:272
+#: A_New_Order/scenarios/13_Scouting.cfg:287
 msgid "Now that we know where your friend Reme is, we can go to that Bontom place the peasants told us about."
 msgstr ""
 
 #. [scenario]: id=13_Scouting
-#: A_New_Order/scenarios/13_Scouting.cfg:274
+#: A_New_Order/scenarios/13_Scouting.cfg:289
 msgid "I guess we could ask peasants whether they know something about this Bontom place, where your friend Reme is being kept."
 msgstr ""
 
 #. [event]
 #. [scenario]: id=13_Scouting
-#: A_New_Order/scenarios/13_Scouting.cfg:411
-#: A_New_Order/scenarios/13_Scouting.cfg:415
-#: A_New_Order/scenarios/13_Scouting.cfg:280
+#: A_New_Order/scenarios/13_Scouting.cfg:426
+#: A_New_Order/scenarios/13_Scouting.cfg:430
+#: A_New_Order/scenarios/13_Scouting.cfg:295
 msgid "We already know what we were sent to find out. We should return to Freetown now."
 msgstr ""
 
 #. [scenario]: id=13_Scouting
-#: A_New_Order/scenarios/13_Scouting.cfg:282
+#: A_New_Order/scenarios/13_Scouting.cfg:297
 msgid "But we never found out what happened to Reme."
 msgstr ""
 
 #. [scenario]: id=13_Scouting
-#: A_New_Order/scenarios/13_Scouting.cfg:285
+#: A_New_Order/scenarios/13_Scouting.cfg:300
 msgid "We had our chance to rescue him in Bontom, but we failed to do so..."
 msgstr ""
 
 #. [scenario]: id=13_Scouting
-#: A_New_Order/scenarios/13_Scouting.cfg:287
+#: A_New_Order/scenarios/13_Scouting.cfg:302
 msgid "Well, I guess we could still check that Bontom place the peasants told us about."
 msgstr ""
 
 #. [scenario]: id=13_Scouting
-#: A_New_Order/scenarios/13_Scouting.cfg:290
+#: A_New_Order/scenarios/13_Scouting.cfg:305
 msgid "Well, I guess we could still try to find out where this Bontom place is where your friend Reme is being kept."
 msgstr ""
 
 #. [scenario]: id=13_Scouting
-#: A_New_Order/scenarios/13_Scouting.cfg:292
+#: A_New_Order/scenarios/13_Scouting.cfg:307
 msgid "I don't think there's anything we can do about that at this point..."
 msgstr ""
 
 #. [scenario]: id=13_Scouting
-#: A_New_Order/scenarios/13_Scouting.cfg:298
+#: A_New_Order/scenarios/13_Scouting.cfg:313
 msgid "We've already searched for answers in the city of Barnon."
 msgstr ""
 
 #. [scenario]: id=13_Scouting
-#: A_New_Order/scenarios/13_Scouting.cfg:300
+#: A_New_Order/scenarios/13_Scouting.cfg:315
 msgid "My lord, from here we may explore a few possibilities. To the south, there is city of Barnon. It would definitely be very dangerous to go there, but..."
 msgstr ""
 
 #. [scenario]: id=13_Scouting
-#: A_New_Order/scenarios/13_Scouting.cfg:301
+#: A_New_Order/scenarios/13_Scouting.cfg:316
 msgid "...but we could probably find something about orcs there, right?"
 msgstr ""
 
 #. [scenario]: id=13_Scouting
-#: A_New_Order/scenarios/13_Scouting.cfg:304
+#: A_New_Order/scenarios/13_Scouting.cfg:319
 msgid "We already went west to Haeltin. That was where your step-mother was, remember? That she was the 'She-wolf' really surprised me."
 msgstr ""
 
 #. [scenario]: id=13_Scouting
-#: A_New_Order/scenarios/13_Scouting.cfg:306
+#: A_New_Order/scenarios/13_Scouting.cfg:321
 msgid "We've heard that some woman, known by the nickname 'The She-wolf of Haeltin', was besieged by the orcs and she was able to repel them. Haeltin is west from here. It would be easy to go to her and ask her a few questions."
 msgstr ""
 
 #. [scenario]: id=13_Scouting
-#: A_New_Order/scenarios/13_Scouting.cfg:311
+#: A_New_Order/scenarios/13_Scouting.cfg:326
 msgid "We could also go for the swamps."
 msgstr ""
 
 #. [scenario]: id=13_Scouting
-#: A_New_Order/scenarios/13_Scouting.cfg:312
+#: A_New_Order/scenarios/13_Scouting.cfg:327
 msgid "We could, but saurians live in the swamps of Saorduc, and they rarely go outside of their mud. I doubt they would know anything useful. There are also some villages here, you could go and ask peasants, maybe they would know something."
 msgstr ""
 
 #. [scenario]: id=13_Scouting
-#: A_New_Order/scenarios/13_Scouting.cfg:317
+#: A_New_Order/scenarios/13_Scouting.cfg:332
 msgid "Frankly, I have no idea what to do now. We have already searched all of the obvious locations."
 msgstr ""
 
 #. [scenario]: id=13_Scouting
 #. [scenario]: id=18_Start_of_the_Quest
-#: A_New_Order/scenarios/13_Scouting.cfg:346
+#: A_New_Order/scenarios/13_Scouting.cfg:361
 #: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:73
 msgid "Raedwood Forest"
 msgstr ""
 
 #. [scenario]: id=13_Scouting
-#: A_New_Order/scenarios/13_Scouting.cfg:347
+#: A_New_Order/scenarios/13_Scouting.cfg:362
 msgid "To Freetown"
 msgstr ""
 
 #. [scenario]: id=13_Scouting
-#: A_New_Order/scenarios/13_Scouting.cfg:348
+#: A_New_Order/scenarios/13_Scouting.cfg:363
 msgid "To Haeltin"
 msgstr ""
 
 #. [scenario]: id=13_Scouting
-#: A_New_Order/scenarios/13_Scouting.cfg:349
+#: A_New_Order/scenarios/13_Scouting.cfg:364
 msgid "To Saorduc swamps"
 msgstr ""
 
 #. [scenario]: id=13_Scouting
-#: A_New_Order/scenarios/13_Scouting.cfg:350
+#: A_New_Order/scenarios/13_Scouting.cfg:365
 msgid "To Barnon"
 msgstr ""
 
 #. [scenario]: id=13_Scouting
-#: A_New_Order/scenarios/13_Scouting.cfg:351
+#: A_New_Order/scenarios/13_Scouting.cfg:366
 msgid "Hyeton"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:437
+#: A_New_Order/scenarios/13_Scouting.cfg:452
 msgid "It is extremely important to everyone to remember not to refer to Gawen by his real name. Always call him Gaumhaldric."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:438
+#: A_New_Order/scenarios/13_Scouting.cfg:453
 #: A_New_Order/scenarios/15a_The_Preparations.cfg:287
 #: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:466
 #: A_New_Order/scenarios/14b_Bontom.cfg:659
@@ -5498,600 +5507,600 @@ msgid "Why?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:439
+#: A_New_Order/scenarios/13_Scouting.cfg:454
 msgid "First of all, because our people at Freetown aren't ready to have an Akladian leader. Second, because Bor Cryne would send his entire army to pursue us if he heard so much as a whisper of the name Gawen Hagarthen."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:440
+#: A_New_Order/scenarios/13_Scouting.cfg:455
 msgid "Gaumhaldric... so, is this why my son is not shaving? He wants to hide his real identity under a beard?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:441
+#: A_New_Order/scenarios/13_Scouting.cfg:456
 msgid "No, no, no. He HAS to have a beard. All of our great Wesnothian kings had beards!"
 msgstr ""
 
 #. [message]: speaker=Kyobaine
-#: A_New_Order/scenarios/13_Scouting.cfg:453
+#: A_New_Order/scenarios/13_Scouting.cfg:468
 msgid "Do you like my clothes?"
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/13_Scouting.cfg:461
+#: A_New_Order/scenarios/13_Scouting.cfg:476
 msgid "Yes."
 msgstr ""
 
 #. [else]
 #. debug message only for developers; ok to skip translating:
-#: A_New_Order/scenarios/13_Scouting.cfg:465
+#: A_New_Order/scenarios/13_Scouting.cfg:480
 msgid "Darn it, it looks like the [found_item] tag doesn't work across scenarios..."
 msgstr ""
 
 #. [objectives]
-#: A_New_Order/scenarios/13_Scouting.cfg:475
+#: A_New_Order/scenarios/13_Scouting.cfg:490
 msgid "This is a large-scale map, where you may choose a way to go. Move Gawen to a signpost or any other location to move to a new scenario. Move Gawen to the tent to talk with his friends."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:505
+#: A_New_Order/scenarios/13_Scouting.cfg:520
 msgid "My lord, we cannot go back to Freetown. We have nothing to report, and we have not found anything about the orcs."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:508
+#: A_New_Order/scenarios/13_Scouting.cfg:523
 msgid "My lord, I do not think we should go back to Freetown already. We haven't met with the She-wolf of Haeltin west of here. She may have some great insight, having fought with orcs already."
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/13_Scouting.cfg:522
+#: A_New_Order/scenarios/13_Scouting.cfg:537
 msgid "We were in Haeltin already. Where would you like to go now?"
 msgstr ""
 
 #. [else]
-#: A_New_Order/scenarios/13_Scouting.cfg:526
+#: A_New_Order/scenarios/13_Scouting.cfg:541
 msgid "Are you sure you want to go there?"
 msgstr ""
 
 #. [else]
-#: A_New_Order/scenarios/13_Scouting.cfg:532
+#: A_New_Order/scenarios/13_Scouting.cfg:547
 msgid "As you wish, my lord."
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/13_Scouting.cfg:546
+#: A_New_Order/scenarios/13_Scouting.cfg:561
 msgid "We already were in Saorduc. Where to now?"
 msgstr ""
 
 #. [else]
-#: A_New_Order/scenarios/13_Scouting.cfg:550
+#: A_New_Order/scenarios/13_Scouting.cfg:565
 msgid "Are you sure you want to go there? I've told you that I doubt Saurians know anything useful."
 msgstr ""
 
 #. [else]
-#: A_New_Order/scenarios/13_Scouting.cfg:555
-#: A_New_Order/scenarios/13_Scouting.cfg:557
+#: A_New_Order/scenarios/13_Scouting.cfg:570
+#: A_New_Order/scenarios/13_Scouting.cfg:572
 msgid "So, on to Saorduc! Hopefully it is a wise decision and lizard men know something about orcs."
 msgstr ""
 
 #. [else]
-#: A_New_Order/scenarios/13_Scouting.cfg:561
+#: A_New_Order/scenarios/13_Scouting.cfg:576
 msgid "Lizards? We already fought with them. I hate lizards."
 msgstr ""
 
 #. [else]
-#: A_New_Order/scenarios/13_Scouting.cfg:566
+#: A_New_Order/scenarios/13_Scouting.cfg:581
 msgid "That was wise decision, my lord."
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/13_Scouting.cfg:582
+#: A_New_Order/scenarios/13_Scouting.cfg:597
 msgid "We already scouted near Barnon. Where should we go now?"
 msgstr ""
 
 #. [else]
-#: A_New_Order/scenarios/13_Scouting.cfg:586
+#: A_New_Order/scenarios/13_Scouting.cfg:601
 msgid "Are you sure you want to go there? A lot of enemy soldiers could be near Barnon."
 msgstr ""
 
 #. [else]
-#: A_New_Order/scenarios/13_Scouting.cfg:590
+#: A_New_Order/scenarios/13_Scouting.cfg:605
 msgid "This could be dangerous... but also extremely valuable. We can definitely find out something about orcs there."
 msgstr ""
 
 #. [else]
-#: A_New_Order/scenarios/13_Scouting.cfg:593
+#: A_New_Order/scenarios/13_Scouting.cfg:608
 msgid "Yes, on other hand, maybe we should search elsewhere."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:603
+#: A_New_Order/scenarios/13_Scouting.cfg:618
 msgid "Who is comin' here? What d'ya wanna from us?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:604
-#: A_New_Order/scenarios/13_Scouting.cfg:643
+#: A_New_Order/scenarios/13_Scouting.cfg:619
+#: A_New_Order/scenarios/13_Scouting.cfg:658
 msgid "Don't be afraid, I want ask you few question and then I will go."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:605
+#: A_New_Order/scenarios/13_Scouting.cfg:620
 msgid "So go on an' ask us, then."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:611
-#: A_New_Order/scenarios/13_Scouting.cfg:649
-#: A_New_Order/scenarios/13_Scouting.cfg:682
+#: A_New_Order/scenarios/13_Scouting.cfg:626
+#: A_New_Order/scenarios/13_Scouting.cfg:664
+#: A_New_Order/scenarios/13_Scouting.cfg:697
 msgid "Do you know where the place called Bontom is?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:612
-#: A_New_Order/scenarios/13_Scouting.cfg:624
-#: A_New_Order/scenarios/13_Scouting.cfg:650
-#: A_New_Order/scenarios/13_Scouting.cfg:662
-#: A_New_Order/scenarios/13_Scouting.cfg:683
-#: A_New_Order/scenarios/13_Scouting.cfg:695
+#: A_New_Order/scenarios/13_Scouting.cfg:627
+#: A_New_Order/scenarios/13_Scouting.cfg:639
+#: A_New_Order/scenarios/13_Scouting.cfg:665
+#: A_New_Order/scenarios/13_Scouting.cfg:677
+#: A_New_Order/scenarios/13_Scouting.cfg:698
+#: A_New_Order/scenarios/13_Scouting.cfg:710
 msgid "Do you know anything about Reme Carrenemoe?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:613
-#: A_New_Order/scenarios/13_Scouting.cfg:625
-#: A_New_Order/scenarios/13_Scouting.cfg:651
-#: A_New_Order/scenarios/13_Scouting.cfg:663
-#: A_New_Order/scenarios/13_Scouting.cfg:684
-#: A_New_Order/scenarios/13_Scouting.cfg:696
+#: A_New_Order/scenarios/13_Scouting.cfg:628
+#: A_New_Order/scenarios/13_Scouting.cfg:640
+#: A_New_Order/scenarios/13_Scouting.cfg:666
+#: A_New_Order/scenarios/13_Scouting.cfg:678
+#: A_New_Order/scenarios/13_Scouting.cfg:699
+#: A_New_Order/scenarios/13_Scouting.cfg:711
 msgid "Have you heard anything about orcs?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:614
-#: A_New_Order/scenarios/13_Scouting.cfg:626
-#: A_New_Order/scenarios/13_Scouting.cfg:652
-#: A_New_Order/scenarios/13_Scouting.cfg:664
-#: A_New_Order/scenarios/13_Scouting.cfg:685
-#: A_New_Order/scenarios/13_Scouting.cfg:697
+#: A_New_Order/scenarios/13_Scouting.cfg:629
+#: A_New_Order/scenarios/13_Scouting.cfg:641
+#: A_New_Order/scenarios/13_Scouting.cfg:667
+#: A_New_Order/scenarios/13_Scouting.cfg:679
+#: A_New_Order/scenarios/13_Scouting.cfg:700
+#: A_New_Order/scenarios/13_Scouting.cfg:712
 msgid "Would you want to fight for me?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:615
-#: A_New_Order/scenarios/13_Scouting.cfg:627
-#: A_New_Order/scenarios/13_Scouting.cfg:653
-#: A_New_Order/scenarios/13_Scouting.cfg:665
-#: A_New_Order/scenarios/13_Scouting.cfg:686
-#: A_New_Order/scenarios/13_Scouting.cfg:698
+#: A_New_Order/scenarios/13_Scouting.cfg:630
+#: A_New_Order/scenarios/13_Scouting.cfg:642
+#: A_New_Order/scenarios/13_Scouting.cfg:668
+#: A_New_Order/scenarios/13_Scouting.cfg:680
+#: A_New_Order/scenarios/13_Scouting.cfg:701
+#: A_New_Order/scenarios/13_Scouting.cfg:713
 msgid "Go and work, good man."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:638
+#: A_New_Order/scenarios/13_Scouting.cfg:653
 msgid "Ah, welcome, we've heard about your victories, Gaumhaldric."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:640
+#: A_New_Order/scenarios/13_Scouting.cfg:655
 msgid "I still can't get used to them calling him Gaumhaldric."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:641
+#: A_New_Order/scenarios/13_Scouting.cfg:656
 msgid "Cute name, isn't it?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:644
+#: A_New_Order/scenarios/13_Scouting.cfg:659
 msgid "Anything for you, young knight."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:677
+#: A_New_Order/scenarios/13_Scouting.cfg:692
 msgid "Free men from Raedwood forest! You are always welcome here."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:755
+#: A_New_Order/scenarios/13_Scouting.cfg:770
 msgid "Where Reme Carrenemoe could possibly be?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:756
+#: A_New_Order/scenarios/13_Scouting.cfg:771
 #: A_New_Order/scenarios/18_Start_of_the_Quest.cfg:580
 msgid "Advise me what could we do now."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:757
+#: A_New_Order/scenarios/13_Scouting.cfg:772
 msgid "Tell me about my mother."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:762
+#: A_New_Order/scenarios/13_Scouting.cfg:777
 msgid "You are joking, right? He is in our camp!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:764
+#: A_New_Order/scenarios/13_Scouting.cfg:779
 msgid "Probably still in that Bontom place the peasants told us about."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:766
+#: A_New_Order/scenarios/13_Scouting.cfg:781
 msgid "In some place called Bontom. We could ask peasants about it."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:769
+#: A_New_Order/scenarios/13_Scouting.cfg:784
 msgid "I have no idea where your friend may be; I fear we may have already missed our chance to find out about him..."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:771
+#: A_New_Order/scenarios/13_Scouting.cfg:786
 msgid "I have no idea where your friend may be; maybe we could ask around some more about him."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:777
+#: A_New_Order/scenarios/13_Scouting.cfg:792
 msgid "About your mother? What do you want to know about her?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:778
+#: A_New_Order/scenarios/13_Scouting.cfg:793
 msgid "Everything."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:779
+#: A_New_Order/scenarios/13_Scouting.cfg:794
 msgid "Well, she was from a royal house. The Akladian king gave her a simple choice: marry him or he would unleash his anger on her family. So, she agreed. I visited her from time to time, singing songs, bringing her news from home... "
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:780
+#: A_New_Order/scenarios/13_Scouting.cfg:795
 msgid "I think eventually she even warmed up to your father, the king. When she gave birth to you, she gave everything she had for you. But behind her back Akladian clans were conspiring... and finally someone gave her a poisoned cup. She died, slowly, and painfully. I was able to be near her in her final hours. I promised her that I would take care of you."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:781
+#: A_New_Order/scenarios/13_Scouting.cfg:796
 msgid "Who poisoned her?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:782
+#: A_New_Order/scenarios/13_Scouting.cfg:797
 msgid "I don't know. No one knows."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:784
+#: A_New_Order/scenarios/13_Scouting.cfg:799
 msgid "Rob Roe mentioned Lorin's clan once bought some special poison from Outlaws... "
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:785
+#: A_New_Order/scenarios/13_Scouting.cfg:800
 msgid "And you think that..."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:786
+#: A_New_Order/scenarios/13_Scouting.cfg:801
 msgid "Why shouldn't I think that?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:787
+#: A_New_Order/scenarios/13_Scouting.cfg:802
 msgid "You are right, Gawen. Akladians have a long history of poisoning each other. You might say it's their national sport. But still... yes, it had escaped my attention before."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:789
+#: A_New_Order/scenarios/13_Scouting.cfg:804
 msgid "I wish I had asked around more about poison previously; it's probably too late to find out more now..."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:794
+#: A_New_Order/scenarios/13_Scouting.cfg:809
 msgid "Hey Karen, what's up?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:795
+#: A_New_Order/scenarios/13_Scouting.cfg:810
 msgid "I just made up a new song about you, want to hear it?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:796
+#: A_New_Order/scenarios/13_Scouting.cfg:811
 msgid "You are a gifted girl... fighting, singing, what else can you do?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:797
+#: A_New_Order/scenarios/13_Scouting.cfg:812
 msgid "I can also dance. Gawen. When we return to Freetown I could dance for you... "
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:798
+#: A_New_Order/scenarios/13_Scouting.cfg:813
 msgid "I'm sure I would enjoy watching you dance."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:799
+#: A_New_Order/scenarios/13_Scouting.cfg:814
 msgid "Oh, I bet you would!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:801
+#: A_New_Order/scenarios/13_Scouting.cfg:816
 msgid "Thank you, Gawen, once again. You have saved my life. I will never forget it, and I will never be able to repay my debt. Earlier my life belonged to you because of duty; now it is yours by choice."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:803
+#: A_New_Order/scenarios/13_Scouting.cfg:818
 msgid "Gaumhaldric, an interesting mother you have. Can I ask you a question?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:804
+#: A_New_Order/scenarios/13_Scouting.cfg:819
 msgid "Sure, go ahead."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:805
+#: A_New_Order/scenarios/13_Scouting.cfg:820
 msgid "Is she spoken for? I mean, is there someone she loves? I have often noticed her gazing up at the sky, far, far away, as if she were thinking about someone... or something."
 msgstr ""
 
 #. [event]
 #. this is just Gawen's assumption; my own assumption is that she is thinking about what the Oracle told her:
-#: A_New_Order/scenarios/13_Scouting.cfg:807
+#: A_New_Order/scenarios/13_Scouting.cfg:822
 msgid "I think she must be remembering my father. She has no one else I know about."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:808
+#: A_New_Order/scenarios/13_Scouting.cfg:823
 msgid "That is fortunate for me. She seems to have locked her heart up in an unbreakable fortress... but I think I can find a way into her heart. With time and patience, I'm sure I can discover a way to break down those walls. "
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:809
+#: A_New_Order/scenarios/13_Scouting.cfg:824
 msgid "Majid Yahyazad, Lorin is my step-mother, but she has never really shown any tenderness, even to me. I have always known her to be a harsh and unforgiving woman."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:810
+#: A_New_Order/scenarios/13_Scouting.cfg:825
 msgid "I'm afraid pursuing her will come with a heavy price. I think she thinks love is a weakness... she seems more interested in war and finding new ways to cause pain to others."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:811
+#: A_New_Order/scenarios/13_Scouting.cfg:826
 msgid "Ah, Gaumhaldric, perhaps you are right, but if it will be as a war to unlock her heart, I am prepared to wage it. I am well-acquainted with the ways of war."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:812
+#: A_New_Order/scenarios/13_Scouting.cfg:827
 msgid "Besides, in the end, the war for the affection of a worthy woman is the only war where the price to win is a privilege, not a burden, to pay."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:813
+#: A_New_Order/scenarios/13_Scouting.cfg:828
 msgid "You find my step-mother... a worthy challenge, then? "
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:814
+#: A_New_Order/scenarios/13_Scouting.cfg:829
 msgid "I do... and shall gladly pay the price to try to win her heart. "
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:815
+#: A_New_Order/scenarios/13_Scouting.cfg:830
 msgid "You have my blessing, noble Majid, for what it's worth. Sometimes the ruthlessness of the 'She-Wolf of Haeltin' still scares even me. "
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:820
+#: A_New_Order/scenarios/13_Scouting.cfg:835
 msgid "Mother, may I have a word with you?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:821
+#: A_New_Order/scenarios/13_Scouting.cfg:836
 msgid "Your clan once bought poison from outlaws. Why?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:822
-#: A_New_Order/scenarios/13_Scouting.cfg:830
+#: A_New_Order/scenarios/13_Scouting.cfg:837
+#: A_New_Order/scenarios/13_Scouting.cfg:845
 msgid "What do you think about Yahyazad?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:823
-#: A_New_Order/scenarios/13_Scouting.cfg:831
+#: A_New_Order/scenarios/13_Scouting.cfg:838
+#: A_New_Order/scenarios/13_Scouting.cfg:846
 msgid "What do you know about orcs?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:824
-#: A_New_Order/scenarios/13_Scouting.cfg:832
+#: A_New_Order/scenarios/13_Scouting.cfg:839
+#: A_New_Order/scenarios/13_Scouting.cfg:847
 msgid "How did my real mother die?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:838
+#: A_New_Order/scenarios/13_Scouting.cfg:853
 msgid "Why do you ask?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:839
+#: A_New_Order/scenarios/13_Scouting.cfg:854
 msgid "Well, he seems to be interested in you."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:840
+#: A_New_Order/scenarios/13_Scouting.cfg:855
 msgid "Yes, I noticed that. I think one would have to be blind NOT to notice that. But I am not interested in him."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:841
+#: A_New_Order/scenarios/13_Scouting.cfg:856
 msgid "Why not? He seems to be a good man."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:842
+#: A_New_Order/scenarios/13_Scouting.cfg:857
 msgid "He is an underling."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:843
+#: A_New_Order/scenarios/13_Scouting.cfg:858
 msgid "Underling? Mother, why do you still use such words? I am 'underling' too, after all."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:844
+#: A_New_Order/scenarios/13_Scouting.cfg:859
 msgid "No! I could never call you that. You are not... I mean... I... oh, you are too young to understand!"
 msgstr ""
 
 #. [event]
 #. cross-reference to dialogue in S16, Choosing the Best:
-#: A_New_Order/scenarios/13_Scouting.cfg:846
+#: A_New_Order/scenarios/13_Scouting.cfg:861
 msgid "Besides, you have lost your memory, so you probably do not remember what our customs are regarding widows that betray their dead husbands. I will explain it to you another time."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:848
+#: A_New_Order/scenarios/13_Scouting.cfg:863
 msgid "Orcs? They are good fighters. Strong, disciplined, I wish I had such soldiers."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:849
+#: A_New_Order/scenarios/13_Scouting.cfg:864
 msgid "Mother, orcs just burn, pillage, and murder! They hate us, and yet you seem to respect them?!?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:850
+#: A_New_Order/scenarios/13_Scouting.cfg:865
 msgid "Well, we are burning, pillaging, murdering and hate our enemies too. What's the difference?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:852
+#: A_New_Order/scenarios/13_Scouting.cfg:867
 msgid "Poison? What poison? My clan has never bought any poison!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:853
+#: A_New_Order/scenarios/13_Scouting.cfg:868
 msgid "Rob Roe told me about it."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:854
+#: A_New_Order/scenarios/13_Scouting.cfg:869
 msgid "Can you repeat that name? Rob - Roe. Rob Roe... No, I can't say I remember that name. I don't know anything about my clan buying a poison. But then, I am only a woman, and our clan lord didn't tell me everything."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:857
+#: A_New_Order/scenarios/13_Scouting.cfg:872
 msgid "Your mother? Your... why you are asking ME about your mother?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:858
+#: A_New_Order/scenarios/13_Scouting.cfg:873
 msgid "I can't remember anything about her. I would love to hear something about her. Did you know her?"
 msgstr ""
 
 #. [event]
 #. this is a Suspiciously Specific Denial: https://tvtropes.org/pmwiki/pmwiki.php/Main/SuspiciouslySpecificDenial
-#: A_New_Order/scenarios/13_Scouting.cfg:860
+#: A_New_Order/scenarios/13_Scouting.cfg:875
 msgid "No! I did not know her! I... I'm sorry Gawen, but I don't know how your mother died or who poisoned her."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:861
+#: A_New_Order/scenarios/13_Scouting.cfg:876
 msgid "I wasn't asking you about that."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:878
+#: A_New_Order/scenarios/13_Scouting.cfg:893
 msgid "There are no more orcs near this ruins of the village."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:881
+#: A_New_Order/scenarios/13_Scouting.cfg:896
 msgid "My lord! This time for sure you will chase off that orcish band, kill all the orcs, and free my people!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:883
+#: A_New_Order/scenarios/13_Scouting.cfg:898
 msgid "So, should we take on the orcs?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:903
+#: A_New_Order/scenarios/13_Scouting.cfg:918
 msgid "Someone is hiding here!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:905
+#: A_New_Order/scenarios/13_Scouting.cfg:920
 msgid "Ah! Humans! And Akladians with them?! Still, what good fortune!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:907
+#: A_New_Order/scenarios/13_Scouting.cfg:922
 msgid "Ah! Humans! And not Akladians! What good fortune!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:909
+#: A_New_Order/scenarios/13_Scouting.cfg:924
 msgid "Who are you, and what are you doing here?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:910
+#: A_New_Order/scenarios/13_Scouting.cfg:925
 msgid "The orcs burned down my village, Ruen, and they left not long ago. They took many prisoners. I was hiding here, waiting for a miracle. And now the miracle has come!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:911
+#: A_New_Order/scenarios/13_Scouting.cfg:926
 msgid "Oh my. It's so funny I think I'm gonna die laughing. Gaumhaldric the Miracle-maker, how about the sound of that?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:912
+#: A_New_Order/scenarios/13_Scouting.cfg:927
 msgid "Miracle? What do you mean?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:913
+#: A_New_Order/scenarios/13_Scouting.cfg:928
 msgid "You of course will chase that orcish band, kill all the orcs and free my people!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:915
+#: A_New_Order/scenarios/13_Scouting.cfg:930
 msgid "Hm, my lord, do you think we should fullfill this peasant's request?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:922
+#: A_New_Order/scenarios/13_Scouting.cfg:937
 msgid "Well, I hope it's wise decision."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:923
+#: A_New_Order/scenarios/13_Scouting.cfg:938
 msgid "Of course it is. We are searching for orcs, and those are orcs, isn't it?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:926
-#: A_New_Order/scenarios/13_Scouting.cfg:954
+#: A_New_Order/scenarios/13_Scouting.cfg:941
+#: A_New_Order/scenarios/13_Scouting.cfg:969
 msgid "Yes, on other hand maybe we should search elsewhere."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:937
+#: A_New_Order/scenarios/13_Scouting.cfg:952
 msgid "We already fought with outlaws from Bontom, my lord."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:946
+#: A_New_Order/scenarios/13_Scouting.cfg:961
 msgid "So, should we go into Bontom?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/13_Scouting.cfg:951
+#: A_New_Order/scenarios/13_Scouting.cfg:966
 msgid "Yes, we should save Reme now."
 msgstr ""
 
@@ -7066,7 +7075,7 @@ msgstr ""
 #. [event]
 #: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:53
 #: A_New_Order/scenarios/17_Sneaking_out_of_Raedwood.cfg:88
-#: A_New_Order/scenarios/21a_Abducted_Bride.cfg:576
+#: A_New_Order/scenarios/21a_Abducted_Bride.cfg:578
 msgid "Now, tell me..."
 msgstr ""
 
@@ -7758,72 +7767,72 @@ msgid "Explore"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/21d_Ruins_of_Weldyn.cfg:154
+#: A_New_Order/scenarios/21d_Ruins_of_Weldyn.cfg:155
 msgid "Master, someone approaches us! Should I attack now?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/21d_Ruins_of_Weldyn.cfg:156
+#: A_New_Order/scenarios/21d_Ruins_of_Weldyn.cfg:157
 msgid "No, don't attack."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/21d_Ruins_of_Weldyn.cfg:157
+#: A_New_Order/scenarios/21d_Ruins_of_Weldyn.cfg:158
 msgid "These are Akladians! At least, there are Akladians among them! I will need reinforcements!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/21d_Ruins_of_Weldyn.cfg:158
+#: A_New_Order/scenarios/21d_Ruins_of_Weldyn.cfg:159
 msgid "I said, don't attack. Fear not, friends from distant lands. I know who you are. The Oracle has foreseen your arrival. I have been waiting for you, noble Gaumhaldric - or rather, Gawen Hagarthen. You have no idea how long I have waited for you."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/21d_Ruins_of_Weldyn.cfg:159
+#: A_New_Order/scenarios/21d_Ruins_of_Weldyn.cfg:160
 msgid "Are you Deorien, the great mage?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/21d_Ruins_of_Weldyn.cfg:160
+#: A_New_Order/scenarios/21d_Ruins_of_Weldyn.cfg:161
 msgid "Yes, I am."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/21d_Ruins_of_Weldyn.cfg:161
+#: A_New_Order/scenarios/21d_Ruins_of_Weldyn.cfg:162
 msgid "We need your help. A great army is about to invade Wesnoth, and without mages, we..."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/21d_Ruins_of_Weldyn.cfg:162
+#: A_New_Order/scenarios/21d_Ruins_of_Weldyn.cfg:163
 msgid "I told you I know who you are and why you are here. But I'm afraid that you do not yet know. Gawen Hagarthen, I have been waiting for many, many years for someone like you to appear. When I heard about you, hope arose in my heart. Now, that I see you, I am sure."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/21d_Ruins_of_Weldyn.cfg:163
+#: A_New_Order/scenarios/21d_Ruins_of_Weldyn.cfg:164
 msgid "Sure? Of what? You are confusing me, I only wanted to ask you for help."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/21d_Ruins_of_Weldyn.cfg:164
+#: A_New_Order/scenarios/21d_Ruins_of_Weldyn.cfg:165
 msgid "I invite you and your friends into my rooms. I have hidden amongst these ruins my whole life. In the darkest hour of Wesnoth, I gathered the last surviving mages of Weldyn and we hid in the library. Then... well, I will explain everything to you. But first, you must hear a story. A very long story... Gawen, what do you know about the origins of the Akladians?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/21d_Ruins_of_Weldyn.cfg:165
+#: A_New_Order/scenarios/21d_Ruins_of_Weldyn.cfg:166
 msgid "Akladians? Well... we came from the east, isn't it? Mother, help me out here..."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/21d_Ruins_of_Weldyn.cfg:166
+#: A_New_Order/scenarios/21d_Ruins_of_Weldyn.cfg:167
 msgid "Should I kill this mage now?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/21d_Ruins_of_Weldyn.cfg:167
+#: A_New_Order/scenarios/21d_Ruins_of_Weldyn.cfg:168
 msgid "She won't be able to tell you, because all she knows are legends and myths. Lorin would tell the legend of how God created Akladians so that they could rule over the world, but that a false messiah imprisoned them, so they rebelled and then they journeyed here. She knows only legends and myths passed down from person to person, losing a little bit of truth each time in the re-telling."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/21d_Ruins_of_Weldyn.cfg:169
+#: A_New_Order/scenarios/21d_Ruins_of_Weldyn.cfg:170
 msgid "And yet, for every myth there is a true event which started it, a true beginning twisted and confused with the passing generations. Listen to me now."
 msgstr ""
 
@@ -8111,7 +8120,7 @@ msgstr ""
 
 #. [unit]: id=Reme Carrenemoe, type=Akladian Chieftain
 #: A_New_Order/scenarios/05_Unexpected_Guests.cfg:101
-#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:155
+#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:156
 #: A_New_Order/scenarios/05_The_Swamp_Things.cfg:143
 msgid "Reme Carrenemoe"
 msgstr ""
@@ -8123,7 +8132,7 @@ msgstr ""
 #: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:25
 #: A_New_Order/scenarios/04_Battle_of_Barnon.cfg:1326
 #: A_New_Order/scenarios/06_Separation.cfg:59
-#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:138
+#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:139
 #: A_New_Order/scenarios/05_The_Swamp_Things.cfg:33
 #: A_New_Order/scenarios/10_Siege_of_Haeltin.cfg:59
 #: A_New_Order/scenarios/09_Hired_Swords.cfg:118
@@ -8349,7 +8358,7 @@ msgstr ""
 
 #. [event]
 #. [scenario]: id=21a_Abducted_Bride
-#: A_New_Order/scenarios/21a_Abducted_Bride.cfg:578
+#: A_New_Order/scenarios/21a_Abducted_Bride.cfg:580
 #: A_New_Order/scenarios/21a_Abducted_Bride.cfg:23
 #: A_New_Order/scenarios/21a_Abducted_Bride.cfg:53
 msgid "What are the plans of king Buffin?"
@@ -8357,7 +8366,7 @@ msgstr ""
 
 #. [event]
 #. [scenario]: id=21a_Abducted_Bride
-#: A_New_Order/scenarios/21a_Abducted_Bride.cfg:579
+#: A_New_Order/scenarios/21a_Abducted_Bride.cfg:581
 #: A_New_Order/scenarios/21a_Abducted_Bride.cfg:24
 #: A_New_Order/scenarios/21a_Abducted_Bride.cfg:54
 msgid "What do you know about the situation in Vakladia?"
@@ -8370,7 +8379,7 @@ msgstr ""
 
 #. [event]
 #. [scenario]: id=21a_Abducted_Bride
-#: A_New_Order/scenarios/21a_Abducted_Bride.cfg:590
+#: A_New_Order/scenarios/21a_Abducted_Bride.cfg:592
 #: A_New_Order/scenarios/21a_Abducted_Bride.cfg:29
 msgid "I don't have to explain myself to anyone."
 msgstr ""
@@ -8382,7 +8391,7 @@ msgstr ""
 
 #. [event]
 #. [scenario]: id=21a_Abducted_Bride
-#: A_New_Order/scenarios/21a_Abducted_Bride.cfg:596
+#: A_New_Order/scenarios/21a_Abducted_Bride.cfg:598
 #: A_New_Order/scenarios/21a_Abducted_Bride.cfg:33
 msgid "Vakladia is finished. The whole country is in chaos. I think Bor Cryne, one of their lords, wants to declare himself king, but not many Akladians living there will recognise him. Only Hagarthens can be kings."
 msgstr ""
@@ -8499,7 +8508,7 @@ msgstr ""
 
 #. [objective]: condition=win
 #: A_New_Order/scenarios/21a_Abducted_Bride.cfg:383
-#: A_New_Order/scenarios/21a_Abducted_Bride.cfg:412
+#: A_New_Order/scenarios/21a_Abducted_Bride.cfg:413
 #: A_New_Order/scenarios/23_Trapped.cfg:897
 #: A_New_Order/scenarios/22_Leaving_Okladia.cfg:464
 #: A_New_Order/scenarios/19a_The_Woods_of_Okladia.cfg:177
@@ -8508,159 +8517,160 @@ msgid "Kill all enemy leaders OR"
 msgstr ""
 
 #. [objective]: condition=win
-#: A_New_Order/scenarios/21a_Abducted_Bride.cfg:387
-#: A_New_Order/scenarios/21a_Abducted_Bride.cfg:416
-msgid "Release the peasant girl being kept in a cage and move her to the northern edge of the map."
+#. trailing space is intentional, to pad the footnote a bit:
+#: A_New_Order/scenarios/21a_Abducted_Bride.cfg:388
+#: A_New_Order/scenarios/21a_Abducted_Bride.cfg:418
+msgid "Release the peasant girl being kept in a cage and move her to the northern edge of the map. "
 msgstr ""
 
 #. [unit]: id=Euridica, type=Peasant girl
 #. [event]
-#: A_New_Order/scenarios/21a_Abducted_Bride.cfg:450
-#: A_New_Order/scenarios/21a_Abducted_Bride.cfg:460
-#: A_New_Order/scenarios/21a_Abducted_Bride.cfg:473
-#: A_New_Order/scenarios/21a_Abducted_Bride.cfg:501
+#: A_New_Order/scenarios/21a_Abducted_Bride.cfg:452
+#: A_New_Order/scenarios/21a_Abducted_Bride.cfg:462
+#: A_New_Order/scenarios/21a_Abducted_Bride.cfg:475
+#: A_New_Order/scenarios/21a_Abducted_Bride.cfg:503
 msgid "Euridica"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/21a_Abducted_Bride.cfg:460
+#: A_New_Order/scenarios/21a_Abducted_Bride.cfg:462
 #: A_New_Order/scenarios/14d_Avenging_Ruen.cfg:251
 #: A_New_Order/scenarios/14d_Avenging_Ruen.cfg:286
 msgid "Thank you! Thank you!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/21a_Abducted_Bride.cfg:461
+#: A_New_Order/scenarios/21a_Abducted_Bride.cfg:463
 msgid "Don't thank me, it's not over yet. You have to escape. I think we can escape to the north."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/21a_Abducted_Bride.cfg:462
+#: A_New_Order/scenarios/21a_Abducted_Bride.cfg:464
 msgid "Move the peasant girl to the northern edge of the map."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/21a_Abducted_Bride.cfg:473
+#: A_New_Order/scenarios/21a_Abducted_Bride.cfg:475
 msgid "Thank you once again! Now I can go to my village, to my family and fiance!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/21a_Abducted_Bride.cfg:480
+#: A_New_Order/scenarios/21a_Abducted_Bride.cfg:482
 msgid "Our task here is finished. Should we withdraw now, my lord?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/21a_Abducted_Bride.cfg:492
+#: A_New_Order/scenarios/21a_Abducted_Bride.cfg:494
 msgid "Understood. We shall continue to fight any remnants of her captors' forces until it is completely safe."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/21a_Abducted_Bride.cfg:501
+#: A_New_Order/scenarios/21a_Abducted_Bride.cfg:503
 msgid "Father! Father! Everything is going dark!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/21a_Abducted_Bride.cfg:502
+#: A_New_Order/scenarios/21a_Abducted_Bride.cfg:504
 msgid "Oh no! We have failed our mission!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/21a_Abducted_Bride.cfg:555
+#: A_New_Order/scenarios/21a_Abducted_Bride.cfg:557
 msgid "The poor girl is saved and we may now continue our quest."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/21a_Abducted_Bride.cfg:556
+#: A_New_Order/scenarios/21a_Abducted_Bride.cfg:558
 msgid "Yes - Gawen Hagarthen, a great destiny waits for you. Do not permit it to wait for too long."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/21a_Abducted_Bride.cfg:566
+#: A_New_Order/scenarios/21a_Abducted_Bride.cfg:568
 msgid "Welcome, noble Bark O Skagrrak. My name is Lorin of Gallorae. Some call me the She-wolf of Haeltin. Have you heard about me?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/21a_Abducted_Bride.cfg:567
+#: A_New_Order/scenarios/21a_Abducted_Bride.cfg:569
 msgid "Yes... I've heard about you. You're the hag wife of Hagarthen, the drab harlot from Vattin."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/21a_Abducted_Bride.cfg:568
+#: A_New_Order/scenarios/21a_Abducted_Bride.cfg:570
 msgid "Such a funny man you are, Bark. So willing to mock and flout. I wonder whether you will be equally ready to die."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/21a_Abducted_Bride.cfg:569
+#: A_New_Order/scenarios/21a_Abducted_Bride.cfg:571
 msgid "Mother, please..."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/21a_Abducted_Bride.cfg:570
+#: A_New_Order/scenarios/21a_Abducted_Bride.cfg:572
 msgid "You've heard what he called me! Bark O Skagrrak, my name is Lady Lorin of the Gallorae clan. And my knife is called Truth-sayer. Say hello to it."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/21a_Abducted_Bride.cfg:571
+#: A_New_Order/scenarios/21a_Abducted_Bride.cfg:573
 msgid "You think I will be... AAAARGH!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/21a_Abducted_Bride.cfg:577
+#: A_New_Order/scenarios/21a_Abducted_Bride.cfg:579
 msgid "Why have you kidnapped this poor girl?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/21a_Abducted_Bride.cfg:585
+#: A_New_Order/scenarios/21a_Abducted_Bride.cfg:587
 msgid "She is so beautiful... I want her as a wife and slave, for all eternity."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/21a_Abducted_Bride.cfg:586
+#: A_New_Order/scenarios/21a_Abducted_Bride.cfg:588
 msgid "Besides, our women are under an unknown curse; they give birth to few children and many of them are born sick. A Wesnothian woman could give me a son!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/21a_Abducted_Bride.cfg:587
+#: A_New_Order/scenarios/21a_Abducted_Bride.cfg:589
 msgid "A slave cannot give a son to a Akladian lord!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/21a_Abducted_Bride.cfg:588
+#: A_New_Order/scenarios/21a_Abducted_Bride.cfg:590
 msgid "I don't care! If she would give a life to my son, I would free her, I would made her my first wife, just as she would be of worthy people!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/21a_Abducted_Bride.cfg:589
+#: A_New_Order/scenarios/21a_Abducted_Bride.cfg:591
 msgid "You are making me angry. What if she would give a life to a daughter?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/21a_Abducted_Bride.cfg:592
+#: A_New_Order/scenarios/21a_Abducted_Bride.cfg:594
 msgid "Why should I tell you? This is a secret of my king."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/21a_Abducted_Bride.cfg:593
+#: A_New_Order/scenarios/21a_Abducted_Bride.cfg:595
 msgid "Secret? I love secrets! I'm a woman, you know. Please share it with me. Preeeetty pleaaaase!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/21a_Abducted_Bride.cfg:594
+#: A_New_Order/scenarios/21a_Abducted_Bride.cfg:596
 msgid "Aaargh! Stop it! I will tell you! King Buffin is preparing to invade Vakladia and claim the throne in Vattin. It is empty and it seems that no one will oppose Buffin. The two brothers in Guilcorta are now too busy, so it's a perfect opportunity. The army is ready already."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/21a_Abducted_Bride.cfg:598
+#: A_New_Order/scenarios/21a_Abducted_Bride.cfg:600
 msgid "I don't know who that is!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/21a_Abducted_Bride.cfg:645
+#: A_New_Order/scenarios/21a_Abducted_Bride.cfg:647
 msgid "Curses! They are more dangerous that I thought! Bring the reinforcements!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/21a_Abducted_Bride.cfg:650
+#: A_New_Order/scenarios/21a_Abducted_Bride.cfg:652
 msgid "We must do likewise! Bring our own reinforcements!"
 msgstr ""
 
@@ -9056,7 +9066,7 @@ msgstr ""
 #: A_New_Order/scenarios/23_Trapped.cfg:895
 #: A_New_Order/scenarios/19a_The_Woods_of_Okladia.cfg:175
 #: A_New_Order/scenarios/19b_Entering_Okladia.cfg:166
-#: A_New_Order/scenarios/19c_The_Oracle.cfg:1586
+#: A_New_Order/scenarios/19c_The_Oracle.cfg:1616
 msgid "There are no interrogations in this scenario."
 msgstr ""
 
@@ -9856,8 +9866,8 @@ msgstr ""
 #. [side]: id=Dauri Travil, type=Akladian Lord
 #. [event]
 #: A_New_Order/scenarios/22_Leaving_Okladia.cfg:298
-#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:706
-#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:720
+#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:707
+#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:721
 msgid "Dauri Travil"
 msgstr ""
 
@@ -9939,359 +9949,360 @@ msgid "I will lose it in battle. Charge!"
 msgstr ""
 
 #. [objective]: condition=win
-#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:468
-msgid "Reach the northern edge of the map with Gawen."
-msgstr ""
-
-#. [event]
-#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:512
-msgid "For our king, Gawen Haldric Hagarthen!"
+#. trailing space is intentional, to pad the footnote a bit:
+#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:469
+msgid "Reach the northern edge of the map with Gawen. "
 msgstr ""
 
 #. [event]
 #: A_New_Order/scenarios/22_Leaving_Okladia.cfg:513
-msgid "Your king? You are fighting for the ghost of long dead boy? And why would you call him Haldric?"
+msgid "For our king, Gawen Haldric Hagarthen!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:539
-#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:571
-msgid "You oppose Gawen Hagarthen, your own king."
+#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:514
+msgid "Your king? You are fighting for the ghost of long dead boy? And why would you call him Haldric?"
 msgstr ""
 
 #. [event]
 #: A_New_Order/scenarios/22_Leaving_Okladia.cfg:540
 #: A_New_Order/scenarios/22_Leaving_Okladia.cfg:572
+msgid "You oppose Gawen Hagarthen, your own king."
+msgstr ""
+
+#. [event]
+#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:541
+#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:573
 msgid "Our king? And where is he? Is he hiding behind your backs?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:548
+#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:549
 msgid "Now, feel the wrath of ancient power. Your God is expressing his anger through me, because you are opposing his messiah!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:573
+#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:574
 msgid "My name is Reme Carrenemoe. You doubt my word?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:574
+#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:575
 msgid "If he is really Gawen Hagarthen, why does he send others to fight?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:596
+#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:597
 msgid "He lost consciousness already? Sigh. I hoped we could ask him few questions. But then again, he didn't seem like a guy who would actually KNOW anything."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:602
+#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:603
 msgid "What are you waiting for? Finish me!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:604
+#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:605
 msgid "Then die, if that's what you want!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:605
+#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:606
 msgid "You were worthy opponent"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:609
+#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:610
 msgid "If that's your wish"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:612
+#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:613
 msgid "Why should I do that? You fought like a real man, and I respect you. Rauke, I want you to know that I consider you a good warrior and a fine Akladian. I will ensure your body is buried with all honours."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:614
+#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:615
 msgid "Maybe you are worthy to be our king after all..."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:615
+#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:616
 msgid "Tell me what has happened recently in Vakladia?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:617
+#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:618
 msgid "Nothing changed much. Everyone is fighting with everyone. Bor Cryne and his allies are trying to impose themselves as supreme rulers with the help of the orcs, but even their successes with the rebels have not given them any authority."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:618
-msgid "In Easkladia, king Perien died during the final battle with the Wesnothians. He broke through the Wesnothian lines right to their king. He slew their king, but he was in turn killed by underlings. The battle then ended, undecided, but the Easkladian capital was saved and the underlings withdrew without their king."
-msgstr ""
-
-#. [event]
 #: A_New_Order/scenarios/22_Leaving_Okladia.cfg:619
-#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:650
-#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:661
-msgid "There are multiple rumors about a messiah who will come and unite all the Akladians and lead them into true greatness... (<i>coughs</i>) ...and... (<i>coughs</i>)"
+msgid "In Easkladia, king Perien died during the final battle with the Wesnothians. He broke through the Wesnothian lines right to their king. He slew their king, but he was in turn killed by underlings. The battle then ended, undecided, but the Easkladian capital was saved and the underlings withdrew without their king."
 msgstr ""
 
 #. [event]
 #: A_New_Order/scenarios/22_Leaving_Okladia.cfg:620
 #: A_New_Order/scenarios/22_Leaving_Okladia.cfg:651
-#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:663
+#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:662
+msgid "There are multiple rumors about a messiah who will come and unite all the Akladians and lead them into true greatness... (<i>coughs</i>) ...and... (<i>coughs</i>)"
+msgstr ""
+
+#. [event]
+#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:621
+#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:652
+#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:664
 msgid "He is dead now. Lie in peace, warrior. I will keep my promise"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:625
-#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:763
+#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:626
+#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:764
 msgid "A mage! A mage has defeated me! A creature from the dark past allied with you? God will punish you!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:629
+#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:630
 msgid "Rauke, I like you. That's why I don't want you to scream in pain and agony. What do you say you help me out?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:630
+#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:631
 msgid "Help yourself, fat witch."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:631
+#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:632
 msgid "Fat? That's really unfair. I didn't say anything about you being bald. Now, tell me what happened recently in Vakladia, and..."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:632
+#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:633
 msgid "And..."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:633
+#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:634
 msgid "You will avoid unspeakable pain"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:634
+#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:635
 msgid "I will honour you by burying you properly"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:639
+#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:640
 msgid "You think you can frighten me with mere words? Ha! Ha! Ha! I am an Akladian lord, and I am not afraid... I am half-dead already..."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:640
+#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:641
 msgid "Only half-dead, mind you. It means you can still feel the pain"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:641
+#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:642
 msgid "Aaargh! No! Not there! Aaargh! Stop, stop it!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:642
+#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:643
 msgid "I won't allow for any more of that, mother. Stop it! Stop it right now!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:643
+#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:644
 msgid "Oh, rats, I think I've lost my delicate, feminine touch. My blade slipped and I've killed him too soon. Sigh."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:646
+#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:647
 msgid "Honour me? That's so.. so unlikely of you, Lorin."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:647
-msgid "LADY Lorin, if you don't mind. How do you know what's unlikely for me? You were a fine warrior, and I grow tired of being called emotionless and cruel by my step-son. Would you please tell me about what happened in Vakladia recently?"
-msgstr ""
-
-#. [event]
 #: A_New_Order/scenarios/22_Leaving_Okladia.cfg:648
-#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:659
-msgid "Nothing's changed much. Everyone is fighting with everyone. Bor Cryne and his allies are trying to impose themselves as supreme rulers with the help of the orcs, but even their successes with the rebels have not given them any authority."
+msgid "LADY Lorin, if you don't mind. How do you know what's unlikely for me? You were a fine warrior, and I grow tired of being called emotionless and cruel by my step-son. Would you please tell me about what happened in Vakladia recently?"
 msgstr ""
 
 #. [event]
 #: A_New_Order/scenarios/22_Leaving_Okladia.cfg:649
 #: A_New_Order/scenarios/22_Leaving_Okladia.cfg:660
+msgid "Nothing's changed much. Everyone is fighting with everyone. Bor Cryne and his allies are trying to impose themselves as supreme rulers with the help of the orcs, but even their successes with the rebels have not given them any authority."
+msgstr ""
+
+#. [event]
+#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:650
+#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:661
 msgid "In Easkladia, king Perien died during the final battle with the Wesnothians. He broke through the Wesnothian lines right to their king. He slew their king, but he was in turn slain by underlings. The battle then ended, undecided, but the Easkladian capital was saved and the underlings withdrew without their king."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:656
+#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:657
 msgid "You were a worthy fighter, noble Rauke Harnen. I will do everything to bury your body properly according to our customs."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:657
+#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:658
 msgid "So were you, noble Reme. I've heard about the fate of your clan and family - please, accept my deepest condolences."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:658
+#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:659
 msgid "People die and join their ancestors. I am happy their death was honourable. Please, before you die - could you tell me about what happened in Vakladia recently?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:673
+#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:674
 msgid "Hmm... seems that he had some gold..."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:691
-#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:706
+#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:692
+#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:707
 msgid "Hmm... seems that the traitor had some gold..."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:696
+#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:697
 msgid "Bal Riddon has received 40 gold pieces."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:711
+#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:712
 msgid "Dauri Travil has received 40 gold pieces."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:720
+#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:721
 msgid "Eeek! They killed the boss! Bring reinforcements!"
-msgstr ""
-
-#. [event]
-#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:758
-#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:767
-msgid "Bal Riddon, before you die, I want you to tell me a few things about the plans of your king, Buffin."
 msgstr ""
 
 #. [event]
 #: A_New_Order/scenarios/22_Leaving_Okladia.cfg:759
 #: A_New_Order/scenarios/22_Leaving_Okladia.cfg:768
+msgid "Bal Riddon, before you die, I want you to tell me a few things about the plans of your king, Buffin."
+msgstr ""
+
+#. [event]
+#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:760
+#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:769
 msgid "Ask him yourself, then. I won't tell you anything."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:769
+#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:770
 msgid "Nonono, you have not understood me. I WANT you to tell me few things about the plans of your king. Now, we will start with the basics."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:770
+#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:771
 msgid "Wait! I will tell you what I know. King Buffin wants to use the opportunity he sees here, with Gawen dead, Perien dead, and the two other Hagarthens in Guilcorta busy with quarrels. He wants to trump up some fake election and elect himself king of Vakladia."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:771
+#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:772
 msgid "Gawen is not dead, I assure you."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:772
+#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:773
 msgid "But there is something strange... I've heard strange rumors. Something is happening at our eastern border. Many of the lords from the eastern part of Okladia have not answered the call of Buffin to assemble at his camp."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:773
+#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:774
 msgid "Okladian lords are cowards, what's so strange about that? Do you know anything else? No? Die then."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:778
+#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:779
 msgid "You were worthy fighter, noble Bal Riddon"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:779
+#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:780
 msgid "So were you, Reme. So were you. You behaved honourably, so before I die, I want to warn you: you are headed straight into a trap."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:780
+#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:781
 #: A_New_Order/scenarios/15_Back_in_Freetown.cfg:159
 msgid "What do you mean by that?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:781
+#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:782
 msgid "An army of orcs and Akladians is gathering north of here. They are probably there because they want to head off the army of my king, Buffin. You will be trapped between those two armies. Go back to Okladia and try to find another way."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:782
+#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:783
 msgid "We have no choice. We have to tread this path."
 msgstr ""
 
 #. [message]: speaker=narrator
 #. TODO: think of something better to put here:
-#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:795
+#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:796
 msgid "This signpost is illegible, unfortunately."
 msgstr ""
 
 #. [event]
 #. reference to the event where King Buffin's vanguard starts appearing:
-#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:858
+#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:859
 msgid "Wait... the last time enemy reinforcements arrived..."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:859
+#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:860
 msgid "No, Gawen is correct! There are too many of them now!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:876
+#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:877
 #: A_New_Order/scenarios/19a_The_Woods_of_Okladia.cfg:322
 #: A_New_Order/scenarios/19b_Entering_Okladia.cfg:312
 msgid "We've won! What should we do now?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:877
+#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:878
 msgid "We march straight on to Vattin! Boy, I really feel hungry now. This fight has made me STARVING."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:878
+#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:879
 msgid "I think, my king, we should go to Freetown, so the Wesnothian rebels from Vakladia can see you and acknowledge you as king. We must hurry, because king Buffin is right behind us."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:879
+#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:880
 msgid "Nonono, not to Freetown! There is nothing worth seeing in Freetown!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:880
+#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:881
 msgid "Yes, there is definitely something worth seeing in that city. In fact, I can't wait to see her."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:881
+#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:882
 msgid "Her?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:882
+#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:883
 msgid "Mother, I'll explain later. Let's go!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:938
+#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:939
 msgid "Gee, don't panic. That's only the vanguard of King Buffin's army. I assure you that we still have every opportunity to win."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:990
+#: A_New_Order/scenarios/22_Leaving_Okladia.cfg:991
 msgid "I have strange feeling of dejavu... Hey, $tmp, take care of yourself, would you? "
 msgstr ""
 
@@ -11087,7 +11098,7 @@ msgstr ""
 
 #. [scenario]: id=19c_The_Oracle
 #: A_New_Order/scenarios/19c_The_Oracle.cfg:3
-#: A_New_Order/scenarios/19c_The_Oracle.cfg:1820
+#: A_New_Order/scenarios/19c_The_Oracle.cfg:1853
 msgid "The Oracle"
 msgstr ""
 
@@ -11105,9 +11116,9 @@ msgstr ""
 #. [side]: id=Matthias Ramon, type=General
 #. [event]
 #: A_New_Order/scenarios/19c_The_Oracle.cfg:68
-#: A_New_Order/scenarios/19c_The_Oracle.cfg:1548
-#: A_New_Order/scenarios/19c_The_Oracle.cfg:1615
+#: A_New_Order/scenarios/19c_The_Oracle.cfg:1578
 #: A_New_Order/scenarios/19c_The_Oracle.cfg:1645
+#: A_New_Order/scenarios/19c_The_Oracle.cfg:1678
 msgid "Matthias Ramon"
 msgstr ""
 
@@ -11211,7 +11222,7 @@ msgstr ""
 #. [side]: id=Baruk Urk, type=Orcish Warlord
 #. [event]
 #: A_New_Order/scenarios/19c_The_Oracle.cfg:592
-#: A_New_Order/scenarios/19c_The_Oracle.cfg:1546
+#: A_New_Order/scenarios/19c_The_Oracle.cfg:1576
 msgid "Baruk Urk"
 msgstr ""
 
@@ -11241,7 +11252,7 @@ msgstr ""
 #. [side]: id=Fat Bart, type=Fugitive
 #. [event]
 #: A_New_Order/scenarios/19c_The_Oracle.cfg:818
-#: A_New_Order/scenarios/19c_The_Oracle.cfg:1545
+#: A_New_Order/scenarios/19c_The_Oracle.cfg:1575
 msgid "Fat Bart"
 msgstr ""
 
@@ -11271,7 +11282,7 @@ msgstr ""
 #. [side]: id=Burke Barien, type=Akladian Lord
 #. [event]
 #: A_New_Order/scenarios/19c_The_Oracle.cfg:1048
-#: A_New_Order/scenarios/19c_The_Oracle.cfg:1544
+#: A_New_Order/scenarios/19c_The_Oracle.cfg:1574
 msgid "Burke Barien"
 msgstr ""
 
@@ -11320,8 +11331,8 @@ msgstr ""
 #. [side]: id=Boren Rebarnon, type=Akladian Lord
 #. [event]
 #: A_New_Order/scenarios/19c_The_Oracle.cfg:1267
-#: A_New_Order/scenarios/19c_The_Oracle.cfg:1543
-#: A_New_Order/scenarios/19c_The_Oracle.cfg:1547
+#: A_New_Order/scenarios/19c_The_Oracle.cfg:1573
+#: A_New_Order/scenarios/19c_The_Oracle.cfg:1577
 msgid "Boren Rebarnon"
 msgstr ""
 
@@ -11349,178 +11360,179 @@ msgid "Askarial"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/19c_The_Oracle.cfg:1543
+#: A_New_Order/scenarios/19c_The_Oracle.cfg:1573
 msgid "Remember, the Oracle must be untouched. Do not kill the woman. Bor Cryne wants to have her untouched."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/19c_The_Oracle.cfg:1544
+#: A_New_Order/scenarios/19c_The_Oracle.cfg:1574
 msgid "Bor Cryne may desire whatever he wants. But the holy Oracle will be a 'guest' of the noble lord Uri van Roe."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/19c_The_Oracle.cfg:1545
+#: A_New_Order/scenarios/19c_The_Oracle.cfg:1575
 msgid "You two can settle that later. Everything else inside the city will belong to us!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/19c_The_Oracle.cfg:1546
+#: A_New_Order/scenarios/19c_The_Oracle.cfg:1576
 msgid "Ha, ha, human. You mean, 'everything we leave' will be yours."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/19c_The_Oracle.cfg:1547
+#: A_New_Order/scenarios/19c_The_Oracle.cfg:1577
 msgid "Wait, I think someone is trying to help the besieged."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/19c_The_Oracle.cfg:1548
+#: A_New_Order/scenarios/19c_The_Oracle.cfg:1578
 msgid "The Oracle was right, as always! Relief is coming! Fight harder, men, we must hold out long enough for relief to arrive!"
 msgstr ""
 
 #. [objective]: condition=lose
-#: A_New_Order/scenarios/19c_The_Oracle.cfg:1562
+#: A_New_Order/scenarios/19c_The_Oracle.cfg:1592
 msgid "Any enemy unit reaches the keep of the Oracle."
 msgstr ""
 
 #. [objectives]
 #. EASY difficulty, so be more explicit about how things work:
-#: A_New_Order/scenarios/19c_The_Oracle.cfg:1580
+#: A_New_Order/scenarios/19c_The_Oracle.cfg:1610
 msgid "The scenario will continue even if Matthias Ramon dies. It is the keep upon which he stands that requires greater protection."
 msgstr ""
 
 #. [objectives]
 #. NORMAL, HARD, or NIGHTMARE difficulty, so this should just be a description of mechanics instead of having any sort of hint-like qualities:
-#: A_New_Order/scenarios/19c_The_Oracle.cfg:1583
+#: A_New_Order/scenarios/19c_The_Oracle.cfg:1613
 msgid "The scenario will continue even if Matthias Ramon dies."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/19c_The_Oracle.cfg:1603
+#: A_New_Order/scenarios/19c_The_Oracle.cfg:1633
 msgid "Yikes, this Oracle is better defended than we expected! Let's get some gold together for some more reinforcements!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/19c_The_Oracle.cfg:1615
+#: A_New_Order/scenarios/19c_The_Oracle.cfg:1645
 msgid "I am under attack! To me, men! We must protect the Oracle together!"
 msgstr ""
 
 #. [message]
-#: A_New_Order/scenarios/19c_The_Oracle.cfg:1622
+#: A_New_Order/scenarios/19c_The_Oracle.cfg:1652
 msgid "On our way, sir!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/19c_The_Oracle.cfg:1645
+#: A_New_Order/scenarios/19c_The_Oracle.cfg:1678
 msgid "The attackers have slain me! Hurry, to my keep, men! You must protect the Oracle for me in my stead!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/19c_The_Oracle.cfg:1660
+#: A_New_Order/scenarios/19c_The_Oracle.cfg:1693
 msgid "I found her! I found her! The Oracle!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/19c_The_Oracle.cfg:1661
+#: A_New_Order/scenarios/19c_The_Oracle.cfg:1694
 msgid "All is lost! They captured the Oracle!"
 msgstr ""
 
 #. [event]
 #. The "o" in "oracle" is intentionally lowercase here so that Ruvio can correct Gawen in the line after this.
 #. (I'm not sure how Ruvio can tell case when they're supposed to be speaking aloud, but let's ignore that for now)
-#: A_New_Order/scenarios/19c_The_Oracle.cfg:1829
+#: A_New_Order/scenarios/19c_The_Oracle.cfg:1862
 msgid "We've won! At last. Now, where is that famous oracle?"
 msgstr ""
 
 #. [event]
 #. if your language doesn't have articles or capitalization, come up with some other sort of linguistic cue to signify that
 #. 'The Oracle' is special, like a unique honoriffic (if you language has those) or something:
-#: A_New_Order/scenarios/19c_The_Oracle.cfg:1832
+#: A_New_Order/scenarios/19c_The_Oracle.cfg:1865
 msgid "You pronounce that 'The Oracle'... all she needs is a great big 'The' in front and a capital O. But indeed, where is she?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/19c_The_Oracle.cfg:1850
+#. carets blank EVERYTHING before them, rather than just the preceding word, so that is why I replaced "plural^you" with "all of you" here:
+#: A_New_Order/scenarios/19c_The_Oracle.cfg:1883
 msgid "Here I am. My voice speaks to those willing to listen. I know why you are here. I know who all of you are. Ask your questions and receive the answers, for I can see everything which may be."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/19c_The_Oracle.cfg:1851
+#: A_New_Order/scenarios/19c_The_Oracle.cfg:1884
 msgid "Everything, huh? Then how come you were besieged and almost captured? Why didn't you escape or call on someone to help you?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/19c_The_Oracle.cfg:1852
+#: A_New_Order/scenarios/19c_The_Oracle.cfg:1885
 msgid "The answer to this question is the answer to your doubts. Why haven't I escaped? Why didn't I call someone for help?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/19c_The_Oracle.cfg:1853
+#: A_New_Order/scenarios/19c_The_Oracle.cfg:1886
 msgid "Lady, we are searching for the great mage, Deorien. Maybe you know..."
 msgstr ""
 
 #. [event]
 #. Note to translators: This is archaic English, 'thee' and 'thou' are the singular familiar forms of 'you' - 'crieth' and 'recalleth' are old English for 'cries' and 'recalls'... 'e'en' is a poetic way of saying 'even'
-#: A_New_Order/scenarios/19c_The_Oracle.cfg:1856
+#: A_New_Order/scenarios/19c_The_Oracle.cfg:1889
 msgid "Search for Deorien in the ruins of the great city, where e'en the wind crieth when it recalleth the memories of a marvelous past. He shall give unto thee answers, some of which thou mayest find unwelcome."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/19c_The_Oracle.cfg:1858
+#: A_New_Order/scenarios/19c_The_Oracle.cfg:1891
 msgid "Ruins of the great city? What kind of answer is this? Which city? Why can't you give me straight answers?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/19c_The_Oracle.cfg:1859
+#: A_New_Order/scenarios/19c_The_Oracle.cfg:1892
 msgid "I am an Oracle. Why should I give straight answers? Why do you think my answer is insufficient for you? Why do you think I should tell you more?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/19c_The_Oracle.cfg:1860
+#: A_New_Order/scenarios/19c_The_Oracle.cfg:1893
 msgid "Oracle... I..."
 msgstr ""
 
 #. [event]
 #. If you are translating the Oracle's answers, and if you are not sure what Lorin's questions were, contact the campaign creator. The answers might not involve "to be" in some languages.
 #. Note to translators: This sentence incorporates quite a bit of archaic English. 'Yea' is old English for yes and 'thou' is the familiar/intimate form of a singular 'you'... 'ye' in the third answer is the old English familliar, plural form of 'you' - and 'nay' is old English for 'no.'
-#: A_New_Order/scenarios/19c_The_Oracle.cfg:1864
+#: A_New_Order/scenarios/19c_The_Oracle.cfg:1897
 msgid "I already know your questions, Lorin from Gallorae, the clan which has long had more gold in the hair of their daughters than in their treasuries. The first answer is: yea, thou art. The second is: yea, he shall. The third is: nay, ye never shall."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/19c_The_Oracle.cfg:1866
+#: A_New_Order/scenarios/19c_The_Oracle.cfg:1899
 msgid "No! No!  There has to be a better answer!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/19c_The_Oracle.cfg:1867
+#: A_New_Order/scenarios/19c_The_Oracle.cfg:1900
 msgid "As the Oracle, I have nothing more to say to thee... As a woman, I can advise this: There is only one man in the world who may change your future. I think you know his name. Go and find him. Beg him for forgiveness if you have to. Stay with him as long as you can."
 msgstr ""
 
 #. [event]
-#. FIXME: this wording could be improved:
-#: A_New_Order/scenarios/19c_The_Oracle.cfg:1869
+#. FIXME: this wording could be improved... basically Lorin is saying she accepts the answers the Oracle gave with her Oracle hat on, but not the advice she gave on a woman-to-woman basis:
+#: A_New_Order/scenarios/19c_The_Oracle.cfg:1902
 msgid "Is that all you wanted to tell me? Then know that I've heard, that the She-wolf of Haeltin has heard counsel of the Oracle, voice of God on Earth. She will not hear the counsel woman whom is merely God's tool."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/19c_The_Oracle.cfg:1870
+#: A_New_Order/scenarios/19c_The_Oracle.cfg:1903
 msgid "Let's go, Gawen. We're finished here."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/19c_The_Oracle.cfg:1871
+#: A_New_Order/scenarios/19c_The_Oracle.cfg:1904
 msgid "I didn't catch the meaning of the discussion between you, and I know it was important. But why?"
 msgstr ""
 
 #. [event]
 #. 'import' is an older English term for 'Importance'
-#: A_New_Order/scenarios/19c_The_Oracle.cfg:1874
+#: A_New_Order/scenarios/19c_The_Oracle.cfg:1907
 msgid "You shall understand the full import of it one day, young king, and I daresay sooner than you think. I wish you luck in your quest. I will give one of my sergeants into your service. He will serve you loyally."
 msgstr ""
 
 #. [unit]: type=Sergeant, id=John Fasthood
-#: A_New_Order/scenarios/19c_The_Oracle.cfg:1881
+#: A_New_Order/scenarios/19c_The_Oracle.cfg:1914
 msgid "John Fasthood"
 msgstr ""
 
@@ -16343,335 +16355,336 @@ msgid "Content Note: This campaign contains mature themes, some of which may be 
 msgstr ""
 
 #. [part]
-#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:33
+#. Now into the actual story part, starting with Lorin speaking to Gawen:
+#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:34
 msgid "Moments slowly lengthen into hours. Hope is slipping through my fingers..."
 msgstr ""
 
 #. [part]
 #. Lorin speaking to Gawen:
-#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:39
+#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:40
 msgid "Do you hear me, my son? I am losing hope, you must awaken... it was supposed to be just a routine show of force; kill a few rebels, scare the rest. Now your father is slain and you are lying here, not stirring, for... how many days now? I don't even know if you can hear me or if you care. It's so strange to call a man who is just few years younger 'son.' I wish I knew your real mother; at least then I would know with whom I am competing."
 msgstr ""
 
 #. [part]
 #. "Our people" = the Akladians:
-#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:44
+#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:45
 msgid "Our people came here from the eastern lands long before my birth. Our people's destiny is to rule the world."
 msgstr ""
 
 #. [part]
-#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:57
+#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:58
 msgid "Your grandfather smashed the underling armies in the field and stormed their castles. They were weak while we were strong. Divided, while we were unified. God gave us our destiny; they foolishly trusted mages to alter theirs. They were truly destined to be our slaves."
 msgstr ""
 
 #. [part]
-#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:82
+#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:83
 msgid "We burned their palaces, towns, and castles; there was nothing worthy there. They told us that they put their legends and wisdom on paper, it was as though they thought they could imprison history in their books. We burned them all. Their poetry, wisdom, and history - their entire culture - burned to ashes. And with them, that most irritating underling quality - hope."
 msgstr ""
 
 #. [part]
-#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:105
+#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:106
 msgid "I was only five when your grandfather died and divided his kingdom among his sons, six when your father quelled the first rebellion. I never understood why he chose your mother... was it pure physical attraction, or an attempt to appease the conquered by marrying a woman of their nobility? If it was indeed the latter that he intended, he failed miserably; the underlings' hatred for us only increased, and our own people were uneasy with having such a queen."
 msgstr ""
 
 #. [part]
-#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:109
+#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:110
 msgid "When your mother died, I was chosen from the Gallorae Clan as your father's next wife. I am not certain whether or not this was an act to appease the Clans, but he must have wanted an heir whom our people would not question. My duty was to bear him that son, and I failed. Our people strayed from the old ways, and God turned his back on us as we had to him. Glutted upon land, money, and slaves, the weaker Akladian lords lost their armies and lands in combat with the underlings."
 msgstr ""
 
 #. [part]
-#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:113
+#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:114
 msgid "And now you lie here, defenseless and vulnerable. Your father's death has shown me how tenuous my position is, and how despised you are. Behind your back they call you a mixling, a bastard, a creature not fit to live, let alone to sit on the throne. And as for me... if you die, I would be just the wife of a despised king, stepmother of a hated heir; my death will be all but assured. Had I given birth, I would be your mortal enemy, but I have not. I know there is no love between us, but only together is there any hope..."
 msgstr ""
 
 #. [unit]: id=Eol Areon, type=Akladian Protector, type=Akladian Shieldguard
-#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:173
+#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:174
 msgid "Eol Areon"
 msgstr ""
 
 #. [unit]: id=Iree Rothe, type={ON_DIFFICULTY4 (Akladian Fastfoot) (Akladian Light Infantry) (Akladian Warrior) (Akladian Clansman)}
-#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:192
+#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:193
 msgid "Iree Rothe"
 msgstr ""
 
 #. [unit]: id=Reuke Rothe, type=Akladian Pikeneer, type=Akladian Light Infantry
-#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:207
+#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:208
 msgid "Reuke Rothe"
 msgstr ""
 
 #. [unit]: id=Strome Ohavenort, type=Akladian Clansman
-#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:226
+#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:227
 msgid "Strome Ohavenort"
 msgstr ""
 
 #. [unit]: id=Reonee, type=Akladian Homeguard, type=Akladian Clansman
-#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:241
+#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:242
 msgid "Reonee"
 msgstr ""
 
 #. [unit]: id=Raoke, type=Akladian Warrior, type=Akladian Clansman
-#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:260
+#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:261
 msgid "Raoke"
 msgstr ""
 
 #. [unit]: id=Oyre, type=Akladian Clansman
-#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:286
+#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:287
 msgid "Oyre"
 msgstr ""
 
 #. [unit]: id=Aueree, type=Akladian Homeguard
-#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:305
+#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:306
 msgid "Aueree"
 msgstr ""
 
 #. [side]: id=Rebel, type=City Militia, type=Lieutenant
 #. [event]
-#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:320
-#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:513
+#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:321
+#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:514
 msgid "Heinric the Redbeard"
 msgstr ""
 
 #. [unit]: id=Militiaman, type=City Militia
-#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:349
+#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:350
 msgid "Militiaman"
 msgstr ""
 
 #. [unit]: id=Militiaman, type=Swordsman
-#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:367
+#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:368
 msgid "Swords-wielding Militiaman"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:500
+#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:501
 msgid "He has regained consciousness, my lady!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:501
+#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:502
 msgid "Thank God! Gawen, how do you feel? Can you talk? Move?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:502
+#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:503
 msgid "I feel weak... sick... (<i>pause</i>) ...I can't remember anything... nothing. Who am I?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:503
+#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:504
 msgid "I fear the blade which wounded him was poisoned, my lady.  We must wait here and pray that our God shows him mercy. <small>(<i>Whispering</i>) And then we shall bury him with all ceremonies.</small>"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:504
+#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:505
 msgid "No! We can't wait. We have to reach a town nearby and find a medic, quickly!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:505
+#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:506
 msgid "He will not make it."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:506
+#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:507
 msgid "I vow to sacrifice a lamb to God if he can be cured. If not, I won't even sacrifice so much as a mouse ever again! Do you hear me, God? Do you?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:507
+#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:508
 msgid "Gawen, get up!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:508
+#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:509
 msgid "Yes... But... I can't remember anything... Who am I?! Who are you?"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:509
+#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:510
 msgid "I am Lorin, your mother, the only person whom you can trust. These are your few loyal soldiers, who remained when everyone else deserted us. You are Gawen Hagarthen, the rightful king of Vakladia."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:510
+#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:511
 msgid "My mother? You seem... a bit young."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:511
+#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:512
 msgid "I am only your step-mother, but there is no time for more talk. We have to reach the town and find a medic!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:513
+#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:514
 msgid "Look, Akladians! To arms! Their king is dead; it's time to kill them all and be done with our slavery!"
 msgstr ""
 
 #. [event]
 #. EASY difficulty; Reme's hints should be helpful:
-#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:516
+#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:517
 msgid "My lord, if you can't remember anything, then permit me a few suggestions. While our troops are not the armoured types the Wesnothians have, they are far more resistant to pain and faster than the craven underlings. Remember to seek advantageous terrain; it's good to defend on the hills or in villages or forests. Do not charge blindly into the enemy; we have no means to replenish our army here."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:517
+#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:518
 msgid "I see two good defensive positions here. One is to the north, near the village; the second is on the hills to the east of us. Use your troops to cover your back. Clansmen are not experienced enough to control terrain next to them, so you must put them adjacent to one another to block the enemy."
 msgstr ""
 
 #. [event]
 #. NORMAL difficulty; bare minimum of hints:
-#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:521
+#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:522
 msgid "My lord, if you can't remember anything, then permit me a few suggestions. Let's try to find our way to a village. And remember to keep yourself surrounded with your own troops so that the enemy can't slip in."
 msgstr ""
 
 #. [event]
 #. HARD difficulty; I'm being a bit tongue-in-cheek with the text here to mock how the easier 2 difficulties had hints here:
-#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:525
+#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:526
 msgid "My lord, if you can't remember anything, then, well, I guess... I don't know what to tell you."
 msgstr ""
 
 #. [objective]: condition=win
-#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:532
+#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:533
 msgid "Gawen Hagarthen reaches the enemy keep"
 msgstr ""
 
 #. [objectives]
 #. this description of mechanics is only present on EASY, NORMAL, and HARD, but not NIGHTMARE, though:
-#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:551
+#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:552
 msgid "You cannot recruit new units in this scenario."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:610
+#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:611
 msgid "These ashes are still warm... he has to be somewhere nearby..."
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:623
+#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:624
 msgid "I feel so sick, like poison is burning inside me..."
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:624
+#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:625
 msgid "Try to resist for just a bit longer, my son!"
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:631
+#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:632
 msgid "He will not make it!"
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:632
+#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:633
 msgid "My son! Please, don't give up!"
 msgstr ""
 
 #. [unit]: id=Medic, type=Mage
 #. [then]
-#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:673
-#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:696
-#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:698
-#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:735
+#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:674
+#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:697
+#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:699
+#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:736
 msgid "Medic"
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:685
+#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:686
 msgid "My lady, we have found a medic!"
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:694
+#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:695
 msgid "Underling! My son is dying. If you heal him, I will spare your life. If not, I will burn you and your family alive, do you understand?"
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:696
+#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:697
 msgid "Don't try to intimidate me. I am too old to be afraid of death, I have no family. I will try to heal your son because of my vows as a healer, not because of your threats, Akladian lady."
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:697
+#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:698
 msgid "Your motives are of no concern to me, just do it!"
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:698
+#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:699
 msgid "Hold on a moment."
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:735
+#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:736
 msgid "...and there you go."
 msgstr ""
 
 #. [then]
-#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:736
+#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:737
 msgid "Thank you. (*<i>faints</i>*)"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:781
+#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:782
 msgid "Truly a shame we have no time to loot it or tax the inhabitants..."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:790
+#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:791
 msgid "Ah, a village..."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:791
+#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:792
 msgid "A medic! Somebody find a medic!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:792
+#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:793
 msgid "Unfortunately, it seems that there are no medics here... we will most likely have to wait until we reach the enemy encampment before we can cure Gawen's poison..."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:841
+#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:842
 msgid "I can't see... it's so cold..."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:842
+#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:843
 msgid "No! Don't you DARE die on me! Not now!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:858
+#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:860
 msgid "For freedom! Death to the Akladian beasts!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:859
+#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:861
 msgid "Umm... we are good guys, right?"
 msgstr ""
 
 #. [event]
 #. EASY difficulty, so have Reme give an additional hint:
-#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:862
+#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:864
 msgid "Do not forget to withdraw wounded units to villages, where they can rest and regain some of their health."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:875
+#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:877
 msgid "Get out of my way, filthy underling!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:887
+#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:889
 msgid "Poor fools! They have no chance, yet still they fight."
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:900
+#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:902
 msgid "How dare you oppose us, heathen underling!"
 msgstr ""
 
 #. [event]
-#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:908
+#: A_New_Order/scenarios/01_Breaking_the_Circle.cfg:910
 msgid "Their leader is dead, good! Now bring Gawen to their keep, men!"
 msgstr ""
 
@@ -18152,38 +18165,38 @@ msgstr ""
 
 #. [campaign]: id=A_New_Order
 #. [editor_group]: id=ano
-#: A_New_Order/_main.cfg:38
+#: A_New_Order/_main.cfg:41
 #: A_New_Order/_editor.cfg:14
 msgid "A New Order"
 msgstr ""
 
 #. [campaign]: id=A_New_Order
-#: A_New_Order/_main.cfg:39
+#: A_New_Order/_main.cfg:42
 msgid "ANO"
 msgstr ""
 
 #. [campaign]: id=A_New_Order
-#: A_New_Order/_main.cfg:57
+#: A_New_Order/_main.cfg:60
 msgid "Trivial"
 msgstr ""
 
 #. [campaign]: id=A_New_Order
-#: A_New_Order/_main.cfg:58
+#: A_New_Order/_main.cfg:61
 msgid "Normal"
 msgstr ""
 
 #. [campaign]: id=A_New_Order
-#: A_New_Order/_main.cfg:59
+#: A_New_Order/_main.cfg:62
 msgid "Difficult"
 msgstr ""
 
 #. [campaign]: id=A_New_Order
-#: A_New_Order/_main.cfg:60
+#: A_New_Order/_main.cfg:63
 msgid "Impossible"
 msgstr ""
 
 #. [campaign]: id=A_New_Order
-#: A_New_Order/_main.cfg:75
+#: A_New_Order/_main.cfg:78
 msgid ""
 "The old kingdom of Wesnoth has fallen before barbarian hordes. The occupying barbarians are on the brink of civil war, the seeds of Wesnothian rebellion are kept alive by old legends, while bandits and Dunefolk mercenaries roam the land. Can Gawen Hagarthen unite these disparate factions against a common foe?\n"
 "\n"

--- a/units/_main.cfg
+++ b/units/_main.cfg
@@ -10,8 +10,9 @@
 main={long_firstn}|{short_firstn} {lastn}
 short_firstn={prefix}{suffix}|{prefix_v}{suffix_c}
 long_firstn={prefix}{midfix}{suffix}|{prefix}{midfix}{midfix}{suffix}|{prefix}{midfix_v}{suffix_c}
-lastn=O {uplace}|Ohavenort|Areon|Rothe|Crynenoj|Cruveno|Mathauri|Ramenari|Rebarnon|Khan|Harnen|Barien|Barrae|Scud|Skagrrae|Riddon|Travil|Hurionen|Urien|Brien|Dark|Wonder|Moric|Putin
+lastn=O {uplace}|Ohavenort|Areon|Rothe|Crynenoj|Cruveno|Mathauri|Ramenari|Rebarnon|Khan|Harnen|Barien|Barrae|Scud|Skagrrae|Riddon|Travil|Hurionen|Urien|Brien|Dark|Wonder|Moric|Putin|{uplace}{demonymsuffix}|Netanyahu
 uplace=Gaeltin|Borraine|Barnone|Vattin|Haeltin|Raedbor|Raednon|Barron|Warhol|Skagrrak|Travil|Trimmen
+demonymsuffix=an|ite|ish|ard|iot|na
 prefix={prefix_v}|{prefix_c}
 prefix_v=Re|Ao|Te|Ro|Eo|Lee|La|Ru|Theo|Ae|Rao|Ne|I|Ia|Ioe|Kro|Kre|Yeo|Que|Thu|Mari|Bo|Uri|Ri|Nai|Rau|Gra|Ree|Stro|Reo|Oy|Au|Oe|Mo|No|Rou|Moe|Mi|U|Li|Reu|Ra|Ee|E|Be|Bu|Wu|Dau|Co|Ai|Gau|Al|Odo|Gae|Gei|Eu|Oda|To|Beo|Ku|Tre|Ha|Lu
 prefix_c=Or|Kar|Sav|Raul|Ur|Bar|Er|Mar|Mir|Um|Quiv|Bur|Tel|As|Lar|Rav|Rum|Cim|At|Eur|Tot|Hun|Hil|Hild|En|Enk|Tam|Sky|Ar|Arg|Gen|Kub|Trev|B|Zan

--- a/units/akladians/Akladian_Holyman.cfg
+++ b/units/akladians/Akladian_Holyman.cfg
@@ -25,7 +25,7 @@
     [abilities]
         {ABILITY_CURES}
     [/abilities]
-    description= _ "Devoting their whole life to the task of healing and curing, Akladian Holymans are respected amongst the tribes, and useful to Akladian lords."
+    description= _ "Devoting their whole life to the task of healing and curing, Akladian Holymen are respected amongst the tribes, and useful to Akladian lords."
     {DEFENSE_ANIM akladian/akl-holyman.png akladian/akl-holyman.png {SOUND_LIST:HUMAN_HIT}}
     die_sound={SOUND_LIST:HUMAN_DIE}
     [attack]

--- a/units/akladians/Akladian_Lady.cfg
+++ b/units/akladians/Akladian_Lady.cfg
@@ -29,8 +29,8 @@
         type=blade
         icon=attacks/sword-human.png
         range=melee
-        damage=5
-        number=5
+        damage=6
+        number=4
     [/attack]
     # FIXME: validator issues throughout this animation:
     [attack_anim]

--- a/units/akladians/Akladian_Wiseman.cfg
+++ b/units/akladians/Akladian_Wiseman.cfg
@@ -29,7 +29,7 @@
     [abilities]
         {ABILITY_HEALS}
     [/abilities]
-    description= _ "Akladian Wisemans are those very few from the tribes, who study herbs and ways to heal, instead of how to harm and kill people."
+    description= _ "Akladian Wisemen are those very few from the tribes, who study herbs and ways to heal, instead of how to harm and kill people."
     {DEFENSE_ANIM akladian/akl-wiseman.png akladian/akl-wiseman.png {SOUND_LIST:HUMAN_HIT}}
     die_sound={SOUND_LIST:HUMAN_DIE}
     [attack]


### PR DESCRIPTION
- Another attempt at fixing S02's loyalty again; cc @Toranks and @knyghtmare; closes #23 again
- Sort out instances where it might be better to refer to Gawen as "Haldric"; closes #182
- Dune is probably ok to reference explicitly by name in the translators' comments
- try Lorin stat changes; closes #179
- be more explicit about carryover amounts for issue #14 (still need to check scenarios 20 thru 26)
- check for Lorin's presence in Kyobaine Easter Egg; closes #150
- attempt at improving the situation for issue #165 (still broken)
- Update commentary re: issue #79, and add a few attempts at re-fixing (WIP)
- Enables Raedwood East for normal gameplay; closes #129
- Give Lorin unique bridge destruction dialogue in Orannon; closes #187
- add luacheck workflow
- add a few additional changelog items
- dialogue changes for S10; closes #32
- add a death message for Rob Roe; closes #199 

(leaving this in draft mode until I've had time to adequately test)